### PR TITLE
add alpine v3.19

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ end
 
 alpine_registries = []
 # TODO automate version list from https://dl-cdn.alpinelinux.org/alpine/
-alpine_versions = ['edge', 'v3.18', 'v3.17','v3.16','v3.15','v3.14','v3.13','v3.12', 'v3.11', 'v3.10', 'v3.9', 'v3.8', 'v3.7', 'v3.6', 'v3.5', 'v3.4', 'v3.3']
+alpine_versions = ['edge', 'v3.19', 'v3.18', 'v3.17','v3.16','v3.15','v3.14','v3.13','v3.12', 'v3.11', 'v3.10', 'v3.9', 'v3.8', 'v3.7', 'v3.6', 'v3.5', 'v3.4', 'v3.3']
 
 alpine_versions.each do |version|
   repos = ['main', 'community']


### PR DESCRIPTION
Alpine 3.19 was [released recently](https://alpinelinux.org/posts/Alpine-3.19.0-released.html), so adding support for it to the packages api