### PR TITLE
Fix test in maven_test.rb

### DIFF
--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -16,7 +16,7 @@ class MavenTest < ActiveSupport::TestCase
 
   test 'registry_url with version' do
     registry_url = @ecosystem.registry_url(@package, @version)
-    assert_equal registry_url, "https://central.sonatype.com/artifact/dev.zio/zio-aws-autoscaling_3/5.17.224.2/"
+    assert_equal registry_url, "https://central.sonatype.com/artifact/dev.zio/zio-aws-autoscaling_3/5.17.224.2"
   end
 
   test 'download_url' do


### PR DESCRIPTION
Strange fact: sonatype never adds a trailing slash. The previous test should also fail.

Please advise.