### PR TITLE
Fix header whitespace

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,10 +8,9 @@
           </h1>
         </div>
         <div class="col-md-6 text-md-end">
-			<a class="header__global__menu-link" role="button" aria-expanded="false" aria-controls="header__global__menu" data-bs-toggle="collapse" href="#header__global__menu">All services <%= bootstrap_icon 'caret-down-fill', width: 12, height: 12 %></a>
+          <a class="header__global__menu-link" role="button" aria-expanded="false" aria-controls="header__global__menu" data-bs-toggle="collapse" href="#header__global__menu">All services <%= bootstrap_icon 'caret-down-fill', width: 12, height: 12 %></a>
         </div>
       </div>
-      
       <div id="header__global__menu" class="collapse header__global__menu">
         <% ecosystems_services.each do |category, services| %>
           <div class="header__global__menu__category">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,9 +18,9 @@
             <ul class="header__global__menu__category-links">
               <% services.each do |service| %>
                 <li>
-                  <a href="<%= service[:url] %>" target="_blank" class="<%= 'active' if service[:url] == request.base_url %>">
-                    <%= service[:name] %>
-                  </a>
+                  <a href="<%= service[:url] %>" target="_blank" class="<%= 'active' if service[:url] == request.base_url %>"
+                    ><%= service[:name] %></a
+                  >
                 </li>
               <% end %>
             </ul>


### PR DESCRIPTION
Because of some newlines in `_header.html.erb`, the links in the “All services” portion of the header have distracting whitespace at the end of each link. This PR fixes that.

Before/after GIF:

![animate](https://github.com/user-attachments/assets/9ce9f780-85dc-4dad-8bae-115d627c9c0f)

This should be fixed for all services, but I'm submitting just this PR first, since I tested with Packages.