### PR TITLE
Add bin/dev to run app and workers at the same time

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ Once you've got all of those installed, from the root directory of the project r
 
 ```
 bin/setup
-rails server
+bin/dev
 ```
 
 You can then load up [http://localhost:3000](http://localhost:3000) to access the service.
@@ -77,7 +77,7 @@ You can list all of the available rake tasks with the following command:
 
 Background tasks are handled by [sidekiq](https://github.com/mperham/sidekiq), the workers live in [app/sidekiq](app/sidekiq/).
 
-To process the tasks run the following command:
+Sidekiq is automatically run by `bin/dev`, but if you need to run it manually, run the following command:
 
 `bundle exec sidekiq`
 

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec rails server
+worker: bundle exec sidekiq

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+# Install foreman if needed
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+[ $PORT ] || PORT=3000
+PORT=$PORT exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Following the pattern from https://railsnotes.xyz/blog/procfile-bin-dev-rails7#bindev-foreman-and-procfiledev--how-do-they-work-together, bin/dev helps easily run multiple required tasks at the same time.