### PR TITLE
Add gem.coop registry to seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ default_registries = [
   {name: 'pub.dev', url: 'https://pub.dev', ecosystem: 'pub', github: 'dart-lang', default: true},
   {name: 'pypi.org', url: 'https://pypi.org', ecosystem: 'pypi', github: 'pypi', default: true},
   {name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems', github: 'rubygems', default: true},
-  {name: 'gem.coop', url: 'https://gem.coop', ecosystem: 'rubygems', github: 'gem-coop', default: true},
+  {name: 'gem.coop', url: 'https://gem.coop', ecosystem: 'rubygems', github: 'gem-coop', default: false},
   {name: 'spack.io', url: 'https://packages.spack.io', ecosystem: 'spack', github: 'spack', default: true},
   {name: 'hackage.haskell.org', url: 'https://hackage.haskell.org', ecosystem: 'hackage', github: 'haskell-infra', default: true},
   {name: 'cran.r-project.org', url: 'https://cran.r-project.org', ecosystem: 'cran', github: 'r-project-org', default: true},


### PR DESCRIPTION
Import works fine; only problem is that at the moment the registry URLs 404, because the site doesn't actually generate pages for the gems as far as I can tell (e.g. https://gem.coop/gems/openssl). Not sure if this is worth fixing until the new registry stabilises a bit.