### PR TITLE
Refactor purl methods to purl_params across ecosystem classes

### DIFF
--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -7,13 +7,13 @@ module Ecosystem
       'githubactions'
     end
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: purl_type,
         namespace: package.name.split('/').first,
         name: package.name.split('/').last,
         version: version.try(:number).try(:encode, 'iso-8859-1', invalid: :replace, undef: :replace, replace: '')
-      ).to_s
+      }
     end
 
     def check_status_url(package)

--- a/app/models/ecosystem/adelie.rb
+++ b/app/models/ecosystem/adelie.rb
@@ -6,14 +6,14 @@ module Ecosystem
       true
     end
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: 'apk',
         namespace: 'adelie',
         name: package.name.encode('iso-8859-1'),
         version: version.try(:number).try(:encode,'iso-8859-1'),
-        qualifiers: { 'arch'=> package.metadata['architecture']},
-      ).to_s
+        qualifiers: { 'arch' => package.metadata['architecture'] }
+      }
     end
 
     def registry_url(package, version = nil)

--- a/app/models/ecosystem/alpine.rb
+++ b/app/models/ecosystem/alpine.rb
@@ -6,14 +6,14 @@ module Ecosystem
       true
     end
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: 'apk',
         namespace: 'alpine',
         name: package.name.encode('iso-8859-1'),
         version: version.try(:number).try(:encode,'iso-8859-1'),
-        qualifiers: { 'arch'=> package.metadata['architecture']},
-      ).to_s
+        qualifiers: { 'arch' => package.metadata['architecture'] }
+      }
     end
 
     def registry_url(package, version = nil)

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -156,18 +156,29 @@ module Ecosystem
     end
 
     def purl(package, version = nil)
-      params = {
-        type: purl_type,
-        namespace: nil,
-        name: package.name.encode('iso-8859-1')
-      }
-      if version.present?
-        params[:version] = version.try(:number).try(:encode,'iso-8859-1')
+      params = purl_params(package, version)
+
+      # Add repository_url to qualifiers if non-default registry
+      # default: true means it's the default registry for that ecosystem
+      # nil or false means it's not the default and should include repository_url
+      if @registry.default != true
+        params[:qualifiers] ||= {}
+        params[:qualifiers]['repository_url'] = @registry_url
       end
+
       Purl::PackageURL.new(**params).to_s
     rescue => e
       # invalid encoding or other errors
       nil
+    end
+
+    def purl_params(package, version = nil)
+      {
+        type: purl_type,
+        namespace: nil,
+        name: package.name.encode('iso-8859-1'),
+        version: version.try(:number).try(:encode,'iso-8859-1')
+      }
     end
 
     def purl_type

--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -5,15 +5,15 @@ module Ecosystem
       'golang'
     end
 
-    def purl(package, version = nil)
+    def purl_params(package, version = nil)
       namespace = encode_for_proxy package.name.split('/')[0..-2].join('/')
       name = encode_for_proxy package.name.split('/').last
-      Purl::PackageURL.new(
+      {
         type: purl_type,
         namespace: namespace,
         name: name,
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
 

--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -1,14 +1,14 @@
 module Ecosystem
   class Maven < Base
 
-    def purl(package, version = nil)
+    def purl_params(package, version = nil)
       group_id, artifact_id = *package.name.split(':', 2)
-      Purl::PackageURL.new(
+      {
         type: purl_type,
         namespace: group_id,
         name: artifact_id,
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
     def self.namespace_separator

--- a/app/models/ecosystem/npm.rb
+++ b/app/models/ecosystem/npm.rb
@@ -6,14 +6,14 @@ module Ecosystem
       "https://www.npmjs.com/package/#{package.name}" + (version ? "/v/#{version}" : "")
     end
 
-    def purl(package, version = nil)
+    def purl_params(package, version = nil)
       namespace = package.namespace ? "@#{package.namespace}".encode('iso-8859-1') : nil
-      Purl::PackageURL.new(
+      {
         type: 'npm',
         namespace: namespace,
         name: package.name.split('/').last.encode('iso-8859-1'),
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
     def download_url(package, version)

--- a/app/models/ecosystem/openvsx.rb
+++ b/app/models/ecosystem/openvsx.rb
@@ -2,13 +2,13 @@
 
 module Ecosystem
   class Openvsx < Base
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: purl_type,
         namespace: package.name.split('/').first,
         name: package.name.split('/').last,
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
     def registry_url(package, version = nil)

--- a/app/models/ecosystem/packagist.rb
+++ b/app/models/ecosystem/packagist.rb
@@ -7,13 +7,13 @@ module Ecosystem
       "composer"
     end
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: purl_type,
         namespace: package.name.split('/').first,
         name: package.name.split('/').last,
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
 

--- a/app/models/ecosystem/postmarketos.rb
+++ b/app/models/ecosystem/postmarketos.rb
@@ -6,14 +6,14 @@ module Ecosystem
       true
     end
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: 'apk',
         namespace: 'postmarketos',
         name: package.name.encode('iso-8859-1'),
         version: version.try(:number).try(:encode,'iso-8859-1'),
-        qualifiers: { 'arch'=> package.metadata['architecture']},
-      ).to_s
+        qualifiers: { 'arch' => package.metadata['architecture'] }
+      }
     end
 
     def registry_url(package, version = nil)

--- a/app/models/ecosystem/puppet.rb
+++ b/app/models/ecosystem/puppet.rb
@@ -3,13 +3,13 @@
 module Ecosystem
   class Puppet < Base
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: purl_type,
         namespace: package.name.split('-').first,
         name: package.name.split('-').last,
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
     def all_package_names

--- a/app/models/ecosystem/pypi.rb
+++ b/app/models/ecosystem/pypi.rb
@@ -7,13 +7,13 @@ module Ecosystem
     PEP_508_NAME_REGEX = /[A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9]/i.freeze
     PEP_508_NAME_WITH_EXTRAS_REGEX = /(^#{PEP_508_NAME_REGEX}\s*(?:\[#{PEP_508_NAME_REGEX}(?:,\s*#{PEP_508_NAME_REGEX})*\])?)/i.freeze
 
-    def purl(package, version = nil)
-      Purl::PackageURL.new(
+    def purl_params(package, version = nil)
+      {
         type: purl_type,
         namespace: nil,
         name: package.name.downcase.gsub('_', '-'),
         version: version.try(:number).try(:encode,'iso-8859-1')
-      ).to_s
+      }
     end
 
 

--- a/app/models/ecosystem/swiftpm.rb
+++ b/app/models/ecosystem/swiftpm.rb
@@ -6,16 +6,13 @@ module Ecosystem
       'swift'
     end
 
-    def purl(package, version = nil)
-      params = {
+    def purl_params(package, version = nil)
+      {
         type: purl_type,
         namespace: package.name.split('/')[0..1].join('/'),
-        name: package.name.split('/').last
+        name: package.name.split('/').last,
+        version: version.try(:number).try(:encode, 'iso-8859-1', invalid: :replace, undef: :replace, replace: '')
       }
-      if version.present?
-        params[:version] = version.try(:number).try(:encode, 'iso-8859-1', invalid: :replace, undef: :replace, replace: '')
-      end
-      Purl::PackageURL.new(**params).to_s
     end
 
     def all_package_names

--- a/test/models/ecosystem/actions_test.rb
+++ b/test/models/ecosystem/actions_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ActionsTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.create(name: 'github actions', url: 'https://actions.io', ecosystem: 'actions')
+    @registry = Registry.create(default: true, name: 'github actions', url: 'https://actions.io', ecosystem: 'actions')
     @ecosystem = Ecosystem::Actions.new(@registry)
     @package = @registry.packages.create(ecosystem: 'actions', name: 'getsentry/action-git-diff-suggestions', repository_url: "https://github.com/getsentry/action-git-diff-suggestions")
     @version = @package.versions.create(number: 'v1', metadata: {download_url:"https://codeload.github.com/getsentry/action-git-diff-suggestions/tar.gz/refs/v1"})

--- a/test/models/ecosystem/alpine_test.rb
+++ b/test/models/ecosystem/alpine_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class AlpineTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Alpine v3.21', version: 'v3.21', url: 'https://pkgs.alpinelinux.org', ecosystem: 'alpine')
+    @registry = Registry.new(default: true, name: 'Alpine v3.21', version: 'v3.21', url: 'https://pkgs.alpinelinux.org', ecosystem: 'alpine')
     @ecosystem = Ecosystem::Alpine.new(@registry)
     @package = Package.new(ecosystem: 'alpine', name: 'nextcloud30-dashboard', metadata: { 'repository' => 'community', 'architecture' => 'x86_64' })
     @version = @package.versions.build(number: '30.0.0-r0')

--- a/test/models/ecosystem/bower_test.rb
+++ b/test/models/ecosystem/bower_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class BowerTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.create(name: 'Bower.io', url: 'https://bower.io', ecosystem: 'bower')
+    @registry = Registry.create(default: true, name: 'Bower.io', url: 'https://bower.io', ecosystem: 'bower')
     @ecosystem = Ecosystem::Bower.new(@registry)
     @package = @registry.packages.create(ecosystem: 'bower', name: 'bower-angular', repository_url: "https://github.com/angular/bower-angular")
     @version = @package.versions.create(number: '1.0.0', metadata: {download_url:"https://codeload.github.com/angular/bower-angular/tar.gz/refs/v1.0.0"})

--- a/test/models/ecosystem/cargo_test.rb
+++ b/test/models/ecosystem/cargo_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CargoTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Crates.io', url: 'https://crates.io', ecosystem: 'Cargo')
+    @registry = Registry.new(default: true, name: 'Crates.io', url: 'https://crates.io', ecosystem: 'Cargo')
     @ecosystem = Ecosystem::Cargo.new(@registry)
     @package = Package.new(ecosystem: 'Cargo', name: 'rand')
     @version = @package.versions.build(number: '0.8.5')

--- a/test/models/ecosystem/clojars_test.rb
+++ b/test/models/ecosystem/clojars_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 class ClojarsTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'clojars.org', url: 'https://repo.clojars.org', ecosystem: 'clojars')
+    @registry = Registry.new(default: true, name: 'clojars.org', url: 'https://repo.clojars.org', ecosystem: 'clojars')
     @ecosystem = Ecosystem::Clojars.new(@registry)
     @package = Package.new(ecosystem: 'clojars', name: 'missionary')
     @version = @package.versions.build(number: 'b.26')

--- a/test/models/ecosystem/cocoapods_test.rb
+++ b/test/models/ecosystem/cocoapods_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CocoapodsTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Cocoapod.org', url: 'https://cocoapods.org', ecosystem: 'cocoapods')
+    @registry = Registry.new(default: true, name: 'Cocoapod.org', url: 'https://cocoapods.org', ecosystem: 'cocoapods')
     @ecosystem = Ecosystem::Cocoapods.new(@registry)
     @package = Package.new(ecosystem: 'cocoapods', name: 'Foo')
     @version = @package.versions.build({:number=>"1.0.7", :published_at=>"2019-01-01T11:52:18.000Z", :metadata=>{:sha=>"fc91bdd33fa5019c4b9a0d0bbe359816872cd89c", :download_url=>"https://codeload.github.com/deepesh259nitk/mixedFramework/tar.gz/1.0.7"}})

--- a/test/models/ecosystem/conda_test.rb
+++ b/test/models/ecosystem/conda_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class CondaTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Conda.org', url: 'https://anaconda.org/anaconda', ecosystem: 'conda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'})
-    @registry2 = Registry.new(name: 'conda-forge.org', url: 'https://conda-forge.org/', ecosystem: 'conda', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'})
+    @registry = Registry.new(default: true, name: 'Conda.org', url: 'https://anaconda.org/anaconda', ecosystem: 'conda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'})
+    @registry2 = Registry.new(default: true, name: 'conda-forge.org', url: 'https://conda-forge.org/', ecosystem: 'conda', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'})
     @ecosystem = Ecosystem::Conda.new(@registry)
     @ecosystem2 = Ecosystem::Conda.new(@registry2)
     @package = Package.new(ecosystem: 'conda', name: 'aiofiles')

--- a/test/models/ecosystem/cpan_test.rb
+++ b/test/models/ecosystem/cpan_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CpanTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Metacpan.org', url: 'https://metacpan.org', ecosystem: 'cpan')
+    @registry = Registry.new(default: true, name: 'Metacpan.org', url: 'https://metacpan.org', ecosystem: 'cpan')
     @ecosystem = Ecosystem::Cpan.new(@registry)
     @package = Package.new(ecosystem: 'cpan', name: 'Dpkg')
     @version = @package.versions.build(number: '1.21.5', :metadata=>{:download_url=>"https://cpan.metacpan.org/authors/id/G/GU/GUILLEM/Dpkg-1.21.5.tar.gz"})

--- a/test/models/ecosystem/cran_test.rb
+++ b/test/models/ecosystem/cran_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CranTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'cran.r-project.org', url: 'https://cran.r-project.org', ecosystem: 'cran')
+    @registry = Registry.new(default: true, name: 'cran.r-project.org', url: 'https://cran.r-project.org', ecosystem: 'cran')
     @ecosystem = Ecosystem::Cran.new(@registry)
     @package = Package.new(ecosystem: @registry.ecosystem, name: 'pack')
     @version = @package.versions.build(number: '0.1-1')

--- a/test/models/ecosystem/deno_test.rb
+++ b/test/models/ecosystem/deno_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class DenoTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'deno.land', url: 'https://deno.land', ecosystem: 'deno')
+    @registry = Registry.new(default: true, name: 'deno.land', url: 'https://deno.land', ecosystem: 'deno')
     @ecosystem = Ecosystem::Deno.new(@registry)
     @package = Package.new(ecosystem: 'deno', name: 'deno_es')
     @version = @package.versions.build(number: 'v0.4.2')

--- a/test/models/ecosystem/elm_test.rb
+++ b/test/models/ecosystem/elm_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ElmTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'package.elm-lang.org', url: 'https://package.elm-lang.org', ecosystem: 'elm')
+    @registry = Registry.new(default: true, name: 'package.elm-lang.org', url: 'https://package.elm-lang.org', ecosystem: 'elm')
     @ecosystem = Ecosystem::Elm.new(@registry)
     @package = Package.new(ecosystem: 'elm', name: 'rtfeldman/count')
     @version = @package.versions.build(number: '1.0.1')

--- a/test/models/ecosystem/elpa_test.rb
+++ b/test/models/ecosystem/elpa_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ElpaTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'elpa.nongnu.org', url: 'https://elpa.nongnu.org/nongnu', ecosystem: 'elpa')
+    @registry = Registry.new(default: true, name: 'elpa.nongnu.org', url: 'https://elpa.nongnu.org/nongnu', ecosystem: 'elpa')
     @ecosystem = Ecosystem::Elpa.new(@registry)
     @package = Package.new(ecosystem: 'elpa', name: 'ample-theme')
     @version = @package.versions.build(number: '0.3.0')

--- a/test/models/ecosystem/go_test.rb
+++ b/test/models/ecosystem/go_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class GoTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'proxy.golang.org', url: 'https://proxy.golang.org', ecosystem: 'Go')
+    @registry = Registry.new(default: true, name: 'proxy.golang.org', url: 'https://proxy.golang.org', ecosystem: 'Go')
     @ecosystem = Ecosystem::Go.new(@registry)
     @package = Package.new(ecosystem: 'Go', name: 'github.com/aws/smithy-go')
     @version = @package.versions.build(number: 'v1.11.1')

--- a/test/models/ecosystem/hackage_test.rb
+++ b/test/models/ecosystem/hackage_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class HackageTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Hackage.haskell.org', url: 'https://hackage.haskell.org', ecosystem: 'hackage')
+    @registry = Registry.new(default: true, name: 'Hackage.haskell.org', url: 'https://hackage.haskell.org', ecosystem: 'hackage')
     @ecosystem = Ecosystem::Hackage.new(@registry)
     @package = Package.new(ecosystem: 'hackage', name: 'blockfrost-client')
     @version = @package.versions.build(number: '0.4.0.1')

--- a/test/models/ecosystem/hex_test.rb
+++ b/test/models/ecosystem/hex_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class HexTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Hex.pm', url: 'https://hex.pm', ecosystem: 'Hex')
+    @registry = Registry.new(default: true, name: 'Hex.pm', url: 'https://hex.pm', ecosystem: 'Hex')
     @ecosystem = Ecosystem::Hex.new(@registry)
     @package = Package.new(ecosystem: 'Hex', name: 'rand')
     @version = @package.versions.build(number: '0.8.5')

--- a/test/models/ecosystem/homebrew_test.rb
+++ b/test/models/ecosystem/homebrew_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class HomebrewTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Homebrew.org', url: 'https://homebrew.org', ecosystem: 'homebrew')
+    @registry = Registry.new(default: true, name: 'Homebrew.org', url: 'https://homebrew.org', ecosystem: 'homebrew')
     @ecosystem = Ecosystem::Homebrew.new(@registry)
     @package = Package.new(ecosystem: 'homebrew', name: 'abook')
     @version = @package.versions.build(number: '1.26.8')

--- a/test/models/ecosystem/julia_test.rb
+++ b/test/models/ecosystem/julia_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class JuliaTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'juliahub.com', url: 'https://juliahub.com', ecosystem: 'julia')
+    @registry = Registry.new(default: true, name: 'juliahub.com', url: 'https://juliahub.com', ecosystem: 'julia')
     @ecosystem = Ecosystem::Julia.new(@registry)
     @package = Package.new(ecosystem: 'julia', name: 'Inequality', metadata: {slug: 'xDAp7'}, repository_url: "https://github.com/JosepER/Inequality.jl")
     @version = @package.versions.build(number: '0.0.4')

--- a/test/models/ecosystem/npm_test.rb
+++ b/test/models/ecosystem/npm_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class NpmTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm')
+    @registry = Registry.new(default: true, name: 'Npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm')
     @ecosystem = Ecosystem::Npm.new(@registry)
     @package = Package.new(ecosystem: 'npm', name: 'base62')
     @version = @package.versions.build(number: '2.0.1')

--- a/test/models/ecosystem/nuget_test.rb
+++ b/test/models/ecosystem/nuget_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class NugetTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'NuGet.org', url: 'https://www.nuget.org', ecosystem: 'nuget')
+    @registry = Registry.new(default: true, name: 'NuGet.org', url: 'https://www.nuget.org', ecosystem: 'nuget')
     @ecosystem = Ecosystem::Nuget.new(@registry)
     @package = Package.new(ecosystem: 'nuget', name: 'ogcapi.net.sqlserver')
     @version = @package.versions.build(number: '0.3.1')

--- a/test/models/ecosystem/openvsx_test.rb
+++ b/test/models/ecosystem/openvsx_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class OpenvsxTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'open-vsx.org', url: 'https://open-vsx.org', ecosystem: 'openvsx')
+    @registry = Registry.new(default: true, name: 'open-vsx.org', url: 'https://open-vsx.org', ecosystem: 'openvsx')
     @ecosystem = Ecosystem::Openvsx.new(@registry)
     @package = Package.new(ecosystem: 'Openvsx', namespace: 'redhat', name: 'redhat/vscode-yaml')
     @version = @package.versions.build(number: '1.18.0')

--- a/test/models/ecosystem/packagist_test.rb
+++ b/test/models/ecosystem/packagist_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PackagistTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Packagist.org', url: 'https://packagist.org', ecosystem: 'Packagist')
+    @registry = Registry.new(default: true, name: 'Packagist.org', url: 'https://packagist.org', ecosystem: 'Packagist')
     @ecosystem = Ecosystem::Packagist.new(@registry)
     @package = Package.new(ecosystem: 'Packagist', name: 'psr/log')
     @version = @package.versions.build(number: '3.0.0', :metadata=>{:download_url=>"https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001"})

--- a/test/models/ecosystem/pub_test.rb
+++ b/test/models/ecosystem/pub_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PubTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Pub.dev', url: 'https://pub.dev', ecosystem: 'pub')
+    @registry = Registry.new(default: true, name: 'Pub.dev', url: 'https://pub.dev', ecosystem: 'pub')
     @ecosystem = Ecosystem::Pub.new(@registry)
     @package = Package.new(ecosystem: 'pub', name: 'bloc')
     @version = @package.versions.build(number: '8.0.3')

--- a/test/models/ecosystem/puppet_test.rb
+++ b/test/models/ecosystem/puppet_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PuppetTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'forge.puppet.com', url: 'https://forge.puppet.com', ecosystem: 'puppet')
+    @registry = Registry.new(default: true, name: 'forge.puppet.com', url: 'https://forge.puppet.com', ecosystem: 'puppet')
     @ecosystem = Ecosystem::Puppet.new(@registry)
     @package = Package.new(ecosystem: 'puppet', name: 'puppet-fail2ban')
     @version = @package.versions.build(number: '4.1.0')

--- a/test/models/ecosystem/pypi_test.rb
+++ b/test/models/ecosystem/pypi_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PypiTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Pypi.org', url: 'https://pypi.org', ecosystem: 'pypi')
+    @registry = Registry.new(default: true, name: 'Pypi.org', url: 'https://pypi.org', ecosystem: 'pypi')
     @ecosystem = Ecosystem::Pypi.new(@registry)
     @package = Package.new(ecosystem: 'pypi', name: 'urllib3')
     @version = @package.versions.build(number: '1.26.8', metadata: {download_url: 'https://files.pythonhosted.org/packages/8b/e1/40122572f57349365391b8955178d52cd42d2c1f767030cbd196883adee7/yiban-0.1.2.32-py3-none-any.whl'})

--- a/test/models/ecosystem/racket_test.rb
+++ b/test/models/ecosystem/racket_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RacketTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.create(name: 'Racket', url: 'http://pkgs.racket-lang.org', ecosystem: 'racket')
+    @registry = Registry.create(default: true, name: 'Racket', url: 'http://pkgs.racket-lang.org', ecosystem: 'racket')
     @ecosystem = Ecosystem::Racket.new(@registry)
     @package = @registry.packages.create(ecosystem: 'racket', name: '4chdl', repository_url: "https://github.com/winny-/4chdl")
     @version = @package.versions.create(number: '1.0.0', :metadata=>{:download_url=>"https://codeload.github.com/winny-/4chdl/tar.gz/refs/heads/master"})

--- a/test/models/ecosystem/spack_test.rb
+++ b/test/models/ecosystem/spack_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SpackTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'Spack.io', url: 'https://packages.spack.io', ecosystem: 'spack')
+    @registry = Registry.new(default: true, name: 'Spack.io', url: 'https://packages.spack.io', ecosystem: 'spack')
     @ecosystem = Ecosystem::Spack.new(@registry)
     @package = Package.new(ecosystem: 'spack', name: '3proxy')
     @version = @package.versions.build(number: '0.8.13', metadata: {download_url: "https://github.com/z3APA3A/3proxy/archive/0.8.13.tar.gz"})

--- a/test/models/ecosystem/swiftpm_test.rb
+++ b/test/models/ecosystem/swiftpm_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SwiftpmTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.create(name: 'Swiftpm.io', url: 'https://swiftpm.io', ecosystem: 'swiftpm')
+    @registry = Registry.create(default: true, name: 'Swiftpm.io', url: 'https://swiftpm.io', ecosystem: 'swiftpm')
     @ecosystem = Ecosystem::Swiftpm.new(@registry)
     @package = @registry.packages.create(ecosystem: 'swiftpm', name: 'github.com/swift-cloud/Compute', repository_url: "https://github.com/swift-cloud/Compute")
     @version = @package.versions.create(number: '2.3.1', metadata: {download_url:"https://codeload.github.com/swift-cloud/Compute/tar.gz/refs/2.3.1"})

--- a/test/models/ecosystem/vcpkg_test.rb
+++ b/test/models/ecosystem/vcpkg_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class VcpkgTest < ActiveSupport::TestCase
   setup do
-    @registry = Registry.new(name: 'vcpkg.org', url: 'https://vcpkg.org', ecosystem: 'vcpkg')
+    @registry = Registry.new(default: true, name: 'vcpkg.org', url: 'https://vcpkg.org', ecosystem: 'vcpkg')
     @ecosystem = Ecosystem::Vcpkg.new(@registry)
     @package = Package.new(ecosystem: 'vcpkg', name: 'zziplib')
     @version = @package.versions.build(number: '1.26.8')

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -15,7 +15,7 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   setup do
-    @registry = Registry.create(name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+    @registry = Registry.create(default: true, name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
     @package = @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem, licenses: 'mit')
     @version = @package.versions.create(number: '1.0.0', published_at: 1.month.ago)
     @version2 = @package.versions.create(number: '2.0.0', published_at: 1.week.ago)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -13,7 +13,7 @@ class VersionTest < ActiveSupport::TestCase
   end
 
   setup do 
-    @registry = Registry.create(name: 'Rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+    @registry = Registry.create(default: true, name: 'Rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
     @package = @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)
     @version = @package.versions.create(number: '1.0.0', created_at: Time.now)
     @version2 = @package.versions.create(number: '2.0.0', created_at: 1.week.ago)


### PR DESCRIPTION
Following on from https://github.com/ecosyste-ms/packages/pull/1247

When generating PURLs for packages from non-default registries, we now include the `repository_url` qualifier to properly identify the source.

**Examples:**

- Default: `pkg:maven/groovy/groovy@1.0`
- Non-default: `pkg:maven/groovy/groovy@1.0?repository_url=https://maven.google.com`

Also did a bit of rework to just override the purl_params in each subclass rather than the whole generation so this feature only needed to be implemented in Base