### PR TITLE
fix: incorrect funding url

### DIFF
--- a/app/models/ecosystem/pypi.rb
+++ b/app/models/ecosystem/pypi.rb
@@ -70,7 +70,7 @@ module Ecosystem
         releases: package['releases'],
         downloads_period: 'last-month',
         metadata: {
-          "funding" => package.dig("info", "project_urls", "Funding"),
+          "funding" => fetch_funding_link(package.dig("info", "project_urls") || {}, %w[donate donation funding sponsor]),
           "documentation" => package.dig("info", "project_urls", "Documentation"),
           "classifiers" => package["info"]["classifiers"],
           "normalized_name" => package["info"]["name"].downcase.gsub('_', '-').gsub('.', '-'),
@@ -83,6 +83,19 @@ module Ecosystem
       downloads = downloads(package)
       h[:downloads] = downloads if downloads.present?
       h
+    end
+
+    def fetch_funding_link(object, keys)
+      # Normalize keys to lowercase for case-insensitive lookup
+      # return after the first element found
+      keys.each do |key|
+        value = object.find { |k, _|
+            k.downcase == key
+          }&.last
+        return value if value
+      end
+      
+      nil
     end
 
     def parse_repository_url(package)

--- a/test/fixtures/files/pypi/flask/flask
+++ b/test/fixtures/files/pypi/flask/flask
@@ -1,0 +1,2513 @@
+{
+  "info": {
+    "author": null,
+    "author_email": null,
+    "bugtrack_url": null,
+    "classifiers": [
+      "Development Status :: 5 - Production/Stable",
+      "Environment :: Web Environment",
+      "Framework :: Flask",
+      "Intended Audience :: Developers",
+      "Operating System :: OS Independent",
+      "Programming Language :: Python",
+      "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+      "Topic :: Internet :: WWW/HTTP :: WSGI",
+      "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+      "Topic :: Software Development :: Libraries :: Application Frameworks",
+      "Typing :: Typed"
+    ],
+    "description": "<div align=\"center\"><img src=\"https://raw.githubusercontent.com/pallets/flask/refs/heads/stable/docs/_static/flask-name.svg\" alt=\"\" height=\"150\"></div>\n\n# Flask\n\nFlask is a lightweight [WSGI] web application framework. It is designed\nto make getting started quick and easy, with the ability to scale up to\ncomplex applications. It began as a simple wrapper around [Werkzeug]\nand [Jinja], and has become one of the most popular Python web\napplication frameworks.\n\nFlask offers suggestions, but doesn't enforce any dependencies or\nproject layout. It is up to the developer to choose the tools and\nlibraries they want to use. There are many extensions provided by the\ncommunity that make adding new functionality easy.\n\n[WSGI]: https://wsgi.readthedocs.io/\n[Werkzeug]: https://werkzeug.palletsprojects.com/\n[Jinja]: https://jinja.palletsprojects.com/\n\n## A Simple Example\n\n```python\n# save this as app.py\nfrom flask import Flask\n\napp = Flask(__name__)\n\n@app.route(\"/\")\ndef hello():\n    return \"Hello, World!\"\n```\n\n```\n$ flask run\n  * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)\n```\n\n## Donate\n\nThe Pallets organization develops and supports Flask and the libraries\nit uses. In order to grow the community of contributors and users, and\nallow the maintainers to devote more time to the projects, [please\ndonate today].\n\n[please donate today]: https://palletsprojects.com/donate\n\n## Contributing\n\nSee our [detailed contributing documentation][contrib] for many ways to\ncontribute, including reporting issues, requesting features, asking or answering\nquestions, and making PRs.\n\n[contrib]: https://palletsprojects.com/contributing/\n\n",
+    "description_content_type": "text/markdown",
+    "docs_url": null,
+    "download_url": null,
+    "downloads": {
+      "last_day": -1,
+      "last_month": -1,
+      "last_week": -1
+    },
+    "dynamic": null,
+    "home_page": null,
+    "keywords": null,
+    "license": null,
+    "license_expression": "BSD-3-Clause",
+    "license_files": [
+      "LICENSE.txt"
+    ],
+    "maintainer": null,
+    "maintainer_email": "Pallets <contact@palletsprojects.com>",
+    "name": "Flask",
+    "package_url": "https://pypi.org/project/Flask/",
+    "platform": null,
+    "project_url": "https://pypi.org/project/Flask/",
+    "project_urls": {
+      "Changes": "https://flask.palletsprojects.com/page/changes/",
+      "Chat": "https://discord.gg/pallets",
+      "Documentation": "https://flask.palletsprojects.com/",
+      "Donate": "https://palletsprojects.com/donate",
+      "Source": "https://github.com/pallets/flask/"
+    },
+    "provides_extra": [
+      "async",
+      "dotenv"
+    ],
+    "release_url": "https://pypi.org/project/Flask/3.1.2/",
+    "requires_dist": [
+      "blinker>=1.9.0",
+      "click>=8.1.3",
+      "importlib-metadata>=3.6.0; python_version < \"3.10\"",
+      "itsdangerous>=2.2.0",
+      "jinja2>=3.1.2",
+      "markupsafe>=2.1.1",
+      "werkzeug>=3.1.0",
+      "asgiref>=3.2; extra == \"async\"",
+      "python-dotenv; extra == \"dotenv\""
+    ],
+    "requires_python": ">=3.9",
+    "summary": "A simple framework for building complex web applications.",
+    "version": "3.1.2",
+    "yanked": false,
+    "yanked_reason": null
+  },
+  "last_serial": 30778307,
+  "releases": {
+    "0.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "6e4943b514bfdaf4af12e6ef1f17aa25447157bcbb864c07775dacd72e8c8e02",
+          "md5": "d0c458397c49114fa279716798ca80c8",
+          "sha256": "9da884457e910bf0847d396cb4b778ad9f3c3d17db1c5997cb861937bd284237"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "d0c458397c49114fa279716798ca80c8",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 9168,
+        "upload_time": "2010-04-16T14:29:37",
+        "upload_time_iso_8601": "2010-04-16T14:29:37.458396Z",
+        "url": "https://files.pythonhosted.org/packages/6e/49/43b514bfdaf4af12e6ef1f17aa25447157bcbb864c07775dacd72e8c8e02/Flask-0.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.10": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "f34653d83cbdb79b27678c7b032d5deaa556655dd034cc747ee609b3e3cbf95b",
+          "md5": "92bc6b6ebd37d3120c235430a0491a15",
+          "sha256": "84b3b352c3d6b888ee56c645d83a3b54a86fab6236be3d44fd55a275f2c8b207"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.10.tar.gz",
+        "has_sig": false,
+        "md5_digest": "92bc6b6ebd37d3120c235430a0491a15",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 544031,
+        "upload_time": "2013-06-13T08:35:51",
+        "upload_time_iso_8601": "2013-06-13T08:35:51.483512Z",
+        "url": "https://files.pythonhosted.org/packages/f3/46/53d83cbdb79b27678c7b032d5deaa556655dd034cc747ee609b3e3cbf95b/Flask-0.10.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.10.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "db9c149ba60c47d107f85fe52564133348458f093dd5e6b57a5b60ab9ac517bb",
+          "md5": "378670fe456957eb3c27ddaef60b2b24",
+          "sha256": "4c83829ff83d408b5e1d4995472265411d2c414112298f2eb4b359d9e4563373"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.10.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "378670fe456957eb3c27ddaef60b2b24",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 544247,
+        "upload_time": "2013-06-14T08:54:19",
+        "upload_time_iso_8601": "2013-06-14T08:54:19.252169Z",
+        "url": "https://files.pythonhosted.org/packages/db/9c/149ba60c47d107f85fe52564133348458f093dd5e6b57a5b60ab9ac517bb/Flask-0.10.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.11": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "ac0b191c5dc6b3e22dfacb8e1eba2bb8dc211c16972b23a0b419f8a33b3deb71",
+          "md5": "fa0c2ac5c6980fc92e2591ebfcad706c",
+          "sha256": "6b221aef9684a92209628c8ffeba35fc60a0c89e4424662809e7da6035f257a7"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.11-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "fa0c2ac5c6980fc92e2591ebfcad706c",
+        "packagetype": "bdist_wheel",
+        "python_version": "2.7",
+        "requires_python": null,
+        "size": 80577,
+        "upload_time": "2016-05-29T09:02:35",
+        "upload_time_iso_8601": "2016-05-29T09:02:35.093225Z",
+        "url": "https://files.pythonhosted.org/packages/ac/0b/191c5dc6b3e22dfacb8e1eba2bb8dc211c16972b23a0b419f8a33b3deb71/Flask-0.11-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "dccac0ed9cc90c079085c698e284b672edbc1ffd6866b1830574095cbc5b7752",
+          "md5": "89fbdcb04b7b96c5b24625ae299cf48b",
+          "sha256": "29a7405a7f0de178232fe48cd9b2a2403083bf03bd34eabe12168863d4cdb493"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.11.tar.gz",
+        "has_sig": false,
+        "md5_digest": "89fbdcb04b7b96c5b24625ae299cf48b",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 563928,
+        "upload_time": "2016-05-29T09:02:29",
+        "upload_time_iso_8601": "2016-05-29T09:02:29.470315Z",
+        "url": "https://files.pythonhosted.org/packages/dc/ca/c0ed9cc90c079085c698e284b672edbc1ffd6866b1830574095cbc5b7752/Flask-0.11.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.11.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "632b01f5ed23a78391f6e3e73075973da0ecb467c831376a0b09c0ec5afd7977",
+          "md5": "920be5772ee6399f70794d33a9eb9a13",
+          "sha256": "a4f97abd30d289e548434ef42317a793f58087be1989eab96f2c647470e77000"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.11.1-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "920be5772ee6399f70794d33a9eb9a13",
+        "packagetype": "bdist_wheel",
+        "python_version": "2.7",
+        "requires_python": null,
+        "size": 80615,
+        "upload_time": "2016-06-07T16:25:21",
+        "upload_time_iso_8601": "2016-06-07T16:25:21.831874Z",
+        "url": "https://files.pythonhosted.org/packages/63/2b/01f5ed23a78391f6e3e73075973da0ecb467c831376a0b09c0ec5afd7977/Flask-0.11.1-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "558a78e165d30f0c8bb5d57c429a30ee5749825ed461ad6c959688872643ffb3",
+          "md5": "d2af95d8fe79cf7da099f062dd122a08",
+          "sha256": "b4713f2bfb9ebc2966b8a49903ae0d3984781d5c878591cf2f7b484d28756b0e"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.11.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "d2af95d8fe79cf7da099f062dd122a08",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 564993,
+        "upload_time": "2016-06-07T16:25:04",
+        "upload_time_iso_8601": "2016-06-07T16:25:04.430636Z",
+        "url": "https://files.pythonhosted.org/packages/55/8a/78e165d30f0c8bb5d57c429a30ee5749825ed461ad6c959688872643ffb3/Flask-0.11.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.12": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "0ee937ee66dde483dceefe45bb5e92b387f990d4f097df40c400cf816dcebaa4",
+          "md5": "d3351b10f54446203ac0fd8839850c62",
+          "sha256": "7f03bb2c255452444f7265eddb51601806e5447b6f8a2d50bbc77a654a14c118"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "d3351b10f54446203ac0fd8839850c62",
+        "packagetype": "bdist_wheel",
+        "python_version": "2.7",
+        "requires_python": null,
+        "size": 82841,
+        "upload_time": "2016-12-21T20:22:15",
+        "upload_time_iso_8601": "2016-12-21T20:22:15.304851Z",
+        "url": "https://files.pythonhosted.org/packages/0e/e9/37ee66dde483dceefe45bb5e92b387f990d4f097df40c400cf816dcebaa4/Flask-0.12-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4b3a4c20183df155dd2e39168e35d53a388efb384a512ca6c73001d8292c094a",
+          "md5": "c1d30f51cff4a38f9454b23328a15c5a",
+          "sha256": "93e803cdbe326a61ebd5c5d353959397c85f829bec610d59cb635c9f97d7ca8b"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.tar.gz",
+        "has_sig": false,
+        "md5_digest": "c1d30f51cff4a38f9454b23328a15c5a",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 531923,
+        "upload_time": "2016-12-21T20:22:12",
+        "upload_time_iso_8601": "2016-12-21T20:22:12.557092Z",
+        "url": "https://files.pythonhosted.org/packages/4b/3a/4c20183df155dd2e39168e35d53a388efb384a512ca6c73001d8292c094a/Flask-0.12.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.12.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "f443fb2d5fb1d10e1d0402dd57836cf9a78b7f69c8b5f76a04b6e6113d0d7c5a",
+          "md5": "8229cb65bc853afb6e4cf4f251f026eb",
+          "sha256": "6c3130c8927109a08225993e4e503de4ac4f2678678ae211b33b519c622a7242"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.1-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "8229cb65bc853afb6e4cf4f251f026eb",
+        "packagetype": "bdist_wheel",
+        "python_version": "2.7",
+        "requires_python": null,
+        "size": 82997,
+        "upload_time": "2017-03-31T16:43:41",
+        "upload_time_iso_8601": "2017-03-31T16:43:41.486925Z",
+        "url": "https://files.pythonhosted.org/packages/f4/43/fb2d5fb1d10e1d0402dd57836cf9a78b7f69c8b5f76a04b6e6113d0d7c5a/Flask-0.12.1-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "246e11b9c57e46f276a8a8dfda85a2fa7ada62b0463b68693616c7ab5df356fa",
+          "md5": "76e9fee5c3afcf4634b9baf96c578207",
+          "sha256": "9dce4b6bfbb5b062181d3f7da8f727ff70c1156cbb4024351eafd426deb5fb88"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "76e9fee5c3afcf4634b9baf96c578207",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 548511,
+        "upload_time": "2017-03-31T16:43:38",
+        "upload_time_iso_8601": "2017-03-31T16:43:38.937461Z",
+        "url": "https://files.pythonhosted.org/packages/24/6e/11b9c57e46f276a8a8dfda85a2fa7ada62b0463b68693616c7ab5df356fa/Flask-0.12.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.12.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "7732e3597cb19ffffe724ad4bf0beca4153419918e7fa4ba6a34b04ee4da3371",
+          "md5": "a0ded1d9a2066d3522efba953b4ed874",
+          "sha256": "0749df235e3ff61ac108f69ac178c9770caeaccad2509cb762ce1f65570a8856"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.2-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "a0ded1d9a2066d3522efba953b4ed874",
+        "packagetype": "bdist_wheel",
+        "python_version": "2.7",
+        "requires_python": null,
+        "size": 83018,
+        "upload_time": "2017-05-16T06:39:38",
+        "upload_time_iso_8601": "2017-05-16T06:39:38.355773Z",
+        "url": "https://files.pythonhosted.org/packages/77/32/e3597cb19ffffe724ad4bf0beca4153419918e7fa4ba6a34b04ee4da3371/Flask-0.12.2-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "eb121c7bd06fcbd08ba544f25bf2c6612e305a70ea51ca0eda8007344ec3f123",
+          "md5": "97278dfdafda98ba7902e890b0289177",
+          "sha256": "49f44461237b69ecd901cc7ce66feea0319b9158743dd27a2899962ab214dac1"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "97278dfdafda98ba7902e890b0289177",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 548510,
+        "upload_time": "2017-05-16T06:39:34",
+        "upload_time_iso_8601": "2017-05-16T06:39:34.794990Z",
+        "url": "https://files.pythonhosted.org/packages/eb/12/1c7bd06fcbd08ba544f25bf2c6612e305a70ea51ca0eda8007344ec3f123/Flask-0.12.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.12.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "243e1b6aa496fa9bb119f6b22263ca5ca9e826aaa132431fd78f413c8bcc18e3",
+          "md5": "7ff37015d2c34754c92bcbc7afeb94ae",
+          "sha256": "74bb782687731332b86aa8ab0817be14c9e63e5fa837934de8be4f9236d6d0d2"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.3-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "7ff37015d2c34754c92bcbc7afeb94ae",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 88361,
+        "upload_time": "2018-04-26T20:12:32",
+        "upload_time_iso_8601": "2018-04-26T20:12:32.459965Z",
+        "url": "https://files.pythonhosted.org/packages/24/3e/1b6aa496fa9bb119f6b22263ca5ca9e826aaa132431fd78f413c8bcc18e3/Flask-0.12.3-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "8084ddf5d2141e84f71ba184ea58b3d9b9caaee9cc49ca0303051ac02381791c",
+          "md5": "a27a2c89b82d4ff44eb2a2cc9e450e09",
+          "sha256": "0f431076a50908f0484dcddd0f2fd0241129ef9ca1876799b3ebe14d823f60de"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "a27a2c89b82d4ff44eb2a2cc9e450e09",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 531380,
+        "upload_time": "2018-04-26T20:12:34",
+        "upload_time_iso_8601": "2018-04-26T20:12:34.580941Z",
+        "url": "https://files.pythonhosted.org/packages/80/84/ddf5d2141e84f71ba184ea58b3d9b9caaee9cc49ca0303051ac02381791c/Flask-0.12.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.12.4": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "2e48f1936dadac2326b3d73f2fe0a964a87d16be16eb9d7fc56f09c1bea3d17c",
+          "md5": "3b498df2add69ee16b228e8bdd581bce",
+          "sha256": "6c02dbaa5a9ef790d8219bdced392e2d549c10cd5a5ba4b6aa65126b2271af29"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.4-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "3b498df2add69ee16b228e8bdd581bce",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 81756,
+        "upload_time": "2018-04-30T01:24:56",
+        "upload_time_iso_8601": "2018-04-30T01:24:56.768063Z",
+        "url": "https://files.pythonhosted.org/packages/2e/48/f1936dadac2326b3d73f2fe0a964a87d16be16eb9d7fc56f09c1bea3d17c/Flask-0.12.4-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "1b72ffc594a6832337ace475f939e61c34a44cbb150cde9589f98c482b407dd8",
+          "md5": "f885afe6dd25e8d48d5ba23f2857687e",
+          "sha256": "2ea22336f6d388b4b242bc3abf8a01244a8aa3e236e7407469ef78c16ba355dd"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "f885afe6dd25e8d48d5ba23f2857687e",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 531086,
+        "upload_time": "2018-04-30T01:25:00",
+        "upload_time_iso_8601": "2018-04-30T01:25:00.430363Z",
+        "url": "https://files.pythonhosted.org/packages/1b/72/ffc594a6832337ace475f939e61c34a44cbb150cde9589f98c482b407dd8/Flask-0.12.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.12.5": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "a436756c34af4523bb0dfa77d3c83455bc4d5d01d6f03b20d8414f3e4deb8669",
+          "md5": "3baccb52c500f0b3dfcda30b175833d0",
+          "sha256": "2c710d1d42317c802c43000daa16de9de6026146b344ab3376cbc6d18846b863"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.5-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "3baccb52c500f0b3dfcda30b175833d0",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 81748,
+        "upload_time": "2020-02-10T19:31:26",
+        "upload_time_iso_8601": "2020-02-10T19:31:26.873584Z",
+        "url": "https://files.pythonhosted.org/packages/a4/36/756c34af4523bb0dfa77d3c83455bc4d5d01d6f03b20d8414f3e4deb8669/Flask-0.12.5-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "32573c33fe153ea008e9e0202eb028972178337c55777686aac03f41ade671f8",
+          "md5": "6eb3909d46ed6e4db2155d3d5a765edc",
+          "sha256": "fac2b9d443e49f7e7358a444a3db5950bdd0324674d92ba67f8f1f15f876b14f"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.12.5.tar.gz",
+        "has_sig": false,
+        "md5_digest": "6eb3909d46ed6e4db2155d3d5a765edc",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 621389,
+        "upload_time": "2020-02-10T19:31:30",
+        "upload_time_iso_8601": "2020-02-10T19:31:30.140398Z",
+        "url": "https://files.pythonhosted.org/packages/32/57/3c33fe153ea008e9e0202eb028972178337c55777686aac03f41ade671f8/Flask-0.12.5.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9adb245abc92428bcdfdc32d8017ddd1b079afffce9c74f94e34d1aa777bc771",
+          "md5": "6926822b17cc5c7baa7df9d22c9cf114",
+          "sha256": "2f992b8081cc6091a29b2b5f65d56433857320889c733da837e75b51c7d1b743"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "6926822b17cc5c7baa7df9d22c9cf114",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 13877,
+        "upload_time": "2010-05-12T01:31:26",
+        "upload_time_iso_8601": "2010-05-12T01:31:26.850453Z",
+        "url": "https://files.pythonhosted.org/packages/9a/db/245abc92428bcdfdc32d8017ddd1b079afffce9c74f94e34d1aa777bc771/Flask-0.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "8bcb706dbb37f4ef3a75366c9e715f41d22e73ca4594303f48d229d906c80632",
+          "md5": "5beb1e1b3c243d3ca078fe1ea9d6dbd8",
+          "sha256": "943ffb10abcc6fef6c3fbcc04f3be81cc6caa598ee7469d446f52d18bee1160f"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "5beb1e1b3c243d3ca078fe1ea9d6dbd8",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 1001397,
+        "upload_time": "2010-05-28T01:24:37",
+        "upload_time_iso_8601": "2010-05-28T01:24:37.182936Z",
+        "url": "https://files.pythonhosted.org/packages/8b/cb/706dbb37f4ef3a75366c9e715f41d22e73ca4594303f48d229d906c80632/Flask-0.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.3.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "e0d74de91ad9fc1854e651cf03f87eff939a92cd06716645dee86b0382674ea3",
+          "md5": "22bde65fbbcd93c6509b9939817e3853",
+          "sha256": "7d80bc18748e4243e389cf1cac50d24b74a39b631dd5176525f10dad01ebae1d"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.3.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "22bde65fbbcd93c6509b9939817e3853",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 339666,
+        "upload_time": "2010-05-28T21:23:15",
+        "upload_time_iso_8601": "2010-05-28T21:23:15.767688Z",
+        "url": "https://files.pythonhosted.org/packages/e0/d7/4de91ad9fc1854e651cf03f87eff939a92cd06716645dee86b0382674ea3/Flask-0.3.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.4": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "a389a4bf29e78a87e11f0f6fdd4d9e02a0aece1eecd38118496da58d4826d7e3",
+          "md5": "aec554ae684e7ff5895fd1b5c0dea378",
+          "sha256": "4fc67fa570801209413fbd649e85e435bd3441a19d2d5cbebe7e44f33094940f"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "aec554ae684e7ff5895fd1b5c0dea378",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 352924,
+        "upload_time": "2010-06-18T17:14:06",
+        "upload_time_iso_8601": "2010-06-18T17:14:06.911868Z",
+        "url": "https://files.pythonhosted.org/packages/a3/89/a4bf29e78a87e11f0f6fdd4d9e02a0aece1eecd38118496da58d4826d7e3/Flask-0.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.5": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "d46a93500f2a7089b4e993fb095215979890b6204a5ba3f6b0f63dc6c3c6c827",
+          "md5": "b5580ae05d75d80485c8694532f95910",
+          "sha256": "20e176b1db0e2bfe92d869f7b5d0ee3e5d6cb60e793755aaf2284bd78a6202ea"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.5.tar.gz",
+        "has_sig": false,
+        "md5_digest": "b5580ae05d75d80485c8694532f95910",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 369558,
+        "upload_time": "2010-07-06T16:28:02",
+        "upload_time_iso_8601": "2010-07-06T16:28:02.414425Z",
+        "url": "https://files.pythonhosted.org/packages/d4/6a/93500f2a7089b4e993fb095215979890b6204a5ba3f6b0f63dc6c3c6c827/Flask-0.5.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.5.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "16a6c458d3305e689d7e06a23eacee414ea10d870074a7673864ffea67109f9d",
+          "md5": "c54da4a640554eb616e4210f256199e6",
+          "sha256": "09a90f9678e2ffdefd2848d6c6a5d6476d675bef874cfd0f06c7608b99682e1d"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.5.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "c54da4a640554eb616e4210f256199e6",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 369739,
+        "upload_time": "2010-07-06T19:25:37",
+        "upload_time_iso_8601": "2010-07-06T19:25:37.546865Z",
+        "url": "https://files.pythonhosted.org/packages/16/a6/c458d3305e689d7e06a23eacee414ea10d870074a7673864ffea67109f9d/Flask-0.5.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.5.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "1cb503c412ba48148e6c222e238201a0924360a85d755ce9597acbd99a1a6240",
+          "md5": "002b8ff41fa14d82662b1d7763f77855",
+          "sha256": "7a78e498cb9cdb104429ed2ff8823b8a4dd10db32ff9a20bb3ef3132a3885e8d"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.5.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "002b8ff41fa14d82662b1d7763f77855",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 369791,
+        "upload_time": "2010-07-15T20:02:56",
+        "upload_time_iso_8601": "2010-07-15T20:02:56.267146Z",
+        "url": "https://files.pythonhosted.org/packages/1c/b5/03c412ba48148e6c222e238201a0924360a85d755ce9597acbd99a1a6240/Flask-0.5.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.6": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4486481371798994529e105633a50b2332638105a1e191053bc0f4bbc9b91791",
+          "md5": "55a5222123978c8c16dae385724c0f3a",
+          "sha256": "9dc18a7c673bf0a6fada51e011fc411285a8301f6dfc1c000ebfa272b5e609e4"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.6.tar.gz",
+        "has_sig": false,
+        "md5_digest": "55a5222123978c8c16dae385724c0f3a",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 388672,
+        "upload_time": "2010-07-27T14:39:13",
+        "upload_time_iso_8601": "2010-07-27T14:39:13.285427Z",
+        "url": "https://files.pythonhosted.org/packages/44/86/481371798994529e105633a50b2332638105a1e191053bc0f4bbc9b91791/Flask-0.6.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.6.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "8f1c453a427f55b91239b3368c8b975b55d089d5d79dc37545af41cd7157c187",
+          "md5": "7af56e33fb6a35db2818c20e604c8698",
+          "sha256": "fe0e31bf71a1fc1d2e0786052855c94cd9ee43546d3e15ff98ccee0c5bc21f70"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.6.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "7af56e33fb6a35db2818c20e604c8698",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 413766,
+        "upload_time": "2010-12-31T15:23:05",
+        "upload_time_iso_8601": "2010-12-31T15:23:05.868761Z",
+        "url": "https://files.pythonhosted.org/packages/8f/1c/453a427f55b91239b3368c8b975b55d089d5d79dc37545af41cd7157c187/Flask-0.6.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.7": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4308e4907533c6ca0ebb1867182fa94b1ffa41fa3aba5f6cb4969e108262e92b",
+          "md5": "1aaf5504ae28925fb97fb3ab8b85d3cd",
+          "sha256": "ab377ff4113d76d7dd3496c05716ff7a7a7b9e492460e775991e9addc271ba16"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.7.tar.gz",
+        "has_sig": false,
+        "md5_digest": "1aaf5504ae28925fb97fb3ab8b85d3cd",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 469417,
+        "upload_time": "2011-06-28T16:06:18",
+        "upload_time_iso_8601": "2011-06-28T16:06:18.291844Z",
+        "url": "https://files.pythonhosted.org/packages/43/08/e4907533c6ca0ebb1867182fa94b1ffa41fa3aba5f6cb4969e108262e92b/Flask-0.7.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.7.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "fe3ead5eb51d4666e76f389cd4f9c6cc22e1544e0daf72419ccab8705e918911",
+          "md5": "4705d31035839dec320a1fd76ac2fa30",
+          "sha256": "7a60e179884b1037ca6182639659f819a0b89675a0cc02d7d9cd21819bfa8d3f"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.7.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4705d31035839dec320a1fd76ac2fa30",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 469692,
+        "upload_time": "2011-06-29T18:37:29",
+        "upload_time_iso_8601": "2011-06-29T18:37:29.978951Z",
+        "url": "https://files.pythonhosted.org/packages/fe/3e/ad5eb51d4666e76f389cd4f9c6cc22e1544e0daf72419ccab8705e918911/Flask-0.7.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.7.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "1cc7a361d00f4c9ed3f1b7ab77976e820ca347f3b0aec4dee6c66fe5c5a2124d",
+          "md5": "a6f52d8de1f536ec982b363e4b6a0387",
+          "sha256": "95fb72b7f2b0ccc68757fc03f7ae559d9fb8814fa5ddbfa27ae2a6d9b1e3f8cb"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.7.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "a6f52d8de1f536ec982b363e4b6a0387",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 469996,
+        "upload_time": "2011-07-06T10:19:39",
+        "upload_time_iso_8601": "2011-07-06T10:19:39.762212Z",
+        "url": "https://files.pythonhosted.org/packages/1c/c7/a361d00f4c9ed3f1b7ab77976e820ca347f3b0aec4dee6c66fe5c5a2124d/Flask-0.7.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.8": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "f084e3c207a6aad1acfdfe1eda20abeadff47035f24820f09ac6870f9c8a26a3",
+          "md5": "a5169306cfe49b3b369086f2a63816ab",
+          "sha256": "937504fc2ae59c44f2181be139733190ed98c51a00adbb6013873692e90b06c9"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.8.tar.gz",
+        "has_sig": false,
+        "md5_digest": "a5169306cfe49b3b369086f2a63816ab",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 494211,
+        "upload_time": "2011-09-29T23:34:21",
+        "upload_time_iso_8601": "2011-09-29T23:34:21.197086Z",
+        "url": "https://files.pythonhosted.org/packages/f0/84/e3c207a6aad1acfdfe1eda20abeadff47035f24820f09ac6870f9c8a26a3/Flask-0.8.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.8.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "205df355d122c9d7a45d7846449f94b9f1d26df88556f705f14dd84a8fa264ea",
+          "md5": "4b9e866bf43723d834b3ce8fcd13574d",
+          "sha256": "f3fcaca39ab1ebd9e6e7def0928bf9f280cafb3f90a6e1c70420e9c1c25b8b6e"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.8.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4b9e866bf43723d834b3ce8fcd13574d",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 458490,
+        "upload_time": "2012-07-01T13:08:59",
+        "upload_time_iso_8601": "2012-07-01T13:08:59.206109Z",
+        "url": "https://files.pythonhosted.org/packages/20/5d/f355d122c9d7a45d7846449f94b9f1d26df88556f705f14dd84a8fa264ea/Flask-0.8.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "490afe5021b35436202d3d4225a766f3bdc7fb51521ad89e73c5162db36cdbc7",
+          "md5": "4a89ef2b3ab0f151f781182bd0cc8933",
+          "sha256": "2fd5d4ffe81f762dd2a3e58472d690a0dbba3766776506003aee3ed7aaa8afef"
+        },
+        "downloads": -1,
+        "filename": "Flask-0.9.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4a89ef2b3ab0f151f781182bd0cc8933",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 481982,
+        "upload_time": "2012-07-01T13:12:50",
+        "upload_time_iso_8601": "2012-07-01T13:12:50.941321Z",
+        "url": "https://files.pythonhosted.org/packages/49/0a/fe5021b35436202d3d4225a766f3bdc7fb51521ad89e73c5162db36cdbc7/Flask-0.9.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "55b14365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6",
+          "md5": "4c0757a5a489d4db8260c6d722c5e6b0",
+          "sha256": "b1883637bbee4dc7bc98d900792d0a304d609fce0f5bd9ca91d1b6457e5918dd"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "4c0757a5a489d4db8260c6d722c5e6b0",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 97791,
+        "upload_time": "2018-04-26T20:12:52",
+        "upload_time_iso_8601": "2018-04-26T20:12:52.254298Z",
+        "url": "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "99abeedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772",
+          "md5": "7140df3116386c7af0f389800a91817b",
+          "sha256": "7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "7140df3116386c7af0f389800a91817b",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 643442,
+        "upload_time": "2018-04-26T20:12:54",
+        "upload_time_iso_8601": "2018-04-26T20:12:54.184864Z",
+        "url": "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.0.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9072b5ed853418364d8e7006550dbdb2cb9ac3e33ce3c9145acc7898fca8c0b6",
+          "md5": "f0e1421b2f993c166d59d3858f03cd93",
+          "sha256": "dbe2a9f539f4d0fe26fa44c08d6e556e2a4a4dd3a3fb0550f39954cf57571363"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.1-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "f0e1421b2f993c166d59d3858f03cd93",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 91320,
+        "upload_time": "2018-04-30T02:09:48",
+        "upload_time_iso_8601": "2018-04-30T02:09:48.725075Z",
+        "url": "https://files.pythonhosted.org/packages/90/72/b5ed853418364d8e7006550dbdb2cb9ac3e33ce3c9145acc7898fca8c0b6/Flask-1.0.1-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "6d2f95a73db56fa2c2b3187bb69783cb2bea4327d1e7b2e0cf60e15df59502ee",
+          "md5": "a4a7d9d73575ea210267f26b5ab94129",
+          "sha256": "cfc15b45622f9cfee6b5803723070fd0f489b3bd662179195e702cb95fd924c8"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "a4a7d9d73575ea210267f26b5ab94129",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 644402,
+        "upload_time": "2018-04-30T02:09:53",
+        "upload_time_iso_8601": "2018-04-30T02:09:53.237533Z",
+        "url": "https://files.pythonhosted.org/packages/6d/2f/95a73db56fa2c2b3187bb69783cb2bea4327d1e7b2e0cf60e15df59502ee/Flask-1.0.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.0.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "7fe708578774ed4536d3242b14dacb4696386634607af824ea997202cd0edb4b",
+          "md5": "d1d5c106d04d90bba6121d0df5bfee76",
+          "sha256": "a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.2-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "d1d5c106d04d90bba6121d0df5bfee76",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 91364,
+        "upload_time": "2018-05-02T14:26:26",
+        "upload_time_iso_8601": "2018-05-02T14:26:26.228390Z",
+        "url": "https://files.pythonhosted.org/packages/7f/e7/08578774ed4536d3242b14dacb4696386634607af824ea997202cd0edb4b/Flask-1.0.2-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4b12c1fbf4971fda0e4de05565694c9f0c92646223cff53f15b6eb248a310a62",
+          "md5": "824f0f20aae1f44c9c7dc4054adb7969",
+          "sha256": "2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "824f0f20aae1f44c9c7dc4054adb7969",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 644534,
+        "upload_time": "2018-05-02T14:26:28",
+        "upload_time_iso_8601": "2018-05-02T14:26:28.310571Z",
+        "url": "https://files.pythonhosted.org/packages/4b/12/c1fbf4971fda0e4de05565694c9f0c92646223cff53f15b6eb248a310a62/Flask-1.0.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.0.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9a74670ae9737d14114753b8c8fdf2e8bd212a05d3b361ab15b44937dfd40985",
+          "md5": "68c3b83ec9c46b58b36a4d9345dc5059",
+          "sha256": "e7d32475d1de5facaa55e3958bc4ec66d3762076b074296aa50ef8fdc5b9df61"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.3-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "68c3b83ec9c46b58b36a4d9345dc5059",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 92053,
+        "upload_time": "2019-05-17T17:59:03",
+        "upload_time_iso_8601": "2019-05-17T17:59:03.245856Z",
+        "url": "https://files.pythonhosted.org/packages/9a/74/670ae9737d14114753b8c8fdf2e8bd212a05d3b361ab15b44937dfd40985/Flask-1.0.3-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "e9968f6d83828a77306a119e12b215a7b0637c955b408fb1c161311a6891b958",
+          "md5": "4b81d0538eb6515ce94df05e74523913",
+          "sha256": "ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4b81d0538eb6515ce94df05e74523913",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 647311,
+        "upload_time": "2019-05-17T17:59:07",
+        "upload_time_iso_8601": "2019-05-17T17:59:07.791692Z",
+        "url": "https://files.pythonhosted.org/packages/e9/96/8f6d83828a77306a119e12b215a7b0637c955b408fb1c161311a6891b958/Flask-1.0.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.0.4": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "d8947350820ae209ccdba073f83220cea1c376f2621254d1e0e82609c9a65e58",
+          "md5": "5998d75e870424f08845754351988f2c",
+          "sha256": "1a21ccca71cee5e55b6a367cc48c6eb47e3c447f76e64d41f3f3f931c17e7c96"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.4-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "5998d75e870424f08845754351988f2c",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        "size": 92416,
+        "upload_time": "2019-07-04T22:58:23",
+        "upload_time_iso_8601": "2019-07-04T22:58:23.261646Z",
+        "url": "https://files.pythonhosted.org/packages/d8/94/7350820ae209ccdba073f83220cea1c376f2621254d1e0e82609c9a65e58/Flask-1.0.4-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "36702234ee8842148cef44261c2cebca3a6384894bce6112b73b18693cdcc62f",
+          "md5": "c56998d88ded8bdb4ec3e7f16d115a79",
+          "sha256": "ed1330220a321138de53ec7c534c3d90cf2f7af938c7880fc3da13aa46bf870f"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.0.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "c56998d88ded8bdb4ec3e7f16d115a79",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        "size": 615497,
+        "upload_time": "2019-07-04T22:58:27",
+        "upload_time_iso_8601": "2019-07-04T22:58:27.094092Z",
+        "url": "https://files.pythonhosted.org/packages/36/70/2234ee8842148cef44261c2cebca3a6384894bce6112b73b18693cdcc62f/Flask-1.0.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.1.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "c3316904ac846fc65a7fa6cac8b4ddc392ce96ca08ee67b0f97854e9575bbb26",
+          "md5": "84f3775abbd953a2d1bf310a520cae73",
+          "sha256": "a31adc27de06034c657a8dc091cc5fcb0227f2474798409bff0e9674de31a026"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.0-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "84f3775abbd953a2d1bf310a520cae73",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 94238,
+        "upload_time": "2019-07-04T23:19:19",
+        "upload_time_iso_8601": "2019-07-04T23:19:19.719994Z",
+        "url": "https://files.pythonhosted.org/packages/c3/31/6904ac846fc65a7fa6cac8b4ddc392ce96ca08ee67b0f97854e9575bbb26/Flask-1.1.0-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "1b735133d483c4eac2c49f82a80bbb25c2d75e01177afe66f84ef8dc6d17c071",
+          "md5": "dbeb645d255cef26ff46733f4caa76a0",
+          "sha256": "b5ae63812021cb04174fcff05d560a98387a44d9cccd4652a2bfa131ba4e4c9b"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "dbeb645d255cef26ff46733f4caa76a0",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 625159,
+        "upload_time": "2019-07-04T23:19:24",
+        "upload_time_iso_8601": "2019-07-04T23:19:24.142387Z",
+        "url": "https://files.pythonhosted.org/packages/1b/73/5133d483c4eac2c49f82a80bbb25c2d75e01177afe66f84ef8dc6d17c071/Flask-1.1.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.1.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9b93628509b8d5dc749656a9641f4caf13540e2cdec85276964ff8f43bbb1d3b",
+          "md5": "b5cc35905a936f5f64e51421d1ebe29c",
+          "sha256": "45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.1-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "b5cc35905a936f5f64e51421d1ebe29c",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 94457,
+        "upload_time": "2019-07-08T18:00:28",
+        "upload_time_iso_8601": "2019-07-08T18:00:28.597456Z",
+        "url": "https://files.pythonhosted.org/packages/9b/93/628509b8d5dc749656a9641f4caf13540e2cdec85276964ff8f43bbb1d3b/Flask-1.1.1-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "2e803726a729de758513fd3dbc64e93098eb009c49305a97c6751de55b20b694",
+          "md5": "0e3ed44ece1c489ed835d1b7047e349c",
+          "sha256": "13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "0e3ed44ece1c489ed835d1b7047e349c",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 625458,
+        "upload_time": "2019-07-08T18:00:31",
+        "upload_time_iso_8601": "2019-07-08T18:00:31.166781Z",
+        "url": "https://files.pythonhosted.org/packages/2e/80/3726a729de758513fd3dbc64e93098eb009c49305a97c6751de55b20b694/Flask-1.1.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.1.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "f2282a03252dfb9ebf377f40fba6a7841b47083260bf8bd8e737b0c6952df83f",
+          "md5": "1811ab52f277d5eccfa3d7127afd7f92",
+          "sha256": "8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.2-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "1811ab52f277d5eccfa3d7127afd7f92",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 94570,
+        "upload_time": "2020-04-03T17:17:53",
+        "upload_time_iso_8601": "2020-04-03T17:17:53.739219Z",
+        "url": "https://files.pythonhosted.org/packages/f2/28/2a03252dfb9ebf377f40fba6a7841b47083260bf8bd8e737b0c6952df83f/Flask-1.1.2-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4e0bcb02268c90e67545a0e3a37ea1ca3d45de3aca43ceb7dbf1712fb5127d5d",
+          "md5": "0da4145d172993cd28a6c619630cc19c",
+          "sha256": "4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "0da4145d172993cd28a6c619630cc19c",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 637516,
+        "upload_time": "2020-04-03T17:17:56",
+        "upload_time_iso_8601": "2020-04-03T17:17:56.951165Z",
+        "url": "https://files.pythonhosted.org/packages/4e/0b/cb02268c90e67545a0e3a37ea1ca3d45de3aca43ceb7dbf1712fb5127d5d/Flask-1.1.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.1.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "a7001d77abb36c69a6d91388dec45cc4c651336412f74c1356fa9c83a582a7d4",
+          "md5": "ba3f2923ef4cc89e0b7831356d303768",
+          "sha256": "d89a27d3f7150268ec078b94760f9a2628079f0b7998b55ecfd73a0bcce90e9f"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.3-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "ba3f2923ef4cc89e0b7831356d303768",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 94594,
+        "upload_time": "2021-05-13T23:26:08",
+        "upload_time_iso_8601": "2021-05-13T23:26:08.710780Z",
+        "url": "https://files.pythonhosted.org/packages/a7/00/1d77abb36c69a6d91388dec45cc4c651336412f74c1356fa9c83a582a7d4/Flask-1.1.3-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "eb29d5afa1447df7e4ccb4d7f9427de5beef2210d238c0fefbef4bbe165d2f50",
+          "md5": "15bd758e34bf732246270201b3a6137e",
+          "sha256": "56513a61e2b953dce9c0a1680886a72e169afe13fe6341ac2cdab82426ea1586"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "15bd758e34bf732246270201b3a6137e",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 635885,
+        "upload_time": "2021-05-13T23:26:13",
+        "upload_time_iso_8601": "2021-05-13T23:26:13.486798Z",
+        "url": "https://files.pythonhosted.org/packages/eb/29/d5afa1447df7e4ccb4d7f9427de5beef2210d238c0fefbef4bbe165d2f50/Flask-1.1.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.1.4": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "e86d994208daa354f68fd89a34a8bafbeaab26fda84e7af1e35bdaed02b667e6",
+          "md5": "6e579a6228c0333dd5b61c5bd214ea05",
+          "sha256": "c34f04500f2cbbea882b1acb02002ad6fe6b7ffa64a6164577995657f50aed22"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.4-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "6e579a6228c0333dd5b61c5bd214ea05",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 94591,
+        "upload_time": "2021-05-14T01:45:55",
+        "upload_time_iso_8601": "2021-05-14T01:45:55.061151Z",
+        "url": "https://files.pythonhosted.org/packages/e8/6d/994208daa354f68fd89a34a8bafbeaab26fda84e7af1e35bdaed02b667e6/Flask-1.1.4-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4d5b2d145f5fe718b2f15ebe69240538f06faa8bbb76488bf962091db1f7a26d",
+          "md5": "49c23fb3096ee548f9737bbddc934c41",
+          "sha256": "0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196"
+        },
+        "downloads": -1,
+        "filename": "Flask-1.1.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "49c23fb3096ee548f9737bbddc934c41",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        "size": 635920,
+        "upload_time": "2021-05-14T01:45:58",
+        "upload_time_iso_8601": "2021-05-14T01:45:58.328834Z",
+        "url": "https://files.pythonhosted.org/packages/4d/5b/2d145f5fe718b2f15ebe69240538f06faa8bbb76488bf962091db1f7a26d/Flask-1.1.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.0.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "bf739180d22a40da68382e9cb6edb66a74bf09cb72ac825c130dce9c5a44198d",
+          "md5": "0ecd811c763bca19c8d1257e70535c6d",
+          "sha256": "1833a4b36ace08dfa1510d86f1bb6fc595d990ec1b838e03ac8dd80ac0705954"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.0-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "0ecd811c763bca19c8d1257e70535c6d",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.6",
+        "size": 93174,
+        "upload_time": "2021-05-11T21:46:04",
+        "upload_time_iso_8601": "2021-05-11T21:46:04.397919Z",
+        "url": "https://files.pythonhosted.org/packages/bf/73/9180d22a40da68382e9cb6edb66a74bf09cb72ac825c130dce9c5a44198d/Flask-2.0.0-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "376d61637b8981e76a9256fade8ce7677e86a6edcd6d4525f459a6b9edbd96a4",
+          "md5": "85c647c7e213e3e65a3f80d6467e6ed1",
+          "sha256": "168e8507792cb8a3aa06afbe5d4d431d3e07c6318bc3893ceecb81aff09f848d"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "85c647c7e213e3e65a3f80d6467e6ed1",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.6",
+        "size": 624458,
+        "upload_time": "2021-05-11T21:46:07",
+        "upload_time_iso_8601": "2021-05-11T21:46:07.758781Z",
+        "url": "https://files.pythonhosted.org/packages/37/6d/61637b8981e76a9256fade8ce7677e86a6edcd6d4525f459a6b9edbd96a4/Flask-2.0.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.0.0rc1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "a80467073caa5397b39e5b19f00e8d8cdd2c4a9b5b83ed4329a812d82227039a",
+          "md5": "0668e00e629a86c45e5d45784c2dc486",
+          "sha256": "ac8a1e93614ec8d4143b54587692b0bac6d094c543add0d026b5443139781378"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.0rc1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "0668e00e629a86c45e5d45784c2dc486",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.6",
+        "size": 88388,
+        "upload_time": "2021-04-16T15:54:18",
+        "upload_time_iso_8601": "2021-04-16T15:54:18.348273Z",
+        "url": "https://files.pythonhosted.org/packages/a8/04/67073caa5397b39e5b19f00e8d8cdd2c4a9b5b83ed4329a812d82227039a/Flask-2.0.0rc1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "34b27b7e56d1acb16a211b9024a81154160da43aad32d9780e9cd31262da581c",
+          "md5": "a374b2de7153f49b80fe14e800d1faa5",
+          "sha256": "2353e7afbd0525d52ae8de3e259d89c2c951eae6f935126e20c7fd94c36e4255"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.0rc1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "a374b2de7153f49b80fe14e800d1faa5",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.6",
+        "size": 619271,
+        "upload_time": "2021-04-16T15:54:20",
+        "upload_time_iso_8601": "2021-04-16T15:54:20.591597Z",
+        "url": "https://files.pythonhosted.org/packages/34/b2/7b7e56d1acb16a211b9024a81154160da43aad32d9780e9cd31262da581c/Flask-2.0.0rc1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.0.0rc2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "5be2c71f0ed2f1b4a29cc7700173ebd2b72faa2101826b4ebf7d830549142297",
+          "md5": "aaed3bf7cc075145ae80893443693bfd",
+          "sha256": "58dab1652d12e432973284d3be02d5820fdf88850b59f36524650be07a1cde2c"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.0rc2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "aaed3bf7cc075145ae80893443693bfd",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.6",
+        "size": 93189,
+        "upload_time": "2021-05-03T14:14:54",
+        "upload_time_iso_8601": "2021-05-03T14:14:54.562105Z",
+        "url": "https://files.pythonhosted.org/packages/5b/e2/c71f0ed2f1b4a29cc7700173ebd2b72faa2101826b4ebf7d830549142297/Flask-2.0.0rc2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "0ebfcef97d7756e721d75830558b239038173dbf53b097be5b3257bf645a0639",
+          "md5": "c2e916b8342993ef974a5e49163435af",
+          "sha256": "944af3be0256ceeb08fea592fa2efe6a5e038bdba26e732dc4bf039ee2682842"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.0rc2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "c2e916b8342993ef974a5e49163435af",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.6",
+        "size": 624489,
+        "upload_time": "2021-05-03T14:14:57",
+        "upload_time_iso_8601": "2021-05-03T14:14:57.971956Z",
+        "url": "https://files.pythonhosted.org/packages/0e/bf/cef97d7756e721d75830558b239038173dbf53b097be5b3257bf645a0639/Flask-2.0.0rc2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.0.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "544f1b294c1a4ab7b2ad5ca5fc4a9a65a22ef1ac48be126289d97668852d4ab3",
+          "md5": "70dd340b2091805c0446040b6cbe7199",
+          "sha256": "a6209ca15eb63fc9385f38e452704113d679511d9574d09b2cf9183ae7d20dc9"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "70dd340b2091805c0446040b6cbe7199",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.6",
+        "size": 94797,
+        "upload_time": "2021-05-21T15:53:08",
+        "upload_time_iso_8601": "2021-05-21T15:53:08.128824Z",
+        "url": "https://files.pythonhosted.org/packages/54/4f/1b294c1a4ab7b2ad5ca5fc4a9a65a22ef1ac48be126289d97668852d4ab3/Flask-2.0.1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "c0dfc516b5f38a670b6b0de604c2637ed5860db03692c2f8542fd1f60c2552a7",
+          "md5": "9c394db4aadc53adb2699bcebee5a275",
+          "sha256": "1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "9c394db4aadc53adb2699bcebee5a275",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.6",
+        "size": 626851,
+        "upload_time": "2021-05-21T15:53:11",
+        "upload_time_iso_8601": "2021-05-21T15:53:11.463636Z",
+        "url": "https://files.pythonhosted.org/packages/c0/df/c516b5f38a670b6b0de604c2637ed5860db03692c2f8542fd1f60c2552a7/Flask-2.0.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.0.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "8fb6b4fdcb6d01ee20f9cfe81dcf9d3cd6c2f874b996f186f1c0b898c4a59c04",
+          "md5": "ee431da5bffac3fa8266b8ffffbe05ae",
+          "sha256": "cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "ee431da5bffac3fa8266b8ffffbe05ae",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.6",
+        "size": 95238,
+        "upload_time": "2021-10-04T14:34:52",
+        "upload_time_iso_8601": "2021-10-04T14:34:52.916386Z",
+        "url": "https://files.pythonhosted.org/packages/8f/b6/b4fdcb6d01ee20f9cfe81dcf9d3cd6c2f874b996f186f1c0b898c4a59c04/Flask-2.0.2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9540b976286b5e7ba01794a7e7588e7e7fa27fb16c6168fa849234840bf0f61d",
+          "md5": "f875da30335908956e2f9f3d0f224f2d",
+          "sha256": "7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "f875da30335908956e2f9f3d0f224f2d",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.6",
+        "size": 628479,
+        "upload_time": "2021-10-04T14:34:54",
+        "upload_time_iso_8601": "2021-10-04T14:34:54.817314Z",
+        "url": "https://files.pythonhosted.org/packages/95/40/b976286b5e7ba01794a7e7588e7e7fa27fb16c6168fa849234840bf0f61d/Flask-2.0.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.0.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "cd7759df23681f4fd19b7cbbb5e92484d46ad587554f5d490f33ef907e456132",
+          "md5": "6e40e2c427f58288141b29c9322eead8",
+          "sha256": "59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.3-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "6e40e2c427f58288141b29c9322eead8",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.6",
+        "size": 95575,
+        "upload_time": "2022-02-14T20:01:06",
+        "upload_time_iso_8601": "2022-02-14T20:01:06.923079Z",
+        "url": "https://files.pythonhosted.org/packages/cd/77/59df23681f4fd19b7cbbb5e92484d46ad587554f5d490f33ef907e456132/Flask-2.0.3-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "849d66347e6b3e2eb78647392d3969c23bdc2d8b2fdc32bd078c817c15cb81ad",
+          "md5": "54ca1a4714f265225f364755d3e9f7fd",
+          "sha256": "e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.0.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "54ca1a4714f265225f364755d3e9f7fd",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.6",
+        "size": 629304,
+        "upload_time": "2022-02-14T20:01:09",
+        "upload_time_iso_8601": "2022-02-14T20:01:09.281713Z",
+        "url": "https://files.pythonhosted.org/packages/84/9d/66347e6b3e2eb78647392d3969c23bdc2d8b2fdc32bd078c817c15cb81ad/Flask-2.0.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.1.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "ef313ca16c38b92da4850301e426105ba2b747c480d7fe2715ff703360d3880f",
+          "md5": "8ceaf9c9c2c7240cb677d0aca1f22b33",
+          "sha256": "e4c69910f6a096cc57e4ee45b7ba9afafdcad4cc571db6eb97d5bd01b95422ea"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.0-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "8ceaf9c9c2c7240cb677d0aca1f22b33",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 95213,
+        "upload_time": "2022-03-28T19:15:12",
+        "upload_time_iso_8601": "2022-03-28T19:15:12.784348Z",
+        "url": "https://files.pythonhosted.org/packages/ef/31/3ca16c38b92da4850301e426105ba2b747c480d7fe2715ff703360d3880f/Flask-2.1.0-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "c38039a0bcfddac460a7444ca1938cb3f3451bed9d43c976b9c574cf68207b2b",
+          "md5": "ac97c545181892888347ade623bf5063",
+          "sha256": "c4dd4a3d8fcae9f892e3f61edfbb1d3cdf9ac03dc72ea1bf8d5c6c964a669674"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "ac97c545181892888347ade623bf5063",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 630852,
+        "upload_time": "2022-03-28T19:15:15",
+        "upload_time_iso_8601": "2022-03-28T19:15:15.540971Z",
+        "url": "https://files.pythonhosted.org/packages/c3/80/39a0bcfddac460a7444ca1938cb3f3451bed9d43c976b9c574cf68207b2b/Flask-2.1.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.1.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "60473b160a97474858486c6b6259d4cf6c0eb30e86b72014e0fe8c8ea7a22937",
+          "md5": "9af017b13f78d4c23b0af9adb597ecff",
+          "sha256": "8a4cf32d904cf5621db9f0c9fbcd7efabf3003f22a04e4d0ce790c7137ec5264"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "9af017b13f78d4c23b0af9adb597ecff",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 95214,
+        "upload_time": "2022-03-30T21:38:30",
+        "upload_time_iso_8601": "2022-03-30T21:38:30.055541Z",
+        "url": "https://files.pythonhosted.org/packages/60/47/3b160a97474858486c6b6259d4cf6c0eb30e86b72014e0fe8c8ea7a22937/Flask-2.1.1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "aeabb63fc9bf1e71433466978e926b8d58bfdf10acf2d1f6fe67d58f8e931b9e",
+          "md5": "0f7f33d9d7caf93d756c757498ab0419",
+          "sha256": "a8c9bd3e558ec99646d177a9739c41df1ded0629480b4c8d2975412f3c9519c8"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "0f7f33d9d7caf93d756c757498ab0419",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 630996,
+        "upload_time": "2022-03-30T21:38:32",
+        "upload_time_iso_8601": "2022-03-30T21:38:32.544391Z",
+        "url": "https://files.pythonhosted.org/packages/ae/ab/b63fc9bf1e71433466978e926b8d58bfdf10acf2d1f6fe67d58f8e931b9e/Flask-2.1.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.1.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "ba76e9580e494eaf6f09710b0f3b9000c9c0363e44af5390be32bb0394165853",
+          "md5": "07aede47b441c019aeebbeaed6a76215",
+          "sha256": "fad5b446feb0d6db6aec0c3184d16a8c1f6c3e464b511649c8918a9be100b4fe"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "07aede47b441c019aeebbeaed6a76215",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 95235,
+        "upload_time": "2022-04-28T17:47:38",
+        "upload_time_iso_8601": "2022-04-28T17:47:38.409651Z",
+        "url": "https://files.pythonhosted.org/packages/ba/76/e9580e494eaf6f09710b0f3b9000c9c0363e44af5390be32bb0394165853/Flask-2.1.2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "d33c94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b",
+          "md5": "93f1832e5be704ef6ff2a4124579cd85",
+          "sha256": "315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "93f1832e5be704ef6ff2a4124579cd85",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 631846,
+        "upload_time": "2022-04-28T17:47:40",
+        "upload_time_iso_8601": "2022-04-28T17:47:40.695078Z",
+        "url": "https://files.pythonhosted.org/packages/d3/3c/94f38d4db919a9326a706ad56f05a7e6f0c8f7b7d93e2997cca54d3bc14b/Flask-2.1.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.1.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "af6a00d144ac1626fbb44c4ff36519712e258128985a5d0ae43344778ae5cbb9",
+          "md5": "6a302f80514c2da4686b79bc734e2f70",
+          "sha256": "9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.3-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "6a302f80514c2da4686b79bc734e2f70",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 95556,
+        "upload_time": "2022-07-13T20:55:57",
+        "upload_time_iso_8601": "2022-07-13T20:55:57.512393Z",
+        "url": "https://files.pythonhosted.org/packages/af/6a/00d144ac1626fbb44c4ff36519712e258128985a5d0ae43344778ae5cbb9/Flask-2.1.3-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "5b773accd62b8771954e9584beb03f080385b32ddcad30009d2a4fe4068a05d9",
+          "md5": "3c1d9aaeaed0f0b72b8b0aa5bc069f45",
+          "sha256": "15972e5017df0575c3d6c090ba168b6db90259e620ac8d7ea813a396bad5b6cb"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.1.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "3c1d9aaeaed0f0b72b8b0aa5bc069f45",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 630206,
+        "upload_time": "2022-07-13T20:56:00",
+        "upload_time_iso_8601": "2022-07-13T20:56:00.126199Z",
+        "url": "https://files.pythonhosted.org/packages/5b/77/3accd62b8771954e9584beb03f080385b32ddcad30009d2a4fe4068a05d9/Flask-2.1.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.2.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "7b973b7716320e560f937e356773a4ec7846c2617b78f6b7d1334cd1725ba834",
+          "md5": "505147b55885a4d6d14100ca8d81c53e",
+          "sha256": "10dc2bae7a9b6ab59111d6dbece2e08fb0015d2e88d296c40323cc0c7aac2c2e"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.0-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "505147b55885a4d6d14100ca8d81c53e",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 101121,
+        "upload_time": "2022-08-02T00:14:07",
+        "upload_time_iso_8601": "2022-08-02T00:14:07.998878Z",
+        "url": "https://files.pythonhosted.org/packages/7b/97/3b7716320e560f937e356773a4ec7846c2617b78f6b7d1334cd1725ba834/Flask-2.2.0-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "dd2e6efff09194bd056e2dc3d4b87028cf835dfbde5b324570db351ef04b868a",
+          "md5": "d19db63959c3711ba8e388d02e926826",
+          "sha256": "98b33b13ad76ee9c7a80d2f56a6c578780e55bf8281790c62d50d4b7fadec2b8"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "d19db63959c3711ba8e388d02e926826",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 686806,
+        "upload_time": "2022-08-02T00:14:12",
+        "upload_time_iso_8601": "2022-08-02T00:14:12.266527Z",
+        "url": "https://files.pythonhosted.org/packages/dd/2e/6efff09194bd056e2dc3d4b87028cf835dfbde5b324570db351ef04b868a/Flask-2.2.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.2.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "3c966c896f80f466b7f5e2cfd6d632fe5b0464dcb412757c595a663e59589a93",
+          "md5": "2fdb198d1036e689b764dc4aad220d9d",
+          "sha256": "3c604c48c3d5b4c63e72134044c0b4fe90ff01ef65280b9fe2d38c8860d99fe5"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "2fdb198d1036e689b764dc4aad220d9d",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 101548,
+        "upload_time": "2022-08-03T23:52:22",
+        "upload_time_iso_8601": "2022-08-03T23:52:22.699213Z",
+        "url": "https://files.pythonhosted.org/packages/3c/96/6c896f80f466b7f5e2cfd6d632fe5b0464dcb412757c595a663e59589a93/Flask-2.2.1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4b4f50888944490f2263bd70171e8298c9626675fd3dfd750694a7beaa3484fb",
+          "md5": "3db3e5bed4b900911ddbfa4bccb95df8",
+          "sha256": "9c2b81b9b1edcc835af72d600f1955e713a065e7cb41d7e51ee762b449d9c65d"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "3db3e5bed4b900911ddbfa4bccb95df8",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 687433,
+        "upload_time": "2022-08-03T23:52:25",
+        "upload_time_iso_8601": "2022-08-03T23:52:25.162192Z",
+        "url": "https://files.pythonhosted.org/packages/4b/4f/50888944490f2263bd70171e8298c9626675fd3dfd750694a7beaa3484fb/Flask-2.2.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.2.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "0f4315f4f9ab225b0b25352412e8daa3d0e3d135fcf5e127070c74c3632c8b4c",
+          "md5": "e737537775d400ad00adf8f59358f7ab",
+          "sha256": "b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "e737537775d400ad00adf8f59358f7ab",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 101477,
+        "upload_time": "2022-08-08T23:26:30",
+        "upload_time_iso_8601": "2022-08-08T23:26:30.228750Z",
+        "url": "https://files.pythonhosted.org/packages/0f/43/15f4f9ab225b0b25352412e8daa3d0e3d135fcf5e127070c74c3632c8b4c/Flask-2.2.2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "69b653cfa30eed5aa7343daff36622843688ba8c6fe9829bb2b92e193ab1163f",
+          "md5": "c0d2276cb7d59a06d62c915da9c77ba6",
+          "sha256": "642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "c0d2276cb7d59a06d62c915da9c77ba6",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 677389,
+        "upload_time": "2022-08-08T23:26:33",
+        "upload_time_iso_8601": "2022-08-08T23:26:33.199749Z",
+        "url": "https://files.pythonhosted.org/packages/69/b6/53cfa30eed5aa7343daff36622843688ba8c6fe9829bb2b92e193ab1163f/Flask-2.2.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.2.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "959ca3542594ce4973786236a1b7b702b8ca81dbf40ea270f0f96284f0c27348",
+          "md5": "caa7a4f7604efe271c93f742933cb145",
+          "sha256": "c0bec9477df1cb867e5a67c9e1ab758de9cb4a3e52dd70681f59fa40a62b3f2d"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.3-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "caa7a4f7604efe271c93f742933cb145",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 101839,
+        "upload_time": "2023-02-15T22:43:55",
+        "upload_time_iso_8601": "2023-02-15T22:43:55.501110Z",
+        "url": "https://files.pythonhosted.org/packages/95/9c/a3542594ce4973786236a1b7b702b8ca81dbf40ea270f0f96284f0c27348/Flask-2.2.3-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "e85cff9047989bd995b1098d14b03013f160225db2282925b517bb4a967752ee",
+          "md5": "09a3dfdc4fc622ec49910cfd62f45eaa",
+          "sha256": "7eb373984bf1c770023fce9db164ed0c3353cd0b53f130f4693da0ca756a2e6d"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "09a3dfdc4fc622ec49910cfd62f45eaa",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 697599,
+        "upload_time": "2023-02-15T22:43:57",
+        "upload_time_iso_8601": "2023-02-15T22:43:57.265452Z",
+        "url": "https://files.pythonhosted.org/packages/e8/5c/ff9047989bd995b1098d14b03013f160225db2282925b517bb4a967752ee/Flask-2.2.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.2.4": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "cfe6cfd7227e18fc44a56594a7b7df21b7ac63954ea652987e6da7707aba6064",
+          "md5": "185e794f24f567eaba8a50bce787a4b4",
+          "sha256": "13f6329ddbfff11340939cd11919daf150a01358ded4b7e81c03c055dfecb559"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.4-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "185e794f24f567eaba8a50bce787a4b4",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 101736,
+        "upload_time": "2023-04-25T17:52:11",
+        "upload_time_iso_8601": "2023-04-25T17:52:11.659458Z",
+        "url": "https://files.pythonhosted.org/packages/cf/e6/cfd7227e18fc44a56594a7b7df21b7ac63954ea652987e6da7707aba6064/Flask-2.2.4-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "6575ac8773717ab84f2c60710d61f82108fffbf4ed2ffa02b70bc6bc776ca221",
+          "md5": "f56f94d315d3475cd3141710c1720750",
+          "sha256": "77504c4c097f56ac5f29b00f9009213010cf9d2923a288c0e0564a5db2bb53d6"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "f56f94d315d3475cd3141710c1720750",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 697568,
+        "upload_time": "2023-04-25T17:52:13",
+        "upload_time_iso_8601": "2023-04-25T17:52:13.229807Z",
+        "url": "https://files.pythonhosted.org/packages/65/75/ac8773717ab84f2c60710d61f82108fffbf4ed2ffa02b70bc6bc776ca221/Flask-2.2.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.2.5": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9f1a8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310",
+          "md5": "37b0afe5d9c9aca85f00e1967efb8822",
+          "sha256": "58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.5-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "37b0afe5d9c9aca85f00e1967efb8822",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.7",
+        "size": 101817,
+        "upload_time": "2023-05-02T14:42:34",
+        "upload_time_iso_8601": "2023-05-02T14:42:34.858087Z",
+        "url": "https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "5f76a4d2c4436dda4b0a12c71e075c508ea7988a1066b06a575f6afe4fecc023",
+          "md5": "bbca6fb017f4d338cfddfd673e203779",
+          "sha256": "edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.2.5.tar.gz",
+        "has_sig": false,
+        "md5_digest": "bbca6fb017f4d338cfddfd673e203779",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.7",
+        "size": 697814,
+        "upload_time": "2023-05-02T14:42:36",
+        "upload_time_iso_8601": "2023-05-02T14:42:36.742906Z",
+        "url": "https://files.pythonhosted.org/packages/5f/76/a4d2c4436dda4b0a12c71e075c508ea7988a1066b06a575f6afe4fecc023/Flask-2.2.5.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.3.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "24dd45df0b0b93f449cb217486136071294595b2d6f8840eaf38704773093a37",
+          "md5": "e64f189aebc99d8174567794c5ca5793",
+          "sha256": "99a4889167c86fe57c4036825ebc77dc5dc3241bf0d80ea80ca941587d0d6a52"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.3.0-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "e64f189aebc99d8174567794c5ca5793",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 96970,
+        "upload_time": "2023-04-25T18:41:55",
+        "upload_time_iso_8601": "2023-04-25T18:41:55.795394Z",
+        "url": "https://files.pythonhosted.org/packages/24/dd/45df0b0b93f449cb217486136071294595b2d6f8840eaf38704773093a37/Flask-2.3.0-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "04f422384e109d9b7e295b20580bc6af5f45b78730d03f41f826639a5c006d1a",
+          "md5": "7e08943593cff5d4be4033406f51266b",
+          "sha256": "4088b4986f13cae23e02081e67df7e4e434ec6f85a5238bce5e6db6d1de61e06"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.3.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "7e08943593cff5d4be4033406f51266b",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 686253,
+        "upload_time": "2023-04-25T18:41:57",
+        "upload_time_iso_8601": "2023-04-25T18:41:57.135136Z",
+        "url": "https://files.pythonhosted.org/packages/04/f4/22384e109d9b7e295b20580bc6af5f45b78730d03f41f826639a5c006d1a/Flask-2.3.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.3.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "9f27fc83394961f97e74c860d05f9bc848af00259b8c84ca021ab31250b9915e",
+          "md5": "3131351f9573f1df6c22838f9014b361",
+          "sha256": "8ba2a854608fdd603b67dccd4514a46450132227fb9df40127a8d0c1de8769ec"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.3.1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "3131351f9573f1df6c22838f9014b361",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 96973,
+        "upload_time": "2023-04-25T21:20:30",
+        "upload_time_iso_8601": "2023-04-25T21:20:30.610853Z",
+        "url": "https://files.pythonhosted.org/packages/9f/27/fc83394961f97e74c860d05f9bc848af00259b8c84ca021ab31250b9915e/Flask-2.3.1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "46e73dc143f22a6aa997753aac1eb68b1b4ac8696819f10ff89d4ebb3de4c42d",
+          "md5": "32d9430b550703e47f3afcc7e91627c2",
+          "sha256": "a6059db4297106e5a64b3215fa16ae641822c1cb97ecb498573549b2478602cb"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.3.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "32d9430b550703e47f3afcc7e91627c2",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 686211,
+        "upload_time": "2023-04-25T21:20:31",
+        "upload_time_iso_8601": "2023-04-25T21:20:31.897804Z",
+        "url": "https://files.pythonhosted.org/packages/46/e7/3dc143f22a6aa997753aac1eb68b1b4ac8696819f10ff89d4ebb3de4c42d/Flask-2.3.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.3.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "fa1af191d32818e5cd985bdd3f47a6e4f525e2db1ce5e8150045ca0c31813686",
+          "md5": "2f059837d4c9e51a62de0fd061e9c947",
+          "sha256": "77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.3.2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "2f059837d4c9e51a62de0fd061e9c947",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 96867,
+        "upload_time": "2023-05-01T15:42:08",
+        "upload_time_iso_8601": "2023-05-01T15:42:08.893644Z",
+        "url": "https://files.pythonhosted.org/packages/fa/1a/f191d32818e5cd985bdd3f47a6e4f525e2db1ce5e8150045ca0c31813686/Flask-2.3.2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "4d00ef81c18da32fdfcde6381c315f4b11597fb6691180a330418848efee0ae7",
+          "md5": "a5d5fe05dff5c6e0d28ece3fb03ef5cd",
+          "sha256": "8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef"
+        },
+        "downloads": -1,
+        "filename": "Flask-2.3.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "a5d5fe05dff5c6e0d28ece3fb03ef5cd",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 686251,
+        "upload_time": "2023-05-01T15:42:12",
+        "upload_time_iso_8601": "2023-05-01T15:42:12.038448Z",
+        "url": "https://files.pythonhosted.org/packages/4d/00/ef81c18da32fdfcde6381c315f4b11597fb6691180a330418848efee0ae7/Flask-2.3.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "2.3.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "fd5626f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9",
+          "md5": "acbf286236b8040816042af736f2adb5",
+          "sha256": "f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"
+        },
+        "downloads": -1,
+        "filename": "flask-2.3.3-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "acbf286236b8040816042af736f2adb5",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 96112,
+        "upload_time": "2023-08-21T19:52:33",
+        "upload_time_iso_8601": "2023-08-21T19:52:33.115955Z",
+        "url": "https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "46b74ace17e37abd9c21715dea5ee11774a25e404c486a7893fa18e764326ead",
+          "md5": "87c2f9544380d251e7054b960547ee7f",
+          "sha256": "09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc"
+        },
+        "downloads": -1,
+        "filename": "flask-2.3.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "87c2f9544380d251e7054b960547ee7f",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 672756,
+        "upload_time": "2023-08-21T19:52:35",
+        "upload_time_iso_8601": "2023-08-21T19:52:35.012171Z",
+        "url": "https://files.pythonhosted.org/packages/46/b7/4ace17e37abd9c21715dea5ee11774a25e404c486a7893fa18e764326ead/flask-2.3.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.0.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "3642015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f",
+          "md5": "a89da9cc87440ebd82366d605eb866f2",
+          "sha256": "21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.0-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "a89da9cc87440ebd82366d605eb866f2",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 99724,
+        "upload_time": "2023-09-30T14:36:10",
+        "upload_time_iso_8601": "2023-09-30T14:36:10.961495Z",
+        "url": "https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "d809c1a7354d3925a3c6c8cfdebf4245bae67d633ffda1ba415add06ffc839c5",
+          "md5": "4848c9d5305197822b5b00c8e9a6d9aa",
+          "sha256": "cfadcdb638b609361d29ec22360d6070a77d7463dcb3ab08d2c2f2f168845f58"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4848c9d5305197822b5b00c8e9a6d9aa",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 674171,
+        "upload_time": "2023-09-30T14:36:12",
+        "upload_time_iso_8601": "2023-09-30T14:36:12.918335Z",
+        "url": "https://files.pythonhosted.org/packages/d8/09/c1a7354d3925a3c6c8cfdebf4245bae67d633ffda1ba415add06ffc839c5/flask-3.0.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.0.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "bd0e63738e88e981ae57c23bad6c499898314a1110a4141f77d7bd929b552fb4",
+          "md5": "16f700724a67c81161cb918dede0437c",
+          "sha256": "ca631a507f6dfe6c278ae20112cea3ff54ff2216390bf8880f6b035a5354af13"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "16f700724a67c81161cb918dede0437c",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 101243,
+        "upload_time": "2024-01-18T20:02:43",
+        "upload_time_iso_8601": "2024-01-18T20:02:43.898152Z",
+        "url": "https://files.pythonhosted.org/packages/bd/0e/63738e88e981ae57c23bad6c499898314a1110a4141f77d7bd929b552fb4/flask-3.0.1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "b21497b9137a02f57d2287f3a9731b3a339fda716d2d3a157d7d1d89c2bebf7b",
+          "md5": "1f2d47c769796fda3dcdbbc62fead96c",
+          "sha256": "6489f51bb3666def6f314e15f19d50a1869a19ae0e8c9a3641ffe66c77d42403"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "1f2d47c769796fda3dcdbbc62fead96c",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 675138,
+        "upload_time": "2024-01-18T20:02:46",
+        "upload_time_iso_8601": "2024-01-18T20:02:46.031144Z",
+        "url": "https://files.pythonhosted.org/packages/b2/14/97b9137a02f57d2287f3a9731b3a339fda716d2d3a157d7d1d89c2bebf7b/flask-3.0.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.0.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "93a6aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23",
+          "md5": "7de254c028a2a8022a31223266a44be7",
+          "sha256": "3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "7de254c028a2a8022a31223266a44be7",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 101300,
+        "upload_time": "2024-02-03T21:11:42",
+        "upload_time_iso_8601": "2024-02-03T21:11:42.661757Z",
+        "url": "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "3fe0a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be",
+          "md5": "3a419da273f762032d344ea129717171",
+          "sha256": "822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "3a419da273f762032d344ea129717171",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 675248,
+        "upload_time": "2024-02-03T21:11:44",
+        "upload_time_iso_8601": "2024-02-03T21:11:44.790102Z",
+        "url": "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.0.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "6180ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06",
+          "md5": "fe39440012a05441fa61d70e92d81754",
+          "sha256": "34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.3-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "fe39440012a05441fa61d70e92d81754",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.8",
+        "size": 101735,
+        "upload_time": "2024-04-07T19:26:08",
+        "upload_time_iso_8601": "2024-04-07T19:26:08.569305Z",
+        "url": "https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "41e1d104c83026f8d35dfd2c261df7d64738341067526406b40190bc063e829a",
+          "md5": "4658b022a07f6d8df51ef24c717fe162",
+          "sha256": "ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"
+        },
+        "downloads": -1,
+        "filename": "flask-3.0.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4658b022a07f6d8df51ef24c717fe162",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.8",
+        "size": 676315,
+        "upload_time": "2024-04-07T19:26:11",
+        "upload_time_iso_8601": "2024-04-07T19:26:11.035227Z",
+        "url": "https://files.pythonhosted.org/packages/41/e1/d104c83026f8d35dfd2c261df7d64738341067526406b40190bc063e829a/flask-3.0.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.1.0": [
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "af4793213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a",
+          "md5": "afcbff84383f20c8cfdf42d6ff82ba17",
+          "sha256": "d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136"
+        },
+        "downloads": -1,
+        "filename": "flask-3.1.0-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "afcbff84383f20c8cfdf42d6ff82ba17",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.9",
+        "size": 102979,
+        "upload_time": "2024-11-13T18:24:36",
+        "upload_time_iso_8601": "2024-11-13T18:24:36.135982Z",
+        "url": "https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "blake2b_256": "8950dff6380f1c7f84135484e176e0cac8690af72fa90e932ad2a0a60e28c69b",
+          "md5": "c95d81666442bf04f7de7db7edbe2aff",
+          "sha256": "5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac"
+        },
+        "downloads": -1,
+        "filename": "flask-3.1.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "c95d81666442bf04f7de7db7edbe2aff",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.9",
+        "size": 680824,
+        "upload_time": "2024-11-13T18:24:38",
+        "upload_time_iso_8601": "2024-11-13T18:24:38.127413Z",
+        "url": "https://files.pythonhosted.org/packages/89/50/dff6380f1c7f84135484e176e0cac8690af72fa90e932ad2a0a60e28c69b/flask-3.1.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.1.1": [
+      {
+        "comment_text": null,
+        "digests": {
+          "blake2b_256": "3d689d4508e893976286d2ead7f8f571314af6c2037af34853a30fd769c02e9d",
+          "md5": "ce31ab1b9c6faaf9436a70008ed44492",
+          "sha256": "07aae2bb5eaf77993ef57e357491839f5fd9f4dc281593a81a9e4d79a24f295c"
+        },
+        "downloads": -1,
+        "filename": "flask-3.1.1-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "ce31ab1b9c6faaf9436a70008ed44492",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.9",
+        "size": 103305,
+        "upload_time": "2025-05-13T15:01:15",
+        "upload_time_iso_8601": "2025-05-13T15:01:15.591997Z",
+        "url": "https://files.pythonhosted.org/packages/3d/68/9d4508e893976286d2ead7f8f571314af6c2037af34853a30fd769c02e9d/flask-3.1.1-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": null,
+        "digests": {
+          "blake2b_256": "c0dee47735752347f4128bcf354e0da07ef311a78244eba9e3dc1d4a5ab21a98",
+          "md5": "59dc1b0772bab098aff83e8008e97af6",
+          "sha256": "284c7b8f2f58cb737f0cf1c30fd7eaf0ccfcde196099d24ecede3fc2005aa59e"
+        },
+        "downloads": -1,
+        "filename": "flask-3.1.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "59dc1b0772bab098aff83e8008e97af6",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.9",
+        "size": 753440,
+        "upload_time": "2025-05-13T15:01:17",
+        "upload_time_iso_8601": "2025-05-13T15:01:17.447750Z",
+        "url": "https://files.pythonhosted.org/packages/c0/de/e47735752347f4128bcf354e0da07ef311a78244eba9e3dc1d4a5ab21a98/flask-3.1.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "3.1.2": [
+      {
+        "comment_text": null,
+        "digests": {
+          "blake2b_256": "ecf97f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd",
+          "md5": "6d99ed48deab8d1311f6980d4fa670c9",
+          "sha256": "ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c"
+        },
+        "downloads": -1,
+        "filename": "flask-3.1.2-py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "6d99ed48deab8d1311f6980d4fa670c9",
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+        "requires_python": ">=3.9",
+        "size": 103308,
+        "upload_time": "2025-08-19T21:03:19",
+        "upload_time_iso_8601": "2025-08-19T21:03:19.499263Z",
+        "url": "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": null,
+        "digests": {
+          "blake2b_256": "dc6dcfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab",
+          "md5": "62ae81cf2e91a376af909a2bc8939e15",
+          "sha256": "bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87"
+        },
+        "downloads": -1,
+        "filename": "flask-3.1.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "62ae81cf2e91a376af909a2bc8939e15",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": ">=3.9",
+        "size": 720160,
+        "upload_time": "2025-08-19T21:03:21",
+        "upload_time_iso_8601": "2025-08-19T21:03:21.205129Z",
+        "url": "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ]
+  },
+  "urls": [
+    {
+      "comment_text": null,
+      "digests": {
+        "blake2b_256": "ecf97f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd",
+        "md5": "6d99ed48deab8d1311f6980d4fa670c9",
+        "sha256": "ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c"
+      },
+      "downloads": -1,
+      "filename": "flask-3.1.2-py3-none-any.whl",
+      "has_sig": false,
+      "md5_digest": "6d99ed48deab8d1311f6980d4fa670c9",
+      "packagetype": "bdist_wheel",
+      "python_version": "py3",
+      "requires_python": ">=3.9",
+      "size": 103308,
+      "upload_time": "2025-08-19T21:03:19",
+      "upload_time_iso_8601": "2025-08-19T21:03:19.499263Z",
+      "url": "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl",
+      "yanked": false,
+      "yanked_reason": null
+    },
+    {
+      "comment_text": null,
+      "digests": {
+        "blake2b_256": "dc6dcfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab",
+        "md5": "62ae81cf2e91a376af909a2bc8939e15",
+        "sha256": "bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87"
+      },
+      "downloads": -1,
+      "filename": "flask-3.1.2.tar.gz",
+      "has_sig": false,
+      "md5_digest": "62ae81cf2e91a376af909a2bc8939e15",
+      "packagetype": "sdist",
+      "python_version": "source",
+      "requires_python": ">=3.9",
+      "size": 720160,
+      "upload_time": "2025-08-19T21:03:21",
+      "upload_time_iso_8601": "2025-08-19T21:03:21.205129Z",
+      "url": "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz",
+      "yanked": false,
+      "yanked_reason": null
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/test/fixtures/files/pypi/flask/recent
+++ b/test/fixtures/files/pypi/flask/recent
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "last_day": 6399553,
+    "last_month": 157236987,
+    "last_week": 39375127
+  },
+  "package": "flask",
+  "type": "recent_downloads"
+}

--- a/test/models/ecosystem/pypi_test.rb
+++ b/test/models/ecosystem/pypi_test.rb
@@ -293,4 +293,42 @@ class PypiTest < ActiveSupport::TestCase
     # Should pick the Source URL
     assert_equal 'https://github.com/test/test-package', repository_url
   end
+
+  test 'pypi package_metadata funding_url flask' do
+    stub_request(:get, "https://pypi.org/pypi/flask/json")
+      .to_return({ status: 200, body: file_fixture('pypi/flask/flask') })
+    stub_request(:get, "https://pypistats.org/api/packages/flask/recent")
+      .to_return({ status: 200, body: file_fixture('pypi/flask/recent') })
+    stub_request(:get, "https://palletsprojects.com/donate")
+      .to_return({ status: 200, body: '' })
+    package_metadata = @ecosystem.package_metadata('flask')
+
+    assert_equal package_metadata[:name], "flask"
+    assert_equal package_metadata[:description], "A simple framework for building complex web applications."
+    assert_nil package_metadata[:homepage]
+    assert_equal package_metadata[:licenses], ""
+    assert_equal package_metadata[:repository_url], "https://github.com/pallets/flask"
+    assert_equal package_metadata[:keywords_array], []
+    assert_equal package_metadata[:downloads], 157236987
+    assert_equal package_metadata[:downloads_period], "last-month"
+    assert_equal package_metadata[:metadata], {
+      "funding"=> "https://palletsprojects.com/donate",
+      "documentation" => "https://flask.palletsprojects.com/",
+      "classifiers"=> [
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Framework :: Flask",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+        "Topic :: Software Development :: Libraries :: Application Frameworks",
+        "Typing :: Typed"
+      ],
+      "normalized_name"=>"flask",
+      "project_status"=>nil
+    }
+  end
 end


### PR DESCRIPTION
Closes #1281 

This pull request fixes incorrect funding URLs for PyPI packages. The funding field can appear under various names, including `donate`, `donation`, `funding`, or `sponsor`, and this update accounts for all of them.

Additionally, it resolves issues with URL redirects by correctly following redirected links.

**Note:** Tests are included.