### PR TITLE
fix #1289: resolved effective POM for accurate dependency parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --update \
     yaml-dev \
     libffi-dev \
     jemalloc \
+    maven \
  && rm -rf /var/cache/apk/* 
 
 # Will invalidate cache as soon as the Gemfile changes

--- a/test/fixtures/files/maven/netty-nio-client/netty-nio-client-2.5.6.pom
+++ b/test/fixtures/files/maven/netty-nio-client/netty-nio-client-2.5.6.pom
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>http-clients</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.5.6</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>netty-nio-client</artifactId>
+    <name>AWS Java SDK :: HTTP Clients :: Netty Non-Blocking I/O</name>
+
+
+    <dependencies>
+
+        <!--SDK dependencies-->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+
+        <!--Netty dependencies-->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+
+        <!--Reactive Dependencies-->
+        <dependency>
+            <groupId>com.typesafe.netty</groupId>
+            <artifactId>netty-reactive-streams-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!--Test Dependencies-->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.http.nio.netty</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -113,9 +113,9 @@ class MavenTest < ActiveSupport::TestCase
 
     assert_equal versions_metadata, [
       {:number=>"5.17.225.2", :published_at=>"2022-07-12 12:10:25 +0000", :licenses=>"APL2", 
-       :metadata=>{:properties=>{}, :java_version=>nil, :maven_compiler_source=>nil, :maven_compiler_target=>nil, :maven_compiler_release=>nil, :repositories=>[], :distribution_repositories=>[]}},
+       :metadata=>{:properties=>{}, :java_version=>nil, :maven_compiler_source=>nil, :maven_compiler_target=>nil, :maven_compiler_release=>nil, :repositories=>["https://repo.maven.apache.org/maven2"], :distribution_repositories=>[]}},
       {:number=>"5.17.102.7", :published_at=>"2022-07-12 12:10:25 +0000", :licenses=>"APL2",
-       :metadata=>{:properties=>{}, :java_version=>nil, :maven_compiler_source=>nil, :maven_compiler_target=>nil, :maven_compiler_release=>nil, :repositories=>[], :distribution_repositories=>[]}},
+       :metadata=>{:properties=>{}, :java_version=>nil, :maven_compiler_source=>nil, :maven_compiler_target=>nil, :maven_compiler_release=>nil, :repositories=>["https://repo.maven.apache.org/maven2"], :distribution_repositories=>[]}},
     ]
   end
 
@@ -126,12 +126,12 @@ class MavenTest < ActiveSupport::TestCase
     dependencies_metadata = @ecosystem.dependencies_metadata('dev.zio:zio-aws-autoscaling_3', '5.17.225.2', {})
 
     assert_equal [
-      {:package_name=>"dev.zio:zio-aws-core_3", :requirements=>"5.17.225.2", :kind=>nil, :ecosystem=>"maven"},
-      {:package_name=>"org.scala-lang:scala3-library_3", :requirements=>"3.1.3", :kind=>nil, :ecosystem=>"maven"},
-      {:package_name=>"software.amazon.awssdk:autoscaling", :requirements=>"2.17.225", :kind=>nil, :ecosystem=>"maven"},
-      {:package_name=>"dev.zio:zio_3", :requirements=>"2.0.0", :kind=>nil, :ecosystem=>"maven"},
-      {:package_name=>"dev.zio:zio-streams_3", :requirements=>"2.0.0", :kind=>nil, :ecosystem=>"maven"},
-      {:package_name=>"dev.zio:zio-mock_3", :requirements=>"1.0.0-RC8", :kind=>nil, :ecosystem=>"maven"}
+      {:package_name=>"dev.zio:zio-aws-core_3", :requirements=>"5.17.225.2", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"org.scala-lang:scala3-library_3", :requirements=>"3.1.3", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"software.amazon.awssdk:autoscaling", :requirements=>"2.17.225", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"dev.zio:zio_3", :requirements=>"2.0.0", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"dev.zio:zio-streams_3", :requirements=>"2.0.0", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"dev.zio:zio-mock_3", :requirements=>"1.0.0-RC8", :kind=>"compile", :ecosystem=>"maven"}
     ], dependencies_metadata
   end
 
@@ -148,8 +148,8 @@ class MavenTest < ActiveSupport::TestCase
     first_version = versions_metadata.first
     assert_equal first_version[:metadata][:java_version], "11"
     assert_equal first_version[:metadata][:maven_compiler_release], "11"
-    assert_equal first_version[:metadata][:maven_compiler_source], "${maven.compiler.release}"
-    assert_equal first_version[:metadata][:maven_compiler_target], "${maven.compiler.release}"
+    assert_equal first_version[:metadata][:maven_compiler_source], "11"
+    assert_equal first_version[:metadata][:maven_compiler_target], "11"
     assert first_version[:metadata][:properties].key?("maven.compiler.release")
     assert_equal first_version[:metadata][:properties]["maven.compiler.release"], "11"
   end
@@ -185,7 +185,7 @@ class MavenTest < ActiveSupport::TestCase
     
     first_version = versions_metadata.first
     assert_equal first_version[:metadata][:java_version], "17"
-    assert_equal first_version[:metadata][:maven_compiler_release], "${java.version}"
+    assert_equal first_version[:metadata][:maven_compiler_release], "17"
     assert first_version[:metadata][:properties].key?("java.version")
     assert_equal first_version[:metadata][:properties]["java.version"], "17"
   end
@@ -500,5 +500,38 @@ class MavenTest < ActiveSupport::TestCase
     assert_nil versions_metadata[1][:published_at]
   end
 
+  test 'dependencies_metadata netty-nio-client' do
+    stub_request(:get, "https://repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.5.6/netty-nio-client-2.5.6.pom")
+      .to_return({ status: 200, body: file_fixture('maven/netty-nio-client/netty-nio-client-2.5.6.pom'), headers: { 'last-modified' => 'Fri, 08 Mar 2019 20:22:40 GMT' } })
 
+    dependencies_metadata = @ecosystem.dependencies_metadata('software.amazon.awssdk:netty-nio-client', '2.5.6', {})
+
+    assert_equal dependencies_metadata, [
+      {:package_name=>"software.amazon.awssdk:annotations", :requirements=>"2.5.6", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"software.amazon.awssdk:http-client-spi", :requirements=>"2.5.6", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"software.amazon.awssdk:utils", :requirements=>"2.5.6", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-codec-http", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-codec-http2", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-codec", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-transport", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-common", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-buffer", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-handler", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"io.netty:netty-transport-native-epoll", :requirements=>"4.1.33.Final", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"com.typesafe.netty:netty-reactive-streams-http", :requirements=>"2.0.0", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"org.reactivestreams:reactive-streams", :requirements=>"1.0.2", :kind=>"compile", :ecosystem=>"maven"},
+      {:package_name=>"org.slf4j:slf4j-api", :requirements=>"1.7.25", :kind=>"compile", :ecosystem=>"maven"},
+
+      # test dependencies
+      {:package_name=>"com.github.tomakehurst:wiremock", :requirements=>"2.18.0", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"org.apache.commons:commons-lang3", :requirements=>"3.4", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"junit:junit", :requirements=>"4.12", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"org.mockito:mockito-core", :requirements=>"1.10.19", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"org.assertj:assertj-core", :requirements=>"3.8.0", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"org.reactivestreams:reactive-streams-tck", :requirements=>"1.0.2", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"org.slf4j:slf4j-log4j12", :requirements=>"1.7.25", :kind=>"test", :ecosystem=>"maven"},
+      {:package_name=>"log4j:log4j", :requirements=>"1.2.17", :kind=>"test", :ecosystem=>"maven"}
+    ]
+
+  end
 end


### PR DESCRIPTION

This PR generates the effective Maven POM for a given pom, which allows more accurate parsing of dependencies. Instead of relying on the raw POM, it uses Maven’s help:effective-pom.

### Key changes:

* Added the command to run mvn help:effective-pom on the input POM.

* Improves accuracy when extracting dependencies from Maven projects, especially when parent POMs or profiles are involved.

### Notes:

* This approach requires Maven to be installed on the host machine and available in the system PATH.

### Tests
- :heavy_check_mark: All tests passed successfully
