### PR TITLE
Improve GitHub Actions security with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,22 @@ name: CI
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   verify:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:14@sha256:ca25035f7e6f74552655a1c5e4a9eb21f85e9d316f1f70371f790ef70095dd58
         env:
           POSTGRES_USER: packages
           POSTGRES_DB: packages_test
@@ -21,17 +29,19 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis
+        image: redis@sha256:43355efd22490e31ca14b9d569367d05121e2be61fd8e47937563ae2a80952ae
         ports:
         - 6379:6379
         options: --entrypoint redis-server
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        with:
+          persist-credentials: false
       - name: Install dependent libraries
         run: sudo apt-get install libpq-dev
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71
         with:
           bundler-cache: true
 

--- a/.github/workflows/upgrade-ruby.yml
+++ b/.github/workflows/upgrade-ruby.yml
@@ -5,15 +5,23 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Runs weekly
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   upgrade-ruby:
+    name: Upgrade Ruby version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to update .ruby-version and other files
+      pull-requests: write # Needed to create pull requests with Ruby upgrades
     steps:
-      - uses: actions/checkout@v6
-      - uses: andrew/ruby-upgrade-action@main
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        with:
+          persist-credentials: false
+      - uses: andrew/ruby-upgrade-action@68cb37826b94a9f50b1ff1da9ad12f65d5b619be
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Zizmor Security Audit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Needed to upload SARIF results to GitHub Security
+      contents: read # Needed to checkout repository
+      actions: read # Needed to analyze workflow files
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4
+        with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
  - Add zizmor workflow to audit GitHub Actions on every PR and push to main
  - Pin all actions to commit hashes instead of tags
  - Pin container images (postgres, redis) to SHA256 digests
  - Add explicit permissions blocks at workflow and job levels
  - Add persist-credentials: false to all checkout steps
  - Add concurrency controls to prevent conflicting workflow runs
  - Document all permissions with inline comments explaining their purpose
