### PR TITLE
Add rake tasks to export NCSU package data as CSV

### DIFF
--- a/lib/tasks/ncsu_verification.rake
+++ b/lib/tasks/ncsu_verification.rake
@@ -1,80 +1,80 @@
+require 'csv'
+
 namespace :ncsu do
-  desc "Verify NCSU PhD student package counts. Usage: ECOSYSTEM=npm rake ncsu:verify_counts"
-  task verify_counts: :environment do
-    two_years_before_cutoff = Date.new(2023, 10, 4)
-    recent_release_cutoff = Date.new(2023, 10, 4)
+  TWO_YEARS_BEFORE_CUTOFF = Date.new(2023, 10, 4)
+  RECENT_RELEASE_CUTOFF = Date.new(2023, 10, 4)
 
-    ecosystem_name = ENV.fetch('ECOSYSTEM') { abort "Usage: ECOSYSTEM=npm rake ncsu:verify_counts" }
-
+  def self.filter_packages(ecosystem_name, output: $stdout)
     registry = Registry.find_by(ecosystem: ecosystem_name)
     abort "Registry not found for #{ecosystem_name}" unless registry
 
     base = registry.packages.active
 
     # Step 1: Packages at least two years old (first release before Oct 4, 2023)
-    print "Step 1: fetching old packages..."
-    step1_ids = base.where("first_release_published_at <= ?", two_years_before_cutoff).pluck(:id)
-    puts " #{step1_ids.length}"
+    output.print "Step 1: fetching old packages..."
+    step1_ids = base.where("first_release_published_at <= ?", TWO_YEARS_BEFORE_CUTOFF).pluck(:id)
+    output.puts " #{step1_ids.length}"
 
     # Step 2: Packages with GitHub repositories
-    print "Step 2: filtering GitHub repos..."
+    output.print "Step 2: filtering GitHub repos..."
     step2_ids = []
     step1_ids.each_slice(100).with_index do |batch, i|
-      print "\rStep 2: filtering GitHub repos... #{i * 100}/#{step1_ids.length}"
+      output.print "\rStep 2: filtering GitHub repos... #{i * 100}/#{step1_ids.length}"
       ids = Package.where(id: batch)
                    .where("repository_url ILIKE '%github.com%'")
                    .pluck(:id)
       step2_ids.concat(ids)
     end
-    puts "\rStep 2: filtering GitHub repos... #{step2_ids.length}                    "
+    output.puts "\rStep 2: filtering GitHub repos... #{step2_ids.length}                    "
 
     # Step 3: Packages with at least one dependent AND at least one dependency (on latest version)
-    print "Step 3a: filtering packages with dependents..."
+    output.print "Step 3a: filtering packages with dependents..."
     step2_with_dependents = []
     step2_ids.each_slice(100).with_index do |batch, i|
-      print "\rStep 3a: filtering packages with dependents... #{i * 100}/#{step2_ids.length}"
+      output.print "\rStep 3a: filtering packages with dependents... #{i * 100}/#{step2_ids.length}"
       ids = Package.where(id: batch)
                    .where("dependent_packages_count > 0")
                    .pluck(:id)
       step2_with_dependents.concat(ids)
     end
-    puts "\rStep 3a: filtering packages with dependents... #{step2_with_dependents.length}                    "
+    output.puts "\rStep 3a: filtering packages with dependents... #{step2_with_dependents.length}                    "
 
     # Step 3b: Check which packages have dependencies on their latest version
     # First batch fetch all version IDs
-    print "Step 3b: fetching version IDs..."
+    output.print "Step 3b: fetching version IDs..."
     pkg_to_version = {}
     step2_with_dependents.each_slice(1000).with_index do |batch, i|
-      print "\rStep 3b: fetching version IDs... #{i * 1000}/#{step2_with_dependents.length}"
-      $stdout.flush
+      output.print "\rStep 3b: fetching version IDs... #{i * 1000}/#{step2_with_dependents.length}"
+      output.flush
       Version.where(package_id: batch, latest: true).pluck(:package_id, :id).each do |pkg_id, version_id|
         pkg_to_version[pkg_id] = version_id
       end
     end
-    puts "\rStep 3b: fetching version IDs... #{pkg_to_version.length}                    "
+    output.puts "\rStep 3b: fetching version IDs... #{pkg_to_version.length}                    "
 
     # Then batch check which versions have dependencies
-    print "Step 3b: checking for dependencies..."
+    output.print "Step 3b: checking for dependencies..."
     step3_ids = []
     version_to_pkg = pkg_to_version.invert
     pkg_to_version.values.each_slice(1000).with_index do |batch, i|
-      print "\rStep 3b: checking for dependencies... #{i * 1000}/#{pkg_to_version.length}"
-      $stdout.flush
+      output.print "\rStep 3b: checking for dependencies... #{i * 1000}/#{pkg_to_version.length}"
+      output.flush
       Dependency.where(version_id: batch).distinct.pluck(:version_id).each do |version_id|
         step3_ids << version_to_pkg[version_id]
       end
     end
-    puts "\rStep 3b: checking for dependencies... #{step3_ids.length}                    "
+    output.puts "\rStep 3b: checking for dependencies... #{step3_ids.length}                    "
 
     # Load all package data we need for steps 4, 5, 6
-    print "Step 3c: loading package data..."
+    output.print "Step 3c: loading package data..."
     packages_data = {}
     step3_ids.each_slice(100).with_index do |batch, i|
-      print "\rStep 3c: loading package data... #{i * 100}/#{step3_ids.length}"
+      output.print "\rStep 3c: loading package data... #{i * 100}/#{step3_ids.length}"
       Package.where(id: batch)
-             .select(:id, :repository_url, :repo_metadata, :latest_release_number, :latest_release_published_at)
+             .select(:id, :name, :repository_url, :repo_metadata, :latest_release_number, :latest_release_published_at)
              .each do |pkg|
         packages_data[pkg.id] = {
+          name: pkg.name,
           repository_url: pkg.repository_url&.downcase,
           repo_metadata: pkg.repo_metadata,
           latest_release_number: pkg.latest_release_number,
@@ -82,10 +82,10 @@ namespace :ncsu do
         }
       end
     end
-    puts "\rStep 3c: loading package data... #{packages_data.length}                    "
+    output.puts "\rStep 3c: loading package data... #{packages_data.length}                    "
 
     # Step 4: GitHub repositories that map to a single package
-    print "Step 4: finding single-package repos..."
+    output.print "Step 4: finding single-package repos..."
     repo_package_counts = Hash.new(0)
     packages_data.each do |id, data|
       next if data[:repository_url].blank?
@@ -94,10 +94,10 @@ namespace :ncsu do
 
     single_repos = repo_package_counts.select { |_repo, count| count == 1 }.keys.to_set
     step4_ids = packages_data.select { |_id, data| data[:repository_url].present? && single_repos.include?(data[:repository_url]) }.keys
-    puts " #{step4_ids.length}"
+    output.puts " #{step4_ids.length}"
 
     # Step 5: Packages where release tag name matches a tag name in repo
-    print "Step 5: checking release/tag matches..."
+    output.print "Step 5: checking release/tag matches..."
     step5_ids = []
     step4_ids.each do |id|
       data = packages_data[id]
@@ -113,38 +113,97 @@ namespace :ncsu do
         step5_ids << id
       end
     end
-    puts " #{step5_ids.length}"
+    output.puts " #{step5_ids.length}"
 
     # Step 6: Packages with releases in past 2 years (as of Oct 4, 2025)
-    print "Step 6: checking for recent releases..."
+    output.print "Step 6: checking for recent releases..."
     step6_ids = step5_ids.select do |id|
       data = packages_data[id]
-      data[:latest_release_published_at] && data[:latest_release_published_at] >= recent_release_cutoff
+      data[:latest_release_published_at] && data[:latest_release_published_at] >= RECENT_RELEASE_CUTOFF
     end
-    puts " #{step6_ids.length}"
+    output.puts " #{step6_ids.length}"
 
     # Step 7: Packages with more than one release in past 2 years
-    print "Step 7: checking for multiple releases..."
+    output.print "Step 7: checking for multiple releases..."
     step7_ids = []
     step6_ids.each_slice(100).with_index do |batch, i|
-      print "\rStep 7: checking for multiple releases... #{i * 100}/#{step6_ids.length}"
+      output.print "\rStep 7: checking for multiple releases... #{i * 100}/#{step6_ids.length}"
       counts = Version.where(package_id: batch)
-                      .where("published_at >= ?", recent_release_cutoff)
+                      .where("published_at >= ?", RECENT_RELEASE_CUTOFF)
                       .group(:package_id)
                       .count
       counts.each do |pkg_id, count|
         step7_ids << pkg_id if count > 1
       end
     end
-    puts "\rStep 7: checking for multiple releases... #{step7_ids.length}                    "
+    output.puts "\rStep 7: checking for multiple releases... #{step7_ids.length}                    "
+
+    {
+      step1_ids: step1_ids,
+      step2_ids: step2_ids,
+      step3_ids: step3_ids,
+      step4_ids: step4_ids,
+      step5_ids: step5_ids,
+      step6_ids: step6_ids,
+      step7_ids: step7_ids,
+      packages_data: packages_data
+    }
+  end
+
+  desc "Verify NCSU PhD student package counts. Usage: ECOSYSTEM=npm rake ncsu:verify_counts"
+  task verify_counts: :environment do
+    ecosystem_name = ENV.fetch('ECOSYSTEM') { abort "Usage: ECOSYSTEM=npm rake ncsu:verify_counts" }
+
+    results = filter_packages(ecosystem_name)
 
     puts "\n=== #{ecosystem_name.upcase} RESULTS ==="
-    puts "Step 1 (at least 2 years old): #{step1_ids.length}"
-    puts "Step 2 (with GitHub repos): #{step2_ids.length}"
-    puts "Step 3 (has dependent and dependency): #{step3_ids.length}"
-    puts "Step 4 (single package per repo): #{step4_ids.length}"
-    puts "Step 5 (release tag matches tag name): #{step5_ids.length}"
-    puts "Step 6 (releases in past 2 years): #{step6_ids.length}"
-    puts "Step 7 (more than one release in past 2 years): #{step7_ids.length}"
+    puts "Step 1 (at least 2 years old): #{results[:step1_ids].length}"
+    puts "Step 2 (with GitHub repos): #{results[:step2_ids].length}"
+    puts "Step 3 (has dependent and dependency): #{results[:step3_ids].length}"
+    puts "Step 4 (single package per repo): #{results[:step4_ids].length}"
+    puts "Step 5 (release tag matches tag name): #{results[:step5_ids].length}"
+    puts "Step 6 (releases in past 2 years): #{results[:step6_ids].length}"
+    puts "Step 7 (more than one release in past 2 years): #{results[:step7_ids].length}"
+  end
+
+  desc "Export package names and GitHub URLs. Usage: ECOSYSTEM=npm OUTPUT=packages.csv rake ncsu:export_packages"
+  task export_packages: :environment do
+    ecosystem_name = ENV.fetch('ECOSYSTEM') { abort "Usage: ECOSYSTEM=npm OUTPUT=packages.csv rake ncsu:export_packages" }
+    output_file = ENV.fetch('OUTPUT') { abort "Usage: ECOSYSTEM=npm OUTPUT=packages.csv rake ncsu:export_packages" }
+
+    results = filter_packages(ecosystem_name)
+    packages_data = results[:packages_data]
+    final_ids = results[:step7_ids]
+
+    puts "\nExporting #{final_ids.length} packages to #{output_file}..."
+
+    CSV.open(output_file, 'w') do |csv|
+      csv << ['package_name', 'repository_url']
+      final_ids.each do |id|
+        data = packages_data[id]
+        csv << [data[:name], data[:repository_url]]
+      end
+    end
+
+    puts "Done. Exported #{final_ids.length} packages."
+  end
+
+  desc "Export CSV to stdout (for piping via dokku). Usage: dokku run packages ECOSYSTEM=npm rake ncsu:export_csv > packages.csv"
+  task export_csv: :environment do
+    ecosystem_name = ENV.fetch('ECOSYSTEM') { abort "Usage: ECOSYSTEM=npm rake ncsu:export_csv" }
+
+    results = filter_packages(ecosystem_name, output: $stderr)
+    packages_data = results[:packages_data]
+    final_ids = results[:step7_ids]
+
+    $stderr.puts "\nExporting #{final_ids.length} packages..."
+
+    puts CSV.generate_line(['package_name', 'repository_url'])
+    final_ids.each do |id|
+      data = packages_data[id]
+      puts CSV.generate_line([data[:name], data[:repository_url]])
+    end
+
+    $stderr.puts "Done."
   end
 end

--- a/test/tasks/ncsu_verification_rake_test.rb
+++ b/test/tasks/ncsu_verification_rake_test.rb
@@ -1,0 +1,130 @@
+require 'test_helper'
+require 'rake'
+require 'csv'
+
+class NcsuVerificationRakeTest < ActiveSupport::TestCase
+  setup do
+    if Rake::Task.tasks.empty?
+      silence_warnings do
+        Packages::Application.load_tasks
+      end
+    end
+
+    Rake::Task['ncsu:verify_counts'].reenable
+    Rake::Task['ncsu:export_packages'].reenable
+    Rake::Task['ncsu:export_csv'].reenable
+
+    @registry = Registry.create(
+      default: true,
+      name: 'rubygems.org',
+      url: 'https://rubygems.org',
+      ecosystem: 'rubygems'
+    )
+
+    @old_date = Date.new(2020, 1, 1)
+    @recent_date = Date.new(2024, 1, 1)
+  end
+
+  test 'verify_counts runs without error for empty registry' do
+    ENV['ECOSYSTEM'] = 'rubygems'
+    assert_nothing_raised do
+      Rake::Task['ncsu:verify_counts'].invoke
+    end
+  end
+
+  test 'export_packages writes CSV with package names and repository URLs' do
+    create_qualifying_package('test-export-package')
+    output_file = Rails.root.join('tmp', 'test_export.csv').to_s
+
+    ENV['ECOSYSTEM'] = 'rubygems'
+    ENV['OUTPUT'] = output_file
+
+    Rake::Task['ncsu:export_packages'].invoke
+
+    assert File.exist?(output_file)
+    csv_content = CSV.read(output_file)
+    assert_equal ['package_name', 'repository_url'], csv_content[0]
+
+    package_row = csv_content.find { |row| row[0] == 'test-export-package' }
+    assert_not_nil package_row
+    assert_equal 'https://github.com/user/test-export-package', package_row[1]
+  ensure
+    File.delete(output_file) if File.exist?(output_file)
+  end
+
+  test 'export_packages creates empty CSV when no packages match' do
+    output_file = Rails.root.join('tmp', 'test_export_empty.csv').to_s
+
+    ENV['ECOSYSTEM'] = 'rubygems'
+    ENV['OUTPUT'] = output_file
+
+    Rake::Task['ncsu:export_packages'].reenable
+    Rake::Task['ncsu:export_packages'].invoke
+
+    assert File.exist?(output_file)
+    csv_content = CSV.read(output_file)
+    assert_equal 1, csv_content.length
+    assert_equal ['package_name', 'repository_url'], csv_content[0]
+  ensure
+    File.delete(output_file) if File.exist?(output_file)
+  end
+
+  test 'export_csv outputs CSV to stdout' do
+    create_qualifying_package('test-stdout-package')
+
+    ENV['ECOSYSTEM'] = 'rubygems'
+
+    Rake::Task['ncsu:export_csv'].reenable
+
+    output = capture_io do
+      Rake::Task['ncsu:export_csv'].invoke
+    end
+
+    stdout_output = output[0]
+    csv_content = CSV.parse(stdout_output)
+
+    assert_equal ['package_name', 'repository_url'], csv_content[0]
+    package_row = csv_content.find { |row| row[0] == 'test-stdout-package' }
+    assert_not_nil package_row
+    assert_equal 'https://github.com/user/test-stdout-package', package_row[1]
+  end
+
+  def create_package(attrs = {})
+    @registry.packages.create!({
+      ecosystem: @registry.ecosystem,
+      status: nil
+    }.merge(attrs))
+  end
+
+  def create_qualifying_package(name)
+    package = create_package(
+      name: name,
+      first_release_published_at: @old_date,
+      repository_url: "https://github.com/user/#{name}",
+      dependent_packages_count: 5,
+      latest_release_number: 'v1.0.0',
+      latest_release_published_at: @recent_date,
+      repo_metadata: { 'tags' => [{ 'name' => 'v1.0.0' }, { 'name' => 'v0.9.0' }] }
+    )
+
+    version1 = package.versions.create!(
+      number: '1.0.0',
+      published_at: @recent_date,
+      latest: true
+    )
+    package.versions.create!(
+      number: '0.9.0',
+      published_at: @recent_date - 1.month,
+      latest: false
+    )
+
+    Dependency.create!(
+      version_id: version1.id,
+      package_name: 'some-dependency',
+      requirements: '>= 0',
+      ecosystem: @registry.ecosystem
+    )
+
+    package
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `ncsu:export_packages` task to write package names and GitHub URLs to a CSV file
- Adds `ncsu:export_csv` task to output CSV to stdout (for piping via dokku)
- Refactors filtering logic into shared method to avoid duplication

## Test plan
- [x] All existing tests pass (808 runs)
- [x] New tests added for export tasks
- [ ] Run `dokku run packages ECOSYSTEM=npm rake ncsu:export_csv > npm_packages.csv` to verify stdout export works