### PR TITLE
Add registry growth stats page

### DIFF
--- a/app.json
+++ b/app.json
@@ -75,6 +75,10 @@
     {
       "command": "bundle exec rake packages:clean_up_sidekiq_unique_jobs",
       "schedule": "0 0 * * 0"
+    },
+    {
+      "command": "bundle exec rake growth_stats:calculate",
+      "schedule": "0 2 * * 0"
     }
   ]
 }

--- a/app/controllers/growth_controller.rb
+++ b/app/controllers/growth_controller.rb
@@ -1,0 +1,24 @@
+class GrowthController < ApplicationController
+  def index
+    @registries = Registry.all.sort_by { |r| -r.packages_count }
+    @stats_by_registry = RegistryGrowthStat.from_min_year.includes(:registry).group_by(&:registry_id)
+
+    # Aggregate stats across all registries by year
+    @combined_stats = RegistryGrowthStat
+      .from_min_year
+      .group(:year)
+      .select(
+        :year,
+        'SUM(packages_count) as packages_count',
+        'SUM(versions_count) as versions_count',
+        'SUM(new_packages_count) as new_packages_count',
+        'SUM(new_versions_count) as new_versions_count'
+      )
+      .order(:year)
+  end
+
+  def show
+    @registry = Registry.find_by_name!(params[:id])
+    @stats = @registry.registry_growth_stats.from_min_year.by_year
+  end
+end

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -6,6 +6,7 @@ class Registry < ApplicationRecord
   has_many :packages
   has_many :versions
   has_many :maintainers
+  has_many :registry_growth_stats
 
   scope :not_docker, -> { where.not(ecosystem: 'docker') }
 

--- a/app/models/registry_growth_stat.rb
+++ b/app/models/registry_growth_stat.rb
@@ -1,0 +1,29 @@
+class RegistryGrowthStat < ApplicationRecord
+  MIN_YEAR = 2005
+
+  validates_presence_of :registry_id, :year
+  validates_uniqueness_of :year, scope: :registry_id
+
+  belongs_to :registry
+
+  scope :by_year, -> { order(year: :asc) }
+  scope :from_min_year, -> { where("year >= ?", MIN_YEAR) }
+
+  def self.years_range
+    minimum(:year)..maximum(:year)
+  end
+
+  def packages_growth_rate
+    return nil if previous_stat.nil? || previous_stat.packages_count.zero?
+    ((packages_count - previous_stat.packages_count).to_f / previous_stat.packages_count * 100).round(2)
+  end
+
+  def versions_growth_rate
+    return nil if previous_stat.nil? || previous_stat.versions_count.zero?
+    ((versions_count - previous_stat.versions_count).to_f / previous_stat.versions_count * 100).round(2)
+  end
+
+  def previous_stat
+    @previous_stat ||= RegistryGrowthStat.find_by(registry_id: registry_id, year: year - 1)
+  end
+end

--- a/app/views/growth/index.html.erb
+++ b/app/views/growth/index.html.erb
@@ -1,0 +1,293 @@
+<% @meta_title = "Registry Growth" %>
+<% @meta_description = "Year-over-year growth of packages and versions across all package registries." %>
+
+<div class="container-fluid">
+  <div class="row">
+    <% if @stats_by_registry.any? %>
+      <div class="col-md-2 d-none d-md-block">
+        <nav class="position-sticky" style="top: 80px;">
+          <div class="list-group list-group-flush small">
+            <a href="#combined" class="list-group-item list-group-item-action py-2">Combined</a>
+            <a href="#comparison" class="list-group-item list-group-item-action py-2">Comparison</a>
+            <div class="list-group-item py-2 text-muted fw-bold">Registries</div>
+            <% @registries.group_by(&:ecosystem).each do |ecosystem, registries| %>
+              <% registry = registries.first %>
+              <% stats = @stats_by_registry[registry.id] %>
+              <% next if stats.blank? %>
+              <a href="#registry_<%= registry.id %>" class="list-group-item list-group-item-action py-2 text-truncate">
+                <%= registry.name %>
+              </a>
+            <% end %>
+          </div>
+        </nav>
+      </div>
+      <div class="col-md-10">
+    <% else %>
+      <div class="col-12">
+    <% end %>
+
+    <h1 class='mb-3'>Registry Growth</h1>
+
+    <p class='lead'>
+      Year-over-year growth of packages and versions across all package registries.
+    </p>
+
+    <% if @stats_by_registry.empty? %>
+      <div class="alert alert-info">
+        Growth stats have not been calculated yet. Run <code>rake growth_stats:calculate</code> to generate the data.
+      </div>
+    <% else %>
+      <% if @combined_stats.any? %>
+        <% combined_filtered = @combined_stats.to_a.drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 } %>
+        <div class="card mb-4" id="combined">
+          <div class="card-body">
+            <h4 class="card-title mb-3">All Registries Combined</h4>
+            <p class="card-subtitle text-muted mb-3">
+              <%= number_with_delimiter @registries.sum { |r| r.packages_count.to_i } %> packages,
+              <%= number_with_delimiter @registries.sum { |r| r.versions_count.to_i } %> versions
+              across <%= @registries.count %> registries
+            </p>
+
+            <div class="row mb-3">
+              <div class="col-md-6">
+                <h6>Cumulative Packages</h6>
+                <%= line_chart combined_filtered.map { |s| [s.year, s.packages_count] }, height: "250px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+              <div class="col-md-6">
+                <h6>Cumulative Versions</h6>
+                <%= line_chart combined_filtered.map { |s| [s.year, s.versions_count] }, height: "250px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col-md-6">
+                <h6>New Packages per Year</h6>
+                <%= column_chart combined_filtered.map { |s| [s.year, s.new_packages_count] }, height: "250px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+              <div class="col-md-6">
+                <h6>New Versions per Year</h6>
+                <%= column_chart combined_filtered.map { |s| [s.year, s.new_versions_count] }, height: "250px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+            </div>
+
+            <table class="table table-sm table-striped mb-0">
+              <thead>
+                <tr>
+                  <th>Year</th>
+                  <th class="text-end">Packages</th>
+                  <th class="text-end">New</th>
+                  <th class="text-end">Growth</th>
+                  <th class="text-end">Versions</th>
+                  <th class="text-end">New</th>
+                  <th class="text-end">Growth</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% combined_array = combined_filtered %>
+                <% combined_array.last(10).reverse.each_with_index do |stat, idx| %>
+                  <% reverse_idx = combined_array.size - 1 - (combined_array.size - 10 + (9 - idx)) rescue 0 %>
+                  <% prev_stat = combined_array[combined_array.index { |s| s.year == stat.year } - 1] if combined_array.index { |s| s.year == stat.year }.to_i > 0 %>
+                  <% pkg_growth = prev_stat && prev_stat.packages_count > 0 ? ((stat.packages_count - prev_stat.packages_count).to_f / prev_stat.packages_count * 100).round(2) : nil %>
+                  <% ver_growth = prev_stat && prev_stat.versions_count > 0 ? ((stat.versions_count - prev_stat.versions_count).to_f / prev_stat.versions_count * 100).round(2) : nil %>
+                  <tr>
+                    <td><%= stat.year %></td>
+                    <td class="text-end"><%= number_with_delimiter stat.packages_count %></td>
+                    <td class="text-end"><%= number_with_delimiter stat.new_packages_count %></td>
+                    <td class="text-end">
+                      <% if pkg_growth %>
+                        <% if pkg_growth > 0 %>
+                          <span class="text-success">+<%= pkg_growth %>%</span>
+                        <% elsif pkg_growth < 0 %>
+                          <span class="text-danger"><%= pkg_growth %>%</span>
+                        <% else %>
+                          0%
+                        <% end %>
+                      <% else %>
+                        -
+                      <% end %>
+                    </td>
+                    <td class="text-end"><%= number_with_delimiter stat.versions_count %></td>
+                    <td class="text-end"><%= number_with_delimiter stat.new_versions_count %></td>
+                    <td class="text-end">
+                      <% if ver_growth %>
+                        <% if ver_growth > 0 %>
+                          <span class="text-success">+<%= ver_growth %>%</span>
+                        <% elsif ver_growth < 0 %>
+                          <span class="text-danger"><%= ver_growth %>%</span>
+                        <% else %>
+                          0%
+                        <% end %>
+                      <% else %>
+                        -
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <%
+          # Prepare multi-series data for comparison charts (top 10 registries only)
+          top_registries = @registries.first(10)
+
+          comparison_packages = top_registries.map do |r|
+            stats = (@stats_by_registry[r.id]&.sort_by(&:year) || []).drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 }
+            next if stats.empty?
+            { name: r.name, data: stats.map { |s| [s.year, s.packages_count] } }
+          end.compact
+
+          comparison_new_packages = top_registries.map do |r|
+            stats = (@stats_by_registry[r.id]&.sort_by(&:year) || []).drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 }
+            next if stats.empty?
+            { name: r.name, data: stats.map { |s| [s.year, s.new_packages_count] } }
+          end.compact
+
+          comparison_versions = top_registries.map do |r|
+            stats = (@stats_by_registry[r.id]&.sort_by(&:year) || []).drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 }
+            next if stats.empty?
+            { name: r.name, data: stats.map { |s| [s.year, s.versions_count] } }
+          end.compact
+
+          comparison_new_versions = top_registries.map do |r|
+            stats = (@stats_by_registry[r.id]&.sort_by(&:year) || []).drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 }
+            next if stats.empty?
+            { name: r.name, data: stats.map { |s| [s.year, s.new_versions_count] } }
+          end.compact
+        %>
+
+        <% if comparison_packages.any? %>
+          <div class="card mb-4" id="comparison">
+            <div class="card-body">
+              <h4 class="card-title mb-3">Registry Comparison (Top 10)</h4>
+
+              <div class="row mb-3">
+                <div class="col-md-6">
+                  <h6>Cumulative Packages</h6>
+                  <%= line_chart comparison_packages, height: "300px", legend: "bottom", library: { plugins: { legend: { position: 'bottom' } }, scales: { y: { beginAtZero: true } } } %>
+                </div>
+                <div class="col-md-6">
+                  <h6>Cumulative Versions</h6>
+                  <%= line_chart comparison_versions, height: "300px", legend: "bottom", library: { plugins: { legend: { position: 'bottom' } }, scales: { y: { beginAtZero: true } } } %>
+                </div>
+              </div>
+
+              <div class="row mb-3">
+                <div class="col-md-6">
+                  <h6>New Packages per Year</h6>
+                  <%= line_chart comparison_new_packages, height: "300px", legend: "bottom", library: { plugins: { legend: { position: 'bottom' } }, scales: { y: { beginAtZero: true } } } %>
+                </div>
+                <div class="col-md-6">
+                  <h6>New Versions per Year</h6>
+                  <%= line_chart comparison_new_versions, height: "300px", legend: "bottom", library: { plugins: { legend: { position: 'bottom' } }, scales: { y: { beginAtZero: true } } } %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <h4 class="mb-3" id="by-registry">By Registry</h4>
+      <% end %>
+
+      <% @registries.group_by(&:ecosystem).each do |ecosystem, registries| %>
+        <% registry = registries.first %>
+        <% stats = (@stats_by_registry[registry.id]&.sort_by(&:year) || []).drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 } %>
+        <% next if stats.empty? %>
+
+        <div class="card mb-3" id="registry_<%= registry.id %>">
+          <div class="card-body">
+            <div class="d-flex mb-3">
+              <div class="flex-grow-1 ms-3 text-break">
+                <h5 class='card-title'>
+                  <%= link_to registry.name, growth_registry_path(registry.name) %>
+                </h5>
+                <p class="card-subtitle text-muted">
+                  <%= number_with_delimiter registry.packages_count %> packages,
+                  <%= number_with_delimiter registry.versions_count %> versions
+                </p>
+              </div>
+              <div class="flex-shrink-0">
+                <img src="<%= registry.icon_url %>" class="rounded" height='40' width='40' onerror="this.style.display='none'">
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col-md-6">
+                <h6>Cumulative Packages</h6>
+                <%= line_chart stats.map { |s| [s.year, s.packages_count] }, height: "200px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+              <div class="col-md-6">
+                <h6>Cumulative Versions</h6>
+                <%= line_chart stats.map { |s| [s.year, s.versions_count] }, height: "200px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col-md-6">
+                <h6>New Packages per Year</h6>
+                <%= column_chart stats.map { |s| [s.year, s.new_packages_count] }, height: "200px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+              <div class="col-md-6">
+                <h6>New Versions per Year</h6>
+                <%= column_chart stats.map { |s| [s.year, s.new_versions_count] }, height: "200px", library: { scales: { y: { beginAtZero: true } } } %>
+              </div>
+            </div>
+
+            <table class="table table-sm table-striped mb-0">
+              <thead>
+                <tr>
+                  <th>Year</th>
+                  <th class="text-end">Packages</th>
+                  <th class="text-end">New</th>
+                  <th class="text-end">Growth</th>
+                  <th class="text-end">Versions</th>
+                  <th class="text-end">New</th>
+                  <th class="text-end">Growth</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% stats.last(5).reverse.each do |stat| %>
+                  <tr>
+                    <td><%= stat.year %></td>
+                    <td class="text-end"><%= number_with_delimiter stat.packages_count %></td>
+                    <td class="text-end"><%= number_with_delimiter stat.new_packages_count %></td>
+                    <td class="text-end">
+                      <% if stat.packages_growth_rate %>
+                        <% if stat.packages_growth_rate > 0 %>
+                          <span class="text-success">+<%= stat.packages_growth_rate %>%</span>
+                        <% elsif stat.packages_growth_rate < 0 %>
+                          <span class="text-danger"><%= stat.packages_growth_rate %>%</span>
+                        <% else %>
+                          0%
+                        <% end %>
+                      <% else %>
+                        -
+                      <% end %>
+                    </td>
+                    <td class="text-end"><%= number_with_delimiter stat.versions_count %></td>
+                    <td class="text-end"><%= number_with_delimiter stat.new_versions_count %></td>
+                    <td class="text-end">
+                      <% if stat.versions_growth_rate %>
+                        <% if stat.versions_growth_rate > 0 %>
+                          <span class="text-success">+<%= stat.versions_growth_rate %>%</span>
+                        <% elsif stat.versions_growth_rate < 0 %>
+                          <span class="text-danger"><%= stat.versions_growth_rate %>%</span>
+                        <% else %>
+                          0%
+                        <% end %>
+                      <% else %>
+                        -
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/growth/show.html.erb
+++ b/app/views/growth/show.html.erb
@@ -1,0 +1,110 @@
+<% @meta_title = "Growth: #{@registry.name}" %>
+<% @meta_description = "Year-over-year growth of packages and versions for #{@registry.name}." %>
+
+<div class="container-sm">
+  <h1 class='mb-3'>
+    <%= link_to 'Growth', growth_path %>: <%= @registry %>
+  </h1>
+
+  <p class='lead'>
+    <%= number_with_delimiter @registry.packages_count %> packages,
+    <%= number_with_delimiter @registry.versions_count %> versions
+  </p>
+
+  <% if @stats.empty? %>
+    <div class="alert alert-info">
+      Growth stats have not been calculated for this registry. Run <code>rake growth_stats:calculate_for[<%= @registry.name %>]</code> to generate the data.
+    </div>
+  <% else %>
+    <% filtered_stats = @stats.drop_while { |s| s.packages_count.to_i == 0 && s.versions_count.to_i == 0 } %>
+    <div class="row mb-4">
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Cumulative Packages</h5>
+            <%= line_chart filtered_stats.map { |s| [s.year, s.packages_count] }, height: "300px", library: { scales: { y: { beginAtZero: true } } } %>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Cumulative Versions</h5>
+            <%= line_chart filtered_stats.map { |s| [s.year, s.versions_count] }, height: "300px", library: { scales: { y: { beginAtZero: true } } } %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">New Packages per Year</h5>
+            <%= column_chart filtered_stats.map { |s| [s.year, s.new_packages_count] }, height: "300px", library: { scales: { y: { beginAtZero: true } } } %>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">New Versions per Year</h5>
+            <%= column_chart filtered_stats.map { |s| [s.year, s.new_versions_count] }, height: "300px", library: { scales: { y: { beginAtZero: true } } } %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h4>Historical Data</h4>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Year</th>
+          <th class="text-end">Total Packages</th>
+          <th class="text-end">New Packages</th>
+          <th class="text-end">Package Growth</th>
+          <th class="text-end">Total Versions</th>
+          <th class="text-end">New Versions</th>
+          <th class="text-end">Version Growth</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% filtered_stats.reverse_each do |stat| %>
+          <tr>
+            <td><%= stat.year %></td>
+            <td class="text-end"><%= number_with_delimiter stat.packages_count %></td>
+            <td class="text-end"><%= number_with_delimiter stat.new_packages_count %></td>
+            <td class="text-end">
+              <% if stat.packages_growth_rate %>
+                <% if stat.packages_growth_rate > 0 %>
+                  <span class="text-success">+<%= stat.packages_growth_rate %>%</span>
+                <% elsif stat.packages_growth_rate < 0 %>
+                  <span class="text-danger"><%= stat.packages_growth_rate %>%</span>
+                <% else %>
+                  0%
+                <% end %>
+              <% else %>
+                -
+              <% end %>
+            </td>
+            <td class="text-end"><%= number_with_delimiter stat.versions_count %></td>
+            <td class="text-end"><%= number_with_delimiter stat.new_versions_count %></td>
+            <td class="text-end">
+              <% if stat.versions_growth_rate %>
+                <% if stat.versions_growth_rate > 0 %>
+                  <span class="text-success">+<%= stat.versions_growth_rate %>%</span>
+                <% elsif stat.versions_growth_rate < 0 %>
+                  <span class="text-danger"><%= stat.versions_growth_rate %>%</span>
+                <% else %>
+                  0%
+                <% end %>
+              <% else %>
+                -
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,9 @@ Rails.application.routes.draw do
   get 'funding/platforms', to: 'funding#platforms'
   get 'funding/:id', to: 'funding#show', as: :funding_registry, constraints: { id: /[^\/]+/  }
 
+  get :growth, to: 'growth#index'
+  get 'growth/:id', to: 'growth#show', as: :growth_registry, constraints: { id: /[^\/]+/  }
+
   get :underproduction, to: 'underproduction#index'
   get 'underproduction/:id', to: 'underproduction#show', as: :underproduction_registry, constraints: { id: /[^\/]+/  }
 

--- a/db/migrate/20260119151006_create_registry_growth_stats.rb
+++ b/db/migrate/20260119151006_create_registry_growth_stats.rb
@@ -1,0 +1,16 @@
+class CreateRegistryGrowthStats < ActiveRecord::Migration[8.1]
+  def change
+    create_table :registry_growth_stats do |t|
+      t.references :registry, null: false, foreign_key: true
+      t.integer :year, null: false
+      t.bigint :packages_count, default: 0
+      t.bigint :versions_count, default: 0
+      t.bigint :new_packages_count, default: 0
+      t.bigint :new_versions_count, default: 0
+
+      t.timestamps
+    end
+
+    add_index :registry_growth_stats, [:registry_id, :year], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_13_124934) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_19_151006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -192,6 +192,19 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_13_124934) do
     t.integer "versions_count"
   end
 
+  create_table "registry_growth_stats", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "new_packages_count", default: 0
+    t.bigint "new_versions_count", default: 0
+    t.bigint "packages_count", default: 0
+    t.bigint "registry_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "versions_count", default: 0
+    t.integer "year", null: false
+    t.index ["registry_id", "year"], name: "index_registry_growth_stats_on_registry_id_and_year", unique: true
+    t.index ["registry_id"], name: "index_registry_growth_stats_on_registry_id"
+  end
+
   create_table "sources", force: :cascade do |t|
     t.integer "advisories_count", default: 0
     t.datetime "created_at", null: false
@@ -220,4 +233,5 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_13_124934) do
   end
 
   add_foreign_key "advisories", "sources"
+  add_foreign_key "registry_growth_stats", "registries"
 end

--- a/lib/tasks/growth_stats.rake
+++ b/lib/tasks/growth_stats.rake
@@ -1,0 +1,63 @@
+namespace :growth_stats do
+  desc "Calculate and cache year-over-year growth stats for all registries"
+  task calculate: :environment do
+    puts "Calculating growth stats for all registries..."
+
+    min_year = RegistryGrowthStat::MIN_YEAR
+    end_year = Time.current.year
+
+    puts "Calculating stats from #{min_year} to #{end_year}"
+
+    Registry.find_each do |registry|
+      puts "Processing registry: #{registry.name} (id: #{registry.id})"
+      calculate_growth_stats_for_registry(registry, min_year, end_year)
+    end
+
+    puts "Finished calculating growth stats"
+  end
+
+  desc "Calculate growth stats for a specific registry"
+  task :calculate_for, [:registry_name] => :environment do |_t, args|
+    registry = Registry.find_by_name!(args[:registry_name])
+    min_year = RegistryGrowthStat::MIN_YEAR
+    end_year = Time.current.year
+
+    puts "Processing registry: #{registry.name} (#{min_year} to #{end_year})"
+    calculate_growth_stats_for_registry(registry, min_year, end_year)
+    puts "Finished"
+  end
+
+  def calculate_growth_stats_for_registry(registry, start_year, end_year)
+    (start_year..end_year).each do |year|
+      year_end = Date.new(year, 12, 31).end_of_day
+
+      # Use efficient SQL counts
+      packages_count = registry.packages
+        .where("COALESCE(first_release_published_at, created_at) <= ?", year_end)
+        .count
+
+      versions_count = registry.versions
+        .where("COALESCE(published_at, created_at) <= ?", year_end)
+        .count
+
+      year_start = Date.new(year, 1, 1).beginning_of_day
+      new_packages_count = registry.packages
+        .where("COALESCE(first_release_published_at, created_at) >= ? AND COALESCE(first_release_published_at, created_at) <= ?", year_start, year_end)
+        .count
+
+      new_versions_count = registry.versions
+        .where("COALESCE(published_at, created_at) >= ? AND COALESCE(published_at, created_at) <= ?", year_start, year_end)
+        .count
+
+      stat = RegistryGrowthStat.find_or_initialize_by(registry_id: registry.id, year: year)
+      stat.update!(
+        packages_count: packages_count,
+        versions_count: versions_count,
+        new_packages_count: new_packages_count,
+        new_versions_count: new_versions_count
+      )
+
+      puts "  #{year}: #{packages_count} packages (#{new_packages_count} new), #{versions_count} versions (#{new_versions_count} new)"
+    end
+  end
+end

--- a/test/controllers/growth_controller_test.rb
+++ b/test/controllers/growth_controller_test.rb
@@ -1,0 +1,97 @@
+require 'test_helper'
+
+class GrowthControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @registry = Registry.create(name: 'crates.io', url: 'https://crates.io', ecosystem: 'cargo')
+    @stat_2022 = RegistryGrowthStat.create!(
+      registry: @registry,
+      year: 2022,
+      packages_count: 100,
+      versions_count: 500,
+      new_packages_count: 50,
+      new_versions_count: 200
+    )
+    @stat_2023 = RegistryGrowthStat.create!(
+      registry: @registry,
+      year: 2023,
+      packages_count: 180,
+      versions_count: 900,
+      new_packages_count: 80,
+      new_versions_count: 400
+    )
+  end
+
+  test 'should get index' do
+    get growth_path
+    assert_response :success
+    assert_template 'growth/index'
+  end
+
+  test 'index shows registry name' do
+    get growth_path
+    assert_response :success
+    assert_includes response.body, @registry.name
+  end
+
+  test 'index shows charts when stats exist' do
+    get growth_path
+    assert_response :success
+    assert_includes response.body, 'Cumulative Packages'
+    assert_includes response.body, 'New Packages per Year'
+  end
+
+  test 'index shows info message when no stats exist' do
+    RegistryGrowthStat.destroy_all
+    get growth_path
+    assert_response :success
+    assert_includes response.body, 'rake growth_stats:calculate'
+  end
+
+  test 'should get show' do
+    get growth_registry_path(@registry.name)
+    assert_response :success
+    assert_template 'growth/show'
+  end
+
+  test 'show displays registry name' do
+    get growth_registry_path(@registry.name)
+    assert_response :success
+    assert_includes response.body, @registry.name
+  end
+
+  test 'show displays historical data table' do
+    get growth_registry_path(@registry.name)
+    assert_response :success
+    assert_includes response.body, '2022'
+    assert_includes response.body, '2023'
+    assert_includes response.body, 'Total Packages'
+    assert_includes response.body, 'New Packages'
+  end
+
+  test 'show displays growth rates' do
+    get growth_registry_path(@registry.name)
+    assert_response :success
+    assert_includes response.body, '+80.0%'
+  end
+
+  test 'show handles registry not found' do
+    get growth_registry_path('nonexistent')
+    assert_response :not_found
+  end
+
+  test 'show displays info message when no stats exist for registry' do
+    other_registry = Registry.create(name: 'npmjs.org', url: 'https://npmjs.org', ecosystem: 'npm')
+    get growth_registry_path(other_registry.name)
+    assert_response :success
+    assert_includes response.body, 'rake growth_stats:calculate_for'
+  end
+
+  test 'show displays charts' do
+    get growth_registry_path(@registry.name)
+    assert_response :success
+    assert_includes response.body, 'Cumulative Packages'
+    assert_includes response.body, 'Cumulative Versions'
+    assert_includes response.body, 'New Packages per Year'
+    assert_includes response.body, 'New Versions per Year'
+  end
+end

--- a/test/models/registry_growth_stat_test.rb
+++ b/test/models/registry_growth_stat_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class RegistryGrowthStatTest < ActiveSupport::TestCase
+  context 'associations' do
+    should belong_to(:registry)
+  end
+
+  context 'validations' do
+    should validate_presence_of(:registry_id)
+    should validate_presence_of(:year)
+  end
+
+  setup do
+    @registry = Registry.create(name: 'Rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+  end
+
+  test 'uniqueness of year scoped to registry' do
+    RegistryGrowthStat.create!(registry: @registry, year: 2023, packages_count: 100, versions_count: 500)
+    duplicate = RegistryGrowthStat.new(registry: @registry, year: 2023, packages_count: 150, versions_count: 600)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:year], 'has already been taken'
+  end
+
+  test 'allows same year for different registries' do
+    other_registry = Registry.create(name: 'npmjs.org', url: 'https://npmjs.org', ecosystem: 'npm')
+    RegistryGrowthStat.create!(registry: @registry, year: 2023, packages_count: 100, versions_count: 500)
+    stat = RegistryGrowthStat.new(registry: other_registry, year: 2023, packages_count: 200, versions_count: 1000)
+    assert stat.valid?
+  end
+
+  test 'by_year scope orders by year ascending' do
+    RegistryGrowthStat.create!(registry: @registry, year: 2023, packages_count: 300)
+    RegistryGrowthStat.create!(registry: @registry, year: 2021, packages_count: 100)
+    RegistryGrowthStat.create!(registry: @registry, year: 2022, packages_count: 200)
+
+    years = @registry.registry_growth_stats.by_year.pluck(:year)
+    assert_equal [2021, 2022, 2023], years
+  end
+
+  test 'packages_growth_rate calculates percentage growth' do
+    RegistryGrowthStat.create!(registry: @registry, year: 2022, packages_count: 100)
+    stat_2023 = RegistryGrowthStat.create!(registry: @registry, year: 2023, packages_count: 150)
+
+    assert_equal 50.0, stat_2023.packages_growth_rate
+  end
+
+  test 'packages_growth_rate returns nil for first year' do
+    stat = RegistryGrowthStat.create!(registry: @registry, year: 2022, packages_count: 100)
+    assert_nil stat.packages_growth_rate
+  end
+
+  test 'packages_growth_rate returns nil when previous count is zero' do
+    RegistryGrowthStat.create!(registry: @registry, year: 2022, packages_count: 0)
+    stat_2023 = RegistryGrowthStat.create!(registry: @registry, year: 2023, packages_count: 100)
+
+    assert_nil stat_2023.packages_growth_rate
+  end
+
+  test 'versions_growth_rate calculates percentage growth' do
+    RegistryGrowthStat.create!(registry: @registry, year: 2022, versions_count: 1000)
+    stat_2023 = RegistryGrowthStat.create!(registry: @registry, year: 2023, versions_count: 1500)
+
+    assert_equal 50.0, stat_2023.versions_growth_rate
+  end
+
+  test 'versions_growth_rate returns nil for first year' do
+    stat = RegistryGrowthStat.create!(registry: @registry, year: 2022, versions_count: 1000)
+    assert_nil stat.versions_growth_rate
+  end
+
+  test 'default values for counts' do
+    stat = RegistryGrowthStat.create!(registry: @registry, year: 2023)
+    assert_equal 0, stat.packages_count
+    assert_equal 0, stat.versions_count
+    assert_equal 0, stat.new_packages_count
+    assert_equal 0, stat.new_versions_count
+  end
+
+  test 'previous_stat finds stat from previous year' do
+    stat_2022 = RegistryGrowthStat.create!(registry: @registry, year: 2022, packages_count: 100)
+    stat_2023 = RegistryGrowthStat.create!(registry: @registry, year: 2023, packages_count: 150)
+
+    assert_equal stat_2022, stat_2023.previous_stat
+  end
+
+  test 'previous_stat returns nil when no previous year exists' do
+    stat = RegistryGrowthStat.create!(registry: @registry, year: 2022)
+    assert_nil stat.previous_stat
+  end
+end

--- a/test/tasks/growth_stats_rake_test.rb
+++ b/test/tasks/growth_stats_rake_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+require 'rake'
+
+class GrowthStatsRakeTest < ActiveSupport::TestCase
+  setup do
+    if Rake::Task.tasks.empty?
+      silence_warnings do
+        Packages::Application.load_tasks
+      end
+    end
+
+    @registry = Registry.create(name: 'Rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+
+    # Create packages with different creation dates
+    @registry.packages.create!(
+      name: 'package-2022',
+      ecosystem: 'rubygems',
+      first_release_published_at: Date.new(2022, 6, 15)
+    )
+    @registry.packages.create!(
+      name: 'package-2023',
+      ecosystem: 'rubygems',
+      first_release_published_at: Date.new(2023, 3, 10)
+    )
+
+    # Re-enable the task so it can run again (Rake tasks only run once by default)
+    Rake::Task["growth_stats:calculate"].reenable
+  end
+
+  test "calculate task creates growth stats for all registries" do
+    # Creates stats from earliest package year (2022) to current year
+    Rake::Task["growth_stats:calculate"].invoke
+    assert @registry.registry_growth_stats.count >= 2
+    assert @registry.registry_growth_stats.find_by(year: 2022).present?
+    assert @registry.registry_growth_stats.find_by(year: 2023).present?
+  end
+
+  test "calculate task populates package counts correctly" do
+    Rake::Task["growth_stats:calculate"].invoke
+
+    stat_2022 = @registry.registry_growth_stats.find_by(year: 2022)
+    stat_2023 = @registry.registry_growth_stats.find_by(year: 2023)
+
+    assert_equal 1, stat_2022.packages_count
+    assert_equal 1, stat_2022.new_packages_count
+
+    assert_equal 2, stat_2023.packages_count
+    assert_equal 1, stat_2023.new_packages_count
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a `/growth` page showing year-over-year growth of packages and versions across all registries
- Creates a `registry_growth_stats` cache table for performance (handles 140M+ versions)
- Includes combined stats, comparison charts (top 10), and individual registry views with charts and tables
- Adds rake tasks (`growth_stats:calculate` and `growth_stats:calculate_for[name]`) to populate the cache

## Test plan
- [ ] Run `bin/rails db:migrate`
- [ ] Run `rake growth_stats:calculate` to populate the cache table
- [ ] Visit `/growth` and verify combined stats, comparison charts, and per-registry cards display correctly
- [ ] Click a registry name to verify the detail page works
- [ ] Verify sidebar navigation scrolls to each section

🤖 Generated with [Claude Code](https://claude.com/claude-code)