### PR TITLE
Add GNU Guix ecosystem support

### DIFF
--- a/app/models/ecosystem/guix.rb
+++ b/app/models/ecosystem/guix.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Guix < Base
+    def self.purl_type
+      'guix'
+    end
+
+    def sync_in_batches?
+      true
+    end
+
+    def has_dependent_repos?
+      false
+    end
+
+    def registry_url(package, version = nil)
+      v = version.is_a?(String) ? version : version.try(:number)
+      v ||= package.versions.first.try(:number)
+      "https://packages.guix.gnu.org/packages/#{package.name}/#{v}/"
+    end
+
+    def install_command(package, version = nil)
+      v = version.is_a?(String) ? version : version.try(:number)
+      if v.present?
+        "guix install #{package.name}@#{v}"
+      else
+        "guix install #{package.name}"
+      end
+    end
+
+    def documentation_url(package, _version = nil)
+      location = package.metadata&.dig('location')
+      return nil unless location.present?
+
+      file_path, line = location.split(':')
+      "https://git.savannah.gnu.org/cgit/guix.git/tree/#{file_path}#n#{line}"
+    end
+
+    def check_status(package)
+      pkg = fetch_package_metadata(package.name)
+      return 'removed' if pkg.blank?
+      nil
+    end
+
+    def packages_url
+      "https://guix.gnu.org/packages.json"
+    end
+
+    def packages
+      @@guix_packages_cache ||= load_packages_json
+    end
+
+    def self.clear_packages_cache!
+      @@guix_packages_cache = nil
+    end
+
+    def load_packages_json
+      response = get_raw(packages_url)
+      raw = Oj.load(response)
+
+      return {} if raw.nil? || !raw.is_a?(Array)
+
+      index = {}
+      raw.each do |entry|
+        name = entry['name']
+        next if name.blank?
+        index[name] ||= []
+        index[name] << entry
+      end
+      index
+    end
+
+    def all_package_names
+      packages.keys
+    end
+
+    def recently_updated_package_names
+      url = "https://git.savannah.gnu.org/cgit/guix.git/atom/?h=master"
+      begin
+        feed = SimpleRSS.parse(get_raw(url))
+        feed.items.flat_map do |item|
+          title = item.title.to_s
+          if title.include?(':')
+            [title.split(':').first.strip]
+          else
+            []
+          end
+        end.uniq.first(100)
+      rescue
+        []
+      end
+    end
+
+    def fetch_package_metadata_uncached(name)
+      packages[name]
+    end
+
+    def package_metadata(name)
+      entries = fetch_package_metadata(name)
+      map_package_metadata(entries, name)
+    end
+
+    def map_package_metadata(entries, name = nil)
+      return false if entries.blank?
+
+      entries = entries.is_a?(Array) ? entries : [entries]
+      latest = entries.max_by { |e| e['version'].to_s }
+      return false if latest.blank?
+
+      name ||= latest['name']
+
+      licenses = parse_license_from_location(latest['location'])
+
+      {
+        name: name,
+        description: latest['synopsis'],
+        homepage: latest['homepage'],
+        licenses: licenses,
+        repository_url: repo_fallback('', latest['homepage']),
+        metadata: {
+          location: latest['location'],
+          variable_name: latest['variable_name'],
+        }.compact
+      }
+    end
+
+    def versions_metadata(pkg_metadata, _existing_version_numbers = [])
+      entries = fetch_package_metadata(pkg_metadata[:name])
+      return [] if entries.blank?
+
+      Array(entries).map do |entry|
+        integrity = entry.dig('source', 0, 'integrity')
+
+        {
+          number: entry['version'],
+          integrity: integrity,
+          metadata: {
+            variable_name: entry['variable_name'],
+          }.compact
+        }
+      end
+    end
+
+    def maintainers_metadata(_name)
+      []
+    end
+
+    def dependencies_metadata(name, _version, _package)
+      entries = fetch_package_metadata(name)
+      return [] if entries.blank?
+
+      entries = entries.is_a?(Array) ? entries : [entries]
+      latest = entries.max_by { |e| e['version'].to_s }
+      return [] if latest.blank?
+
+      location = latest['location']
+      return [] if location.blank?
+
+      content = fetch_scheme_file(location)
+      return [] if content.blank?
+
+      line_number = location.split(':').last.to_i
+      block = find_package_block(content, line_number)
+      return [] if block.blank?
+
+      parse_guix_dependencies(block)
+    rescue => e
+      Rails.logger.warn "[Guix] Failed to fetch dependencies for #{name}: #{e.message}"
+      []
+    end
+
+    def fetch_scheme_file(location)
+      file_path = location.split(':').first
+      url = "https://raw.githubusercontent.com/Millak/guix/master/#{file_path}"
+      response = get_raw(url)
+      response.presence
+    rescue
+      nil
+    end
+
+    def find_package_block(content, line_number)
+      lines = content.lines
+      return nil if line_number < 1 || line_number > lines.length
+
+      # Search backwards from the given line to find (define-public
+      start_line = nil
+      (line_number - 1).downto(0) do |i|
+        if lines[i] =~ /\(define-public\s/
+          start_line = i
+          break
+        end
+      end
+
+      return nil unless start_line
+
+      # Track balanced parens from start_line to find the end
+      depth = 0
+      end_line = nil
+      (start_line...lines.length).each do |i|
+        lines[i].each_char do |c|
+          depth += 1 if c == '('
+          depth -= 1 if c == ')'
+        end
+        if depth == 0
+          end_line = i
+          break
+        end
+      end
+
+      return nil unless end_line
+
+      lines[start_line..end_line].join
+    end
+
+    def strip_scheme_comments(content)
+      return '' if content.blank?
+      content.gsub(/;[^\n]*/, '')
+    end
+
+    def parse_guix_license(block)
+      return nil if block.blank?
+      block = strip_scheme_comments(block)
+
+      # Find the (license ...) form
+      idx = block.index('(license ')
+      return nil unless idx
+
+      # Extract the balanced s-expression starting at (license
+      depth = 0
+      end_idx = nil
+      (idx...block.length).each do |i|
+        depth += 1 if block[i] == '('
+        depth -= 1 if block[i] == ')'
+        if depth == 0
+          end_idx = i
+          break
+        end
+      end
+      return nil unless end_idx
+
+      license_form = block[(idx + 9)..end_idx] # skip "(license "
+
+      if license_form.start_with?('(list ')
+        # Multiple licenses: (list license:expat license:asl2.0)
+        list_content = license_form[6...-1] # strip "(list " and trailing ")"
+        licenses = list_content.scan(/(?:license:)?([a-zA-Z0-9_.+-]+)/).flatten
+        licenses.join(', ') if licenses.any?
+      else
+        # Single license: license:gpl3+ or gpl3+
+        license_form.strip.sub(/\)\z/, '').sub(/\Alicense:/, '').strip.presence
+      end
+    end
+
+    def parse_guix_dependencies(block)
+      return [] if block.blank?
+      block = strip_scheme_comments(block)
+
+      deps = []
+
+      input_mappings = {
+        'inputs' => 'runtime',
+        'propagated-inputs' => 'runtime',
+        'native-inputs' => 'build',
+      }
+
+      input_mappings.each do |attr, kind|
+        extract_scheme_list(block, attr).each do |dep_name|
+          next if guix_builtin?(dep_name)
+
+          deps << {
+            package_name: dep_name,
+            requirements: '*',
+            kind: kind,
+            optional: false,
+            ecosystem: 'guix'
+          }
+        end
+      end
+
+      deps.uniq { |d| [d[:package_name], d[:kind]] }
+    end
+
+    def extract_scheme_list(content, attr)
+      names = []
+
+      # Match (inputs (list ...)) or (native-inputs (list ...)) etc.
+      pattern = /\(#{Regexp.escape(attr)}\s+\(list\s/
+      return names unless content =~ pattern
+
+      # Get everything after the match
+      remainder = $'.dup
+
+      # Find balanced parens
+      depth = 1 # We're already inside one paren from (list
+      end_idx = 0
+
+      remainder.each_char.with_index do |c, i|
+        depth += 1 if c == '('
+        depth -= 1 if c == ')'
+        if depth == 0
+          end_idx = i
+          break
+        end
+        end_idx = i
+      end
+
+      list_content = remainder[0...end_idx]
+
+      # Extract identifiers - package names in Guix are lowercase with hyphens
+      list_content.scan(/\b([a-zA-Z][a-zA-Z0-9_-]*(?:\.[a-zA-Z0-9_-]+)*)\b/).flatten.each do |name|
+        names << name
+      end
+
+      names.uniq
+    end
+
+    def guix_builtin?(name)
+      %w[list modify-inputs append replace delete].include?(name)
+    end
+
+    def parse_license_from_location(location)
+      return nil if location.blank?
+
+      content = fetch_scheme_file(location)
+      return nil if content.blank?
+
+      line_number = location.split(':').last.to_i
+      block = find_package_block(content, line_number)
+      return nil if block.blank?
+
+      parse_guix_license(block)
+    rescue
+      nil
+    end
+
+    def purl_params(package, version = nil)
+      {
+        type: purl_type,
+        namespace: nil,
+        name: package.name.encode('iso-8859-1'),
+        version: version.try(:number).try(:encode, 'iso-8859-1'),
+      }
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -123,6 +123,16 @@ nixpkgs_registries.each do |data|
   r.save
 end
 
+r = Registry.find_or_initialize_by(url: 'https://guix.gnu.org')
+r.assign_attributes(
+  name: 'guix',
+  url: 'https://guix.gnu.org',
+  ecosystem: 'guix',
+  github: 'guix-mirror',
+  default: true
+)
+r.save
+
 ubuntu_registries = []
 # Ubuntu LTS and current releases - https://releases.ubuntu.com/
 ubuntu_releases = [

--- a/test/fixtures/files/guix/base.scm
+++ b/test/fixtures/files/guix/base.scm
@@ -1,0 +1,84 @@
+;;; GNU Guix --- Functional package management for GNU
+;;; Copyright (C) 2012-2024 Ludovic Courtes <ludo@gnu.org>
+;;;
+;;; This file is part of GNU Guix.
+;;;
+;;; GNU Guix is free software; you can redistribute it and/or modify it
+;;; under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 3 of the License, or (at
+;;; your option) any later version.
+
+(define-module (gnu packages base)
+  #:use-module (guix gexp)
+  #:use-module (guix packages)
+  #:use-module (guix download)
+  #:use-module (guix build-system gnu)
+  #:use-module ((guix licenses) #:prefix license:))
+
+;;; Commentary:
+;;;
+;;; Base packages of the Guix-based GNU user-land software distribution.
+
+;; Some unrelated code to skip past
+(define something-else
+  (let ((x 42))
+    (+ x 1)))
+
+(define-public hello
+  (package
+    (name "hello")
+    (version "2.12.1")
+    (source (origin
+              (method url-fetch)
+              (uri (string-append "mirror://gnu/hello/hello-" version
+                                  ".tar.gz"))
+              (sha256
+               (base32
+                "086vqwk2wl8zfs47sq2xpjc9k066ilmb8z6dn0q6ymwjzlm196cd"))))
+    (build-system gnu-build-system)
+    (synopsis "Hello, GNU world: An example GNU package")
+    (description
+     "GNU Hello prints the message \"Hello, world!\" and then exits.  It
+serves as an example of standard GNU coding practices.")
+    (home-page "https://www.gnu.org/software/hello/")
+    (license license:gpl3+)))
+
+(define-public grep
+  (package
+    (name "grep")
+    (version "3.11")
+    (source (origin
+              (method url-fetch)
+              (uri (string-append "mirror://gnu/grep/grep-"
+                                  version ".tar.xz"))
+              (sha256
+               (base32
+                "1avf4x8skxbqrjp5j2qr9sp5vlf8jkw2i5bdn51fl3cxx3fsxchx"))))
+    (build-system gnu-build-system)
+    (native-inputs (list perl))
+    (inputs (list pcre2))
+    (synopsis "Print lines matching a pattern")
+    (description
+     "grep is a tool for finding text inside files.  Text is found by
+matching a pattern provided by the user in one or many files.")
+    (license license:gpl3+)
+    (home-page "https://www.gnu.org/software/grep/")))
+
+(define-public dual-licensed-example
+  (package
+    (name "dual-licensed-example")
+    (version "1.0")
+    (source (origin
+              (method url-fetch)
+              (uri "https://example.org/dual-1.0.tar.gz")
+              (sha256
+               (base32
+                "0000000000000000000000000000000000000000000000000000"))))
+    (build-system gnu-build-system)
+    (inputs (list glib zlib))
+    (native-inputs (list pkg-config))
+    (propagated-inputs (list libxml2))
+    (synopsis "Example package with dual license")
+    (description "A fake package to test multiple license parsing.")
+    (home-page "https://example.org")
+    (license (list license:expat license:asl2.0))))

--- a/test/fixtures/files/guix/packages.json
+++ b/test/fixtures/files/guix/packages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "zile",
+    "version": "2.6.2",
+    "variable_name": "zile",
+    "source": [
+      {
+        "type": "url",
+        "urls": [
+          "https://ftp.gnu.org/gnu/zile/zile-2.6.2.tar.gz",
+          "https://ftpmirror.gnu.org/zile/zile-2.6.2.tar.gz"
+        ],
+        "integrity": "sha256-abc123def456",
+        "outputHashAlgo": "sha256",
+        "outputHashMode": "flat"
+      }
+    ],
+    "synopsis": "Lightweight Emacs clone",
+    "homepage": "https://www.gnu.org/software/zile/",
+    "location": "gnu/packages/zile.scm:48"
+  },
+  {
+    "name": "hello",
+    "version": "2.12.1",
+    "variable_name": "hello",
+    "source": [
+      {
+        "type": "url",
+        "urls": [
+          "https://ftp.gnu.org/gnu/hello/hello-2.12.1.tar.gz"
+        ],
+        "integrity": "sha256-jZkUKv2SV28wsM18tCqNxoCZmLnighAfahT6AFlSML0=",
+        "outputHashAlgo": "sha256",
+        "outputHashMode": "flat"
+      }
+    ],
+    "synopsis": "Hello, GNU world: An example GNU package",
+    "homepage": "https://www.gnu.org/software/hello/",
+    "location": "gnu/packages/base.scm:92"
+  },
+  {
+    "name": "hello",
+    "version": "2.10",
+    "variable_name": "hello-2.10",
+    "source": [
+      {
+        "type": "url",
+        "urls": [
+          "https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz"
+        ],
+        "integrity": "sha256-MeBmE3qWJnbon2nRtlOC3pWn732RS4y5VvQepy4PUWo=",
+        "outputHashAlgo": "sha256",
+        "outputHashMode": "flat"
+      }
+    ],
+    "synopsis": "Hello, GNU world: An example GNU package",
+    "homepage": "https://www.gnu.org/software/hello/",
+    "location": "gnu/packages/base.scm:72"
+  },
+  {
+    "name": "guile",
+    "version": "3.0.10",
+    "variable_name": "guile-3.0",
+    "source": [
+      {
+        "type": "git",
+        "git_url": "https://git.savannah.gnu.org/git/guile.git",
+        "integrity": "sha256-xyz789",
+        "outputHashAlgo": "sha256",
+        "outputHashMode": "recursive",
+        "git_ref": "v3.0.10"
+      }
+    ],
+    "synopsis": "GNU's programming and extension language",
+    "homepage": "https://www.gnu.org/software/guile/",
+    "location": "gnu/packages/guile.scm:205"
+  }
+]

--- a/test/models/ecosystem/guix_test.rb
+++ b/test/models/ecosystem/guix_test.rb
@@ -1,0 +1,613 @@
+require "test_helper"
+
+class GuixTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'guix', url: 'https://guix.gnu.org', ecosystem: 'guix')
+    @ecosystem = Ecosystem::Guix.new(@registry)
+    @package = Package.new(ecosystem: 'guix', name: 'hello', metadata: { 'location' => 'gnu/packages/base.scm:92' })
+    @version = @package.versions.build(number: '2.12.1')
+    Ecosystem::Guix.clear_packages_cache!
+  end
+
+  teardown do
+    Ecosystem::Guix.clear_packages_cache!
+  end
+
+  def stub_packages_from_fixture
+    json = File.read(Rails.root.join('test/fixtures/files/guix/packages.json'))
+    stub_request(:get, "https://guix.gnu.org/packages.json")
+      .to_return(status: 200, body: json, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def stub_packages_cache(data)
+    Ecosystem::Guix.class_variable_set(:@@guix_packages_cache, data)
+  end
+
+  def scheme_fixture
+    @scheme_fixture ||= File.read(Rails.root.join('test/fixtures/files/guix/base.scm'))
+  end
+
+  def stub_scheme_file_fetch
+    @ecosystem.define_singleton_method(:fetch_scheme_file) { |_loc| File.read(Rails.root.join('test/fixtures/files/guix/base.scm')) }
+  end
+
+  def stub_scheme_file_fetch_nil
+    @ecosystem.define_singleton_method(:fetch_scheme_file) { |_loc| nil }
+  end
+
+  test 'purl_type' do
+    assert_equal 'guix', Ecosystem::Guix.purl_type
+  end
+
+  test 'sync_in_batches?' do
+    assert @ecosystem.sync_in_batches?
+  end
+
+  test 'has_dependent_repos?' do
+    refute @ecosystem.has_dependent_repos?
+  end
+
+  test 'registry_url' do
+    url = @ecosystem.registry_url(@package, @version)
+    assert_equal 'https://packages.guix.gnu.org/packages/hello/2.12.1/', url
+  end
+
+  test 'registry_url with string version' do
+    url = @ecosystem.registry_url(@package, '2.10')
+    assert_equal 'https://packages.guix.gnu.org/packages/hello/2.10/', url
+  end
+
+  test 'install_command' do
+    cmd = @ecosystem.install_command(@package)
+    assert_equal 'guix install hello', cmd
+  end
+
+  test 'install_command with version' do
+    cmd = @ecosystem.install_command(@package, @version)
+    assert_equal 'guix install hello@2.12.1', cmd
+  end
+
+  test 'install_command with string version' do
+    cmd = @ecosystem.install_command(@package, '2.10')
+    assert_equal 'guix install hello@2.10', cmd
+  end
+
+  test 'documentation_url' do
+    url = @ecosystem.documentation_url(@package)
+    assert_equal 'https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/base.scm#n92', url
+  end
+
+  test 'documentation_url without location' do
+    package = Package.new(ecosystem: 'guix', name: 'test')
+    assert_nil @ecosystem.documentation_url(package)
+  end
+
+  test 'documentation_url with empty metadata' do
+    package = Package.new(ecosystem: 'guix', name: 'test', metadata: {})
+    assert_nil @ecosystem.documentation_url(package)
+  end
+
+  test 'check_status returns nil when package exists' do
+    stub_packages_cache({
+      'hello' => [{ 'name' => 'hello', 'version' => '2.12.1' }]
+    })
+
+    assert_nil @ecosystem.check_status(@package)
+  end
+
+  test 'check_status returns removed when package missing' do
+    stub_packages_cache({})
+
+    assert_equal 'removed', @ecosystem.check_status(@package)
+  end
+
+  test 'packages_url' do
+    assert_equal 'https://guix.gnu.org/packages.json', @ecosystem.packages_url
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:guix/hello', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'purl with version' do
+    purl = @ecosystem.purl(@package, @version)
+    assert_equal 'pkg:guix/hello@2.12.1', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'download_url' do
+    assert_nil @ecosystem.download_url(@package, @version)
+  end
+
+  test 'all_package_names' do
+    stub_packages_from_fixture
+
+    names = @ecosystem.all_package_names
+    assert_includes names, 'hello'
+    assert_includes names, 'zile'
+    assert_includes names, 'guile'
+    assert_equal 3, names.length
+  end
+
+  test 'packages indexes by name and groups versions' do
+    stub_packages_from_fixture
+
+    pkgs = @ecosystem.packages
+    assert_equal 3, pkgs.keys.length
+    assert_equal 2, pkgs['hello'].length
+    assert_equal 1, pkgs['zile'].length
+  end
+
+  test 'map_package_metadata' do
+    stub_scheme_file_fetch
+
+    entries = [
+      {
+        'name' => 'hello',
+        'version' => '2.12.1',
+        'synopsis' => 'Hello, GNU world: An example GNU package',
+        'homepage' => 'https://www.gnu.org/software/hello/',
+        'location' => 'gnu/packages/base.scm:30',
+        'variable_name' => 'hello'
+      },
+      {
+        'name' => 'hello',
+        'version' => '2.10',
+        'synopsis' => 'Hello, GNU world: An example GNU package',
+        'homepage' => 'https://www.gnu.org/software/hello/',
+        'location' => 'gnu/packages/base.scm:28',
+        'variable_name' => 'hello-2.10'
+      }
+    ]
+
+    mapped = @ecosystem.map_package_metadata(entries, 'hello')
+
+    assert_equal 'hello', mapped[:name]
+    assert_equal 'Hello, GNU world: An example GNU package', mapped[:description]
+    assert_equal 'https://www.gnu.org/software/hello/', mapped[:homepage]
+    assert_equal 'gnu/packages/base.scm:30', mapped[:metadata][:location]
+    assert_equal 'hello', mapped[:metadata][:variable_name]
+    assert_equal 'gpl3+', mapped[:licenses]
+  end
+
+  test 'map_package_metadata returns false for blank entries' do
+    assert_equal false, @ecosystem.map_package_metadata(nil)
+    assert_equal false, @ecosystem.map_package_metadata([])
+  end
+
+  test 'map_package_metadata with single entry' do
+    stub_scheme_file_fetch_nil
+
+    entry = {
+      'name' => 'zile',
+      'version' => '2.6.2',
+      'synopsis' => 'Lightweight Emacs clone',
+      'homepage' => 'https://www.gnu.org/software/zile/',
+      'location' => 'gnu/packages/zile.scm:48',
+      'variable_name' => 'zile'
+    }
+
+    mapped = @ecosystem.map_package_metadata(entry, 'zile')
+
+    assert_equal 'zile', mapped[:name]
+    assert_equal 'Lightweight Emacs clone', mapped[:description]
+    assert_nil mapped[:licenses]
+  end
+
+  test 'map_package_metadata includes licenses when scheme file available' do
+    stub_scheme_file_fetch
+
+    entry = {
+      'name' => 'grep',
+      'version' => '3.11',
+      'synopsis' => 'Print lines matching a pattern',
+      'homepage' => 'https://www.gnu.org/software/grep/',
+      'location' => 'gnu/packages/base.scm:55',
+      'variable_name' => 'grep'
+    }
+
+    mapped = @ecosystem.map_package_metadata(entry, 'grep')
+
+    assert_equal 'gpl3+', mapped[:licenses]
+  end
+
+  test 'map_package_metadata includes multiple licenses' do
+    stub_scheme_file_fetch
+
+    entry = {
+      'name' => 'dual-licensed-example',
+      'version' => '1.0',
+      'synopsis' => 'Example package with dual license',
+      'homepage' => 'https://example.org',
+      'location' => 'gnu/packages/base.scm:72',
+      'variable_name' => 'dual-licensed-example'
+    }
+
+    mapped = @ecosystem.map_package_metadata(entry, 'dual-licensed-example')
+
+    assert_equal 'expat, asl2.0', mapped[:licenses]
+  end
+
+  test 'versions_metadata returns all versions' do
+    stub_packages_cache({
+      'hello' => [
+        {
+          'name' => 'hello',
+          'version' => '2.12.1',
+          'variable_name' => 'hello',
+          'source' => [{ 'integrity' => 'sha256-jZkUKv2SV28wsM18tCqNxoCZmLnighAfahT6AFlSML0=' }]
+        },
+        {
+          'name' => 'hello',
+          'version' => '2.10',
+          'variable_name' => 'hello-2.10',
+          'source' => [{ 'integrity' => 'sha256-MeBmE3qWJnbon2nRtlOC3pWn732RS4y5VvQepy4PUWo=' }]
+        }
+      ]
+    })
+
+    versions = @ecosystem.versions_metadata({ name: 'hello' })
+
+    assert_equal 2, versions.length
+    version_numbers = versions.map { |v| v[:number] }
+    assert_includes version_numbers, '2.12.1'
+    assert_includes version_numbers, '2.10'
+
+    v1 = versions.find { |v| v[:number] == '2.12.1' }
+    assert_equal 'sha256-jZkUKv2SV28wsM18tCqNxoCZmLnighAfahT6AFlSML0=', v1[:integrity]
+    assert_equal 'hello', v1[:metadata][:variable_name]
+  end
+
+  test 'versions_metadata returns empty when package not found' do
+    stub_packages_cache({})
+
+    versions = @ecosystem.versions_metadata({ name: 'nonexistent' })
+    assert_equal [], versions
+  end
+
+  test 'versions_metadata handles missing source' do
+    stub_packages_cache({
+      'hello' => [
+        { 'name' => 'hello', 'version' => '2.12.1', 'variable_name' => 'hello' }
+      ]
+    })
+
+    versions = @ecosystem.versions_metadata({ name: 'hello' })
+    assert_equal 1, versions.length
+    assert_nil versions[0][:integrity]
+  end
+
+  test 'maintainers_metadata returns empty' do
+    assert_equal [], @ecosystem.maintainers_metadata('hello')
+  end
+
+  test 'dependencies_metadata returns empty when package not found' do
+    stub_packages_cache({})
+
+    assert_equal [], @ecosystem.dependencies_metadata('hello', '2.12.1', nil)
+  end
+
+  test 'dependencies_metadata returns empty when no location' do
+    stub_packages_cache({
+      'hello' => [{ 'name' => 'hello', 'version' => '2.12.1' }]
+    })
+
+    assert_equal [], @ecosystem.dependencies_metadata('hello', '2.12.1', nil)
+  end
+
+  test 'dependencies_metadata returns empty when scheme file fetch fails' do
+    stub_packages_cache({
+      'hello' => [{ 'name' => 'hello', 'version' => '2.12.1', 'location' => 'gnu/packages/base.scm:30' }]
+    })
+    stub_scheme_file_fetch_nil
+
+    assert_equal [], @ecosystem.dependencies_metadata('hello', '2.12.1', nil)
+  end
+
+  test 'dependencies_metadata extracts deps from scheme file' do
+    stub_packages_cache({
+      'grep' => [{ 'name' => 'grep', 'version' => '3.11', 'location' => 'gnu/packages/base.scm:55' }]
+    })
+    stub_scheme_file_fetch
+
+    deps = @ecosystem.dependencies_metadata('grep', '3.11', nil)
+
+    assert deps.any? { |d| d[:package_name] == 'pcre2' && d[:kind] == 'runtime' }
+    assert deps.any? { |d| d[:package_name] == 'perl' && d[:kind] == 'build' }
+    assert_equal 'guix', deps.first[:ecosystem]
+    assert_equal '*', deps.first[:requirements]
+  end
+
+  test 'dependencies_metadata extracts propagated-inputs as runtime' do
+    stub_packages_cache({
+      'dual-licensed-example' => [{ 'name' => 'dual-licensed-example', 'version' => '1.0', 'location' => 'gnu/packages/base.scm:72' }]
+    })
+    stub_scheme_file_fetch
+
+    deps = @ecosystem.dependencies_metadata('dual-licensed-example', '1.0', nil)
+
+    # inputs -> runtime
+    assert deps.any? { |d| d[:package_name] == 'glib' && d[:kind] == 'runtime' }
+    assert deps.any? { |d| d[:package_name] == 'zlib' && d[:kind] == 'runtime' }
+
+    # propagated-inputs -> runtime
+    assert deps.any? { |d| d[:package_name] == 'libxml2' && d[:kind] == 'runtime' }
+
+    # native-inputs -> build
+    assert deps.any? { |d| d[:package_name] == 'pkg-config' && d[:kind] == 'build' }
+  end
+
+  test 'recently_updated_package_names parses atom feed' do
+    atom_xml = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <title>gnu: hello: Update to 2.12.1.</title>
+        </entry>
+        <entry>
+          <title>gnu: guile: Update to 3.0.10.</title>
+        </entry>
+        <entry>
+          <title>Merge branch 'staging'</title>
+        </entry>
+      </feed>
+    XML
+
+    stub_request(:get, "https://git.savannah.gnu.org/cgit/guix.git/atom/?h=master")
+      .to_return(status: 200, body: atom_xml, headers: { 'Content-Type' => 'application/atom+xml' })
+
+    names = @ecosystem.recently_updated_package_names
+    assert_includes names, 'gnu'
+    assert_equal 1, names.count('gnu')
+  end
+
+  test 'recently_updated_package_names returns empty on error' do
+    stub_request(:get, "https://git.savannah.gnu.org/cgit/guix.git/atom/?h=master")
+      .to_return(status: 500, body: '')
+
+    names = @ecosystem.recently_updated_package_names
+    assert_equal [], names
+  end
+
+  test 'load_packages_json handles nil response' do
+    stub_request(:get, "https://guix.gnu.org/packages.json")
+      .to_return(status: 200, body: 'null', headers: { 'Content-Type' => 'application/json' })
+
+    result = @ecosystem.load_packages_json
+    assert_equal({}, result)
+  end
+
+  test 'load_packages_json handles non-array response' do
+    stub_request(:get, "https://guix.gnu.org/packages.json")
+      .to_return(status: 200, body: '{"foo":"bar"}', headers: { 'Content-Type' => 'application/json' })
+
+    result = @ecosystem.load_packages_json
+    assert_equal({}, result)
+  end
+
+  test 'load_packages_json skips entries without name' do
+    json = '[{"version":"1.0","synopsis":"No name"},{"name":"hello","version":"2.12.1"}]'
+    stub_request(:get, "https://guix.gnu.org/packages.json")
+      .to_return(status: 200, body: json, headers: { 'Content-Type' => 'application/json' })
+
+    result = @ecosystem.load_packages_json
+    assert_equal 1, result.keys.length
+    assert_equal ['hello'], result.keys
+  end
+
+  # Scheme parsing tests
+
+  test 'strip_scheme_comments removes line comments' do
+    content = <<~SCM
+      (package
+        (name "hello") ; this is a comment
+        ;; full line comment
+        (version "1.0"))
+    SCM
+
+    stripped = @ecosystem.strip_scheme_comments(content)
+    refute_includes stripped, 'this is a comment'
+    refute_includes stripped, 'full line comment'
+    assert_includes stripped, '(name "hello")'
+    assert_includes stripped, '(version "1.0")'
+  end
+
+  test 'strip_scheme_comments handles blank input' do
+    assert_equal '', @ecosystem.strip_scheme_comments(nil)
+    assert_equal '', @ecosystem.strip_scheme_comments('')
+  end
+
+  test 'find_package_block extracts correct block from fixture' do
+    # hello starts at line 28 in fixture (define-public hello)
+    block = @ecosystem.find_package_block(scheme_fixture, 30)
+
+    assert_includes block, '(define-public hello'
+    assert_includes block, '(license license:gpl3+)'
+    refute_includes block, '(define-public grep'
+  end
+
+  test 'find_package_block extracts grep block' do
+    block = @ecosystem.find_package_block(scheme_fixture, 55)
+
+    assert_includes block, '(define-public grep'
+    assert_includes block, '(native-inputs (list perl))'
+    assert_includes block, '(inputs (list pcre2))'
+    refute_includes block, '(define-public hello'
+  end
+
+  test 'find_package_block returns nil for invalid line number' do
+    assert_nil @ecosystem.find_package_block(scheme_fixture, 0)
+    assert_nil @ecosystem.find_package_block(scheme_fixture, 99999)
+  end
+
+  test 'find_package_block returns nil when no define-public found' do
+    content = "(let ((x 1)) x)\n" * 5
+    assert_nil @ecosystem.find_package_block(content, 3)
+  end
+
+  test 'parse_guix_license with single qualified license' do
+    block = '(define-public hello (package (name "hello") (license license:gpl3+)))'
+    assert_equal 'gpl3+', @ecosystem.parse_guix_license(block)
+  end
+
+  test 'parse_guix_license with single unqualified license' do
+    block = '(define-public hello (package (name "hello") (license gpl3+)))'
+    assert_equal 'gpl3+', @ecosystem.parse_guix_license(block)
+  end
+
+  test 'parse_guix_license with multiple licenses' do
+    block = '(define-public hello (package (name "hello") (license (list license:expat license:asl2.0))))'
+    assert_equal 'expat, asl2.0', @ecosystem.parse_guix_license(block)
+  end
+
+  test 'parse_guix_license returns nil when no license' do
+    block = '(define-public hello (package (name "hello")))'
+    assert_nil @ecosystem.parse_guix_license(block)
+  end
+
+  test 'parse_guix_license returns nil for blank input' do
+    assert_nil @ecosystem.parse_guix_license(nil)
+    assert_nil @ecosystem.parse_guix_license('')
+  end
+
+  test 'parse_guix_license ignores comments containing license' do
+    block = <<~SCM
+      (define-public hello
+        (package
+          (name "hello")
+          ; (license gpl2)
+          (license license:expat)))
+    SCM
+    assert_equal 'expat', @ecosystem.parse_guix_license(block)
+  end
+
+  test 'parse_guix_dependencies extracts inputs' do
+    block = <<~SCM
+      (define-public grep
+        (package
+          (name "grep")
+          (native-inputs (list perl))
+          (inputs (list pcre2))
+          (license gpl3+)))
+    SCM
+
+    deps = @ecosystem.parse_guix_dependencies(block)
+
+    assert deps.any? { |d| d[:package_name] == 'pcre2' && d[:kind] == 'runtime' }
+    assert deps.any? { |d| d[:package_name] == 'perl' && d[:kind] == 'build' }
+    assert_equal 2, deps.length
+  end
+
+  test 'parse_guix_dependencies extracts propagated-inputs as runtime' do
+    block = <<~SCM
+      (define-public example
+        (package
+          (name "example")
+          (propagated-inputs (list libxml2 glib))
+          (license expat)))
+    SCM
+
+    deps = @ecosystem.parse_guix_dependencies(block)
+
+    assert deps.all? { |d| d[:kind] == 'runtime' }
+    assert deps.any? { |d| d[:package_name] == 'libxml2' }
+    assert deps.any? { |d| d[:package_name] == 'glib' }
+  end
+
+  test 'parse_guix_dependencies returns empty for no inputs' do
+    block = <<~SCM
+      (define-public hello
+        (package
+          (name "hello")
+          (license gpl3+)))
+    SCM
+
+    assert_equal [], @ecosystem.parse_guix_dependencies(block)
+  end
+
+  test 'parse_guix_dependencies returns empty for blank input' do
+    assert_equal [], @ecosystem.parse_guix_dependencies(nil)
+    assert_equal [], @ecosystem.parse_guix_dependencies('')
+  end
+
+  test 'parse_guix_dependencies filters builtins' do
+    block = <<~SCM
+      (define-public example
+        (package
+          (name "example")
+          (inputs (list glib))
+          (license expat)))
+    SCM
+
+    deps = @ecosystem.parse_guix_dependencies(block)
+    dep_names = deps.map { |d| d[:package_name] }
+
+    refute_includes dep_names, 'list'
+    assert_includes dep_names, 'glib'
+  end
+
+  test 'extract_scheme_list extracts identifiers from list form' do
+    content = '(inputs (list pcre2 zlib glib))'
+    names = @ecosystem.extract_scheme_list(content, 'inputs')
+
+    assert_includes names, 'pcre2'
+    assert_includes names, 'zlib'
+    assert_includes names, 'glib'
+  end
+
+  test 'extract_scheme_list handles multiline list' do
+    content = <<~SCM
+      (inputs
+        (list pcre2
+              zlib
+              glib))
+    SCM
+
+    names = @ecosystem.extract_scheme_list(content, 'inputs')
+    assert_includes names, 'pcre2'
+    assert_includes names, 'zlib'
+    assert_includes names, 'glib'
+  end
+
+  test 'extract_scheme_list returns empty when attr not found' do
+    content = '(native-inputs (list perl))'
+    names = @ecosystem.extract_scheme_list(content, 'inputs')
+    assert_equal [], names
+  end
+
+  test 'extract_scheme_list returns empty for empty list' do
+    content = '(inputs (list))'
+    names = @ecosystem.extract_scheme_list(content, 'inputs')
+    assert_equal [], names
+  end
+
+  test 'guix_builtin? identifies builtins' do
+    assert @ecosystem.guix_builtin?('list')
+    assert @ecosystem.guix_builtin?('modify-inputs')
+    assert @ecosystem.guix_builtin?('append')
+    assert @ecosystem.guix_builtin?('replace')
+    assert @ecosystem.guix_builtin?('delete')
+
+    refute @ecosystem.guix_builtin?('glib')
+    refute @ecosystem.guix_builtin?('pcre2')
+    refute @ecosystem.guix_builtin?('perl')
+  end
+
+  test 'fetch_scheme_file constructs correct url' do
+    stub_request(:get, "https://raw.githubusercontent.com/Millak/guix/master/gnu/packages/base.scm")
+      .to_return(status: 200, body: '(define-public hello ...)')
+
+    result = @ecosystem.fetch_scheme_file('gnu/packages/base.scm:92')
+    assert_equal '(define-public hello ...)', result
+  end
+
+  test 'fetch_scheme_file returns nil on error' do
+    stub_request(:get, "https://raw.githubusercontent.com/Millak/guix/master/gnu/packages/base.scm")
+      .to_return(status: 404, body: '')
+
+    result = @ecosystem.fetch_scheme_file('gnu/packages/base.scm:92')
+    assert_nil result
+  end
+end


### PR DESCRIPTION
GNU Guix is a functional package manager similar to Nix. This adds support for syncing its ~31k packages from guix.gnu.org/packages.json.

- New `Ecosystem::Guix` class that downloads the flat JSON array and indexes it by package name, grouping multiple versions of the same package
- Tracks recently updated packages via the Savannah git atom feed
- Links to Savannah cgit for source file documentation URLs
- Uses "guix" as the PURL type
- No license or dependency parsing (would require parsing Scheme source files, out of scope for now)