### PR TITLE
Redesign views with card-based layout and breadcrumbs

### DIFF
--- a/app/views/ecosystems/index.html.erb
+++ b/app/views/ecosystems/index.html.erb
@@ -1,14 +1,15 @@
-<% @meta_title = "#{params[:id]} registries" %>
-<% @meta_description = "A list of package registries within the #{params[:id]} ecosystem, offering access to essential tools and libraries." %>
+<% @meta_title = "Ecosystems" %>
+<% @meta_description = "Browse all package ecosystems and their registries." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
-    <%= params[:id]%> registries
-  </h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item active" aria-current="page">Ecosystems</li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    A list of package registries within the <%= params[:id] %> ecosystem, offering access to essential tools and libraries.
-  </p>
+  <h1 class="h4 mb-3">Ecosystems</h1>
 
   <%= render @registries %>
 </div>

--- a/app/views/ecosystems/show.html.erb
+++ b/app/views/ecosystems/show.html.erb
@@ -1,17 +1,28 @@
 <% @meta_title = "#{params[:id]} registries" %>
-<% @meta_description = "A list of package registries within the #{params[:id]} ecosystem, offering access to essential tools and libraries." %>
+<% @meta_description = "A list of package registries within the #{params[:id]} ecosystem." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
-    <%= params[:id]%> registries
-  </h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to "Ecosystems", ecosystems_path %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= params[:id] %></li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    A list of package registries within the <%= params[:id] %> ecosystem, offering access to essential tools and libraries.
-  </p>
+  <h1 class="h4 mb-3"><%= params[:id] %> registries</h1>
 
-  <h4 class='mb-3'>Total packages indexed: <%= number_with_delimiter @registries.sum(&:packages_count) %></h4>
-  
+  <div class="row mb-3">
+    <div class="col-md-4 col-6">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-primary mb-1"><%= number_with_delimiter @registries.sum(&:packages_count) %></h4>
+          <p class="card-text small text-muted mb-0">Total Packages</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class='row'>
     <%= render @registries %>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,46 +1,83 @@
-
 <div class="container-sm">
-  <div class="card mb-3">
-    <div class="card-header">
-      Statistics
+  <div class="row mb-4">
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-primary mb-1"><%= number_with_delimiter @registries.length %></h4>
+          <p class="card-text small text-muted mb-0">Registries</p>
+        </div>
+      </div>
     </div>
-    <div class="card-body">
-      <div class="row">
-        <div class='col-md-3'>
-          Registries: <%= number_with_delimiter @registries.length %><br/>
-          Ecosystems: <%= number_with_delimiter @registries.map(&:ecosystem).uniq.length %><br/>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-success mb-1"><%= number_with_delimiter @registries.map(&:ecosystem).uniq.length %></h4>
+          <p class="card-text small text-muted mb-0">Ecosystems</p>
         </div>
-        <div class='col-md-3'>
-          Packages: <%= number_with_delimiter @registries.sum(&:packages_count) %><br/>
-          Versions: <%= number_with_delimiter @registries.sum{|r| r.versions_count.to_i } %><br/>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-warning mb-1"><%= number_with_delimiter @registries.sum(&:packages_count) %></h4>
+          <p class="card-text small text-muted mb-0">Packages</p>
         </div>
-        <div class='col-md-3'>
-          Maintainers: <%= number_with_delimiter @registries.sum(&:maintainers_count) %><br/>
-          Downloads: <%= number_with_delimiter @registries.sum(&:downloads) %><br/>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-info mb-1"><%= number_with_delimiter @registries.sum{ |r| r.versions_count.to_i } %></h4>
+          <p class="card-text small text-muted mb-0">Versions</p>
         </div>
-        <div class='col-md-3'>  
-          Namespaces: <%= number_with_delimiter @registries.sum(&:namespaces_count) %><br/>
-          Keywords: <%= number_with_delimiter @registries.sum(&:keywords_count) %><br/>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-secondary mb-1"><%= number_with_delimiter @registries.sum(&:maintainers_count) %></h4>
+          <p class="card-text small text-muted mb-0">Maintainers</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-dark mb-1"><%= number_with_delimiter @registries.sum(&:downloads) %></h4>
+          <p class="card-text small text-muted mb-0">Downloads</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-primary mb-1"><%= number_with_delimiter @registries.sum(&:namespaces_count) %></h4>
+          <p class="card-text small text-muted mb-0">Namespaces</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-success mb-1"><%= number_with_delimiter @registries.sum(&:keywords_count) %></h4>
+          <p class="card-text small text-muted mb-0">Keywords</p>
         </div>
       </div>
     </div>
   </div>
 
   <div class='row'>
-
     <% @registries.group_by(&:github).each do |ecosystem, registries| %>
-      <% if registries.length > 1 && registries.all?{|r| r.version.present? } %>
+      <% if registries.length > 1 && registries.all?{ |r| r.version.present? } %>
         <% registry = registries.first %>
         <div class='col-lg-4'>
           <div class="card mb-3 registry d-flex" id="registry_<%= registry.id %>">
             <div class="card-body pb-1">
               <div class="d-flex">
-
                 <div class="flex-grow-1 ms-3 text-break">
                   <h5 class='card-title'>
                     <%= link_to ecosystem, ecosystem_path(registry.ecosystem) %>
                   </h5>
-
                   <p class="card-subtitle mb-2 text-muted">
                     <% registries.first(5).each do |reg| %>
                       <%= link_to reg.version, registry_packages_path(reg.name) %>: <%= number_with_delimiter reg.packages_count %> packages <br/>
@@ -52,7 +89,7 @@
                 </div>
                 <div class="flex-shrink-0">
                   <img src="<%= registry.icon_url %>" class="rounded" height='40' width='40' onerror="this.style.display='none'">
-                </div>  
+                </div>
               </div>
             </div>
           </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,14 +1,15 @@
 <% @meta_title = "Keywords" %>
-<% @meta_description = "Explore a comprehensive list of all keywords used to categorize and discover packages within the ecosystem." %>
+<% @meta_description = "Explore keywords used to categorize and discover packages across all registries." %>
 
 <div class="container-sm">
-  <h2>
-    Keywords
-  </h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item active" aria-current="page">Keywords</li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    Explore a comprehensive list of all keywords used to categorize and discover packages within the ecosystem.
-  </p>
+  <h1 class="h4 mb-3">Keywords</h1>
 
   <div class="row">
     <% @keywords.each do |keyword, count| %>
@@ -27,5 +28,5 @@
       </div>
     <% end %>
   </div>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/keywords/show.html.erb
+++ b/app/views/keywords/show.html.erb
@@ -2,37 +2,36 @@
 <% @meta_description = "Browse packages tagged with the keyword '#{@keyword}' featuring tools and libraries." %>
 
 <div class="container-sm">
-  <h2>
-    "<%= @keyword %>"
-    keyword
-  </h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to "Keywords", keywords_path %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= @keyword %></li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    Browse packages tagged with the keyword "<%= @keyword %>" featuring tools and libraries.
-  </p>
+  <h1 class="h4 mb-3">"<%= @keyword %>" keyword</h1>
 
   <div class='row'>
-    <div class='col-md-8'>
+    <div class='col-lg-8'>
       <%= render @packages %>
-      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-    </div>  
-    <div class='col-md-4'>
+      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+    </div>
+    <div class='col-lg-4'>
       <div class="card">
         <div class="card-header">
-          Related Keywords
+          <h6 class="mb-0">Related Keywords</h6>
         </div>
         <div class="list-group list-group-flush">
           <% @related_keywords.each do |keyword, count| %>
             <% next if keyword.blank? %>
             <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="<%= keyword_path(keyword) %>">
               <%= keyword %>
-              <span class="badge bg-primary rounded-pill"><%= number_with_delimiter count%></span>
+              <span class="badge bg-primary rounded-pill"><%= number_with_delimiter count %></span>
             </a>
           <% end %>
-        </ul>
+        </div>
       </div>
-
-
     </div>
   </div>
 </div>

--- a/app/views/maintainers/_maintainer_tabs.html.erb
+++ b/app/views/maintainers/_maintainer_tabs.html.erb
@@ -1,0 +1,32 @@
+<ul class="nav nav-tabs mb-3">
+  <li class="nav-item">
+    <% if action_name == 'show' %>
+      <a class="nav-link active" aria-current="page">
+    <% else %>
+      <a class="nav-link" href="<%= registry_maintainer_path(@registry, @maintainer) %>">
+    <% end %>
+      Packages
+      <span class="badge bg-secondary rounded-pill">
+        <%= number_with_delimiter @maintainer.packages_count %>
+      </span>
+    </a>
+  </li>
+  <% namespaces_count = @maintainer.namespaces.length %>
+  <% if namespaces_count > 0 %>
+    <li class="nav-item">
+      <% if action_name == 'namespaces' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= namespaces_registry_maintainer_path(@registry, @maintainer) %>">
+      <% end %>
+        Namespaces
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter namespaces_count %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <% if action_name == 'show' %>
+    <%= render 'packages/sort' %>
+  <% end %>
+</ul>

--- a/app/views/maintainers/index.html.erb
+++ b/app/views/maintainers/index.html.erb
@@ -2,56 +2,20 @@
 <% @meta_description = "View the maintainers of the #{@registry} package registry, including their contact information and contributions." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Maintainers</li>
+    </ol>
+  </nav>
+
+  <h1 class='h4 mb-3'>
     <%= @registry %> maintainers
   </h1>
 
-  <p class='lead'>
-    View the maintainers of the <%= @registry %> package registry, including their contact information and contributions.
-  </p>
-
-    <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_packages_path(@registry) %>">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @registry.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% if @registry.maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_namespaces_path(@registry) %>">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.keywords_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= keywords_registry_path(@registry) %>">
-          Keywords
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.keywords_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <%= render 'sort' %>
-  </ul>
+  <%= render 'registries/tabs' %>
 
   <%= render @maintainers %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/maintainers/namespaces.html.erb
+++ b/app/views/maintainers/namespaces.html.erb
@@ -2,41 +2,20 @@
 <% @meta_description = "View the namespaces maintained by #{@maintainer} on the #{@registry} package registry, including their packages and contributions." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
-    <%= link_to @registry.name, registry_maintainers_path %> maintainers:
-    <% if @maintainer.html_url.present? %>
-      <%= link_to @maintainer, @maintainer.html_url, target: :_blank %>
-    <% else%>
-      <%= @maintainer %>
-    <% end %>
-  </h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to "Maintainers", registry_maintainers_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to @maintainer.to_s, registry_maintainer_path(@registry, @maintainer) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Namespaces</li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the namespaces maintained by <%= @maintainer %> on the <%= @registry %> package registry, including their packages and contributions.
-  </p>
+  <h1 class="h4 mb-3"><%= @maintainer %> namespaces</h1>
 
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_maintainer_path(@registry, @maintainer) %>">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @maintainer.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% namespaces_count = @maintainer.namespaces.length %>
-    <% if namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'maintainer_tabs' %>
 
   <%= render collection: @namespaces, partial: 'namespaces/namespace' %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/maintainers/show.html.erb
+++ b/app/views/maintainers/show.html.erb
@@ -2,42 +2,121 @@
 <% @meta_description = "View the packages maintained by #{@maintainer} on the #{@registry} package registry, including their contributions and dependencies." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
-    <%= link_to @registry.name, registry_maintainers_path %> maintainers:
-    <% if @maintainer.html_url.present? %>
-      <%= link_to @maintainer, @maintainer.html_url, target: :_blank %>
-    <% else%>
-      <%= @maintainer %>
-    <% end %>
-  </h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to "Maintainers", registry_maintainers_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= @maintainer %></li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the packages maintained by <%= @maintainer %> on the <%= @registry %> package registry, including their contributions and dependencies.
-  </p>
-
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
+  <div class="card mb-4">
+    <div class="card-header">
+      <h1 class="h4 mb-0">
+        <% if @maintainer.html_url.present? %>
+          <%= link_to @maintainer, @maintainer.html_url, target: :_blank, class: 'text-decoration-none' %>
+        <% else %>
+          <%= @maintainer %>
+        <% end %>
+      </h1>
+    </div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col-md-4 mb-2">
+          <strong>Registry</strong><br>
+          <%= link_to @registry.name, registry_packages_path(@registry) %>
+        </div>
+        <div class="col-md-4 mb-2">
+          <strong>Packages</strong><br>
           <%= number_with_delimiter @maintainer.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% namespaces_count = @maintainer.namespaces.length %>
-    <% if namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= namespaces_registry_maintainer_path(@registry, @maintainer) %>">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <%= render 'packages/sort' %>
-  </ul>
+        </div>
+        <% if @maintainer.total_downloads && @maintainer.total_downloads > 0 %>
+          <div class="col-md-4 mb-2">
+            <strong>Total Downloads</strong><br>
+            <%= number_with_delimiter @maintainer.total_downloads %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 
-  <%= render @packages %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'maintainer_tabs' %>
+
+      <%= render @packages %>
+      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+    </div>
+
+    <div class="col-lg-4">
+      <div class="card mb-4">
+        <div class="card-header">
+          <h6 class="mb-0">Details</h6>
+        </div>
+        <div class="card-body">
+          <table class="table table-sm mb-0">
+            <% if @maintainer.login.present? %>
+              <tr>
+                <td><strong>Login</strong></td>
+                <td><%= @maintainer.login %></td>
+              </tr>
+            <% end %>
+            <% if @maintainer.name.present? && @maintainer.name != @maintainer.login %>
+              <tr>
+                <td><strong>Name</strong></td>
+                <td><%= @maintainer.name %></td>
+              </tr>
+            <% end %>
+            <% if @maintainer.email.present? %>
+              <tr>
+                <td><strong>Email</strong></td>
+                <td><%= @maintainer.email %></td>
+              </tr>
+            <% end %>
+            <% if @maintainer.url.present? %>
+              <tr>
+                <td><strong>URL</strong></td>
+                <td><%= link_to @maintainer.url, @maintainer.url, target: :_blank %></td>
+              </tr>
+            <% end %>
+            <% if @maintainer.html_url.present? %>
+              <tr>
+                <td><strong>Profile</strong></td>
+                <td><%= link_to 'View on ' + @registry.name, @maintainer.html_url, target: :_blank %></td>
+              </tr>
+            <% end %>
+            <% if @maintainer.organization? %>
+              <tr>
+                <td><strong>Type</strong></td>
+                <td>Organization</td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+      </div>
+
+      <% namespaces = @maintainer.namespaces %>
+      <% if namespaces.any? %>
+        <div class="card mb-4">
+          <div class="card-header">
+            <h6 class="mb-0">Namespaces</h6>
+          </div>
+          <div class="list-group list-group-flush">
+            <% namespaces.first(10).each do |namespace, count| %>
+              <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="<%= registry_namespace_path(@registry.name, namespace) %>">
+                <%= namespace %>
+                <span class="badge bg-primary rounded-pill"><%= count %></span>
+              </a>
+            <% end %>
+            <% if namespaces.length > 10 %>
+              <a class="list-group-item list-group-item-action text-center text-muted" href="<%= namespaces_registry_maintainer_path(@registry, @maintainer) %>">
+                View all <%= namespaces.length %> namespaces
+              </a>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/namespaces/_namespace_tabs.html.erb
+++ b/app/views/namespaces/_namespace_tabs.html.erb
@@ -1,0 +1,34 @@
+<ul class="nav nav-tabs mb-3">
+  <li class="nav-item">
+    <% if action_name == 'show' %>
+      <a class="nav-link active" aria-current="page">
+    <% else %>
+      <a class="nav-link" href="<%= registry_namespace_path(@registry, @namespace) %>">
+    <% end %>
+      Packages
+      <% if action_name == 'show' || action_name == 'maintainers' %>
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter @registry.packages.namespace(@namespace).count %>
+        </span>
+      <% end %>
+    </a>
+  </li>
+  <% maintainers_count = @registry.namespace_maintainers(@namespace).length %>
+  <% if maintainers_count > 0 %>
+    <li class="nav-item">
+      <% if action_name == 'maintainers' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= maintainers_registry_namespace_path(@registry, @namespace) %>">
+      <% end %>
+        Maintainers
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter maintainers_count %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <% if action_name == 'show' %>
+    <%= render 'packages/sort' %>
+  <% end %>
+</ul>

--- a/app/views/namespaces/index.html.erb
+++ b/app/views/namespaces/index.html.erb
@@ -2,55 +2,20 @@
 <% @meta_description = "View the namespaces on the #{@registry} package registry, including their packages and maintainers." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Namespaces</li>
+    </ol>
+  </nav>
+
+  <h1 class='h4 mb-3'>
     <%= @registry %> namespaces
   </h1>
 
-  <p class='lead'>
-    View the namespaces on the <%= @registry %> package registry, including their packages and maintainers.
-  </p>
-
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_packages_path(@registry) %>">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @registry.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% if @registry.maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_maintainers_path(@registry) %>">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.keywords_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= keywords_registry_path(@registry) %>">
-          Keywords
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.keywords_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'registries/tabs' %>
 
   <%= render collection: @namespaces, partial: 'namespace' %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/namespaces/maintainers.html.erb
+++ b/app/views/namespaces/maintainers.html.erb
@@ -2,36 +2,20 @@
 <% @meta_description = "View the maintainers of the #{@namespace} namespace on the #{@registry} package registry, including their contact information and contributions." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
-    <%= link_to @registry.name, registry_namespaces_path %> namespaces: <%= @namespace %>
-  </h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to "Namespaces", registry_namespaces_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to @namespace, registry_namespace_path(@registry, @namespace) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Maintainers</li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the maintainers of the <%= @namespace %> namespace on the <%= @registry %> package registry, including their contact information and contributions.
-  </p>
+  <h1 class="h4 mb-3"><%= @namespace %> maintainers</h1>
 
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_namespace_path(@registry, @namespace) %>">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @registry.packages.namespace(@namespace).count %>
-        </span>
-      </a>
-    </li>
-    <% maintainers_count = @registry.namespace_maintainers(@namespace).length %>
-    <% if maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'namespace_tabs' %>
 
   <%= render @maintainers %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/namespaces/show.html.erb
+++ b/app/views/namespaces/show.html.erb
@@ -2,34 +2,19 @@
 <% @meta_description = "View the packages within the #{@namespace} namespace on the #{@registry} package registry, including their maintainers and dependencies." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>
-    <%= link_to @registry.name, registry_namespaces_path %> namespaces: <%= @namespace %>
-  </h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to "Namespaces", registry_namespaces_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= @namespace %></li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the packages within the <%= @namespace %> namespace on the <%= @registry %> package registry, including their maintainers and dependencies.
-  </p>
+  <h1 class="h4 mb-3"><%= @namespace %></h1>
 
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page">
-        Packages
-      </a>
-    </li>
-    <% maintainers_count = @registry.namespace_maintainers(@namespace).length %>
-    <% if maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= maintainers_registry_namespace_path(@registry, @namespace) %>">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <%= render 'packages/sort' %>
-  </ul>
+  <%= render 'namespace_tabs' %>
 
   <%= render @packages %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/packages/_details.html.erb
+++ b/app/views/packages/_details.html.erb
@@ -1,147 +1,61 @@
-  <% if @package.rankings.present? %>
-    <div class="text-end float-end">
-    <% if @package.rankings.present? && @package.rankings['average'] && @package.rankings['average'] < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.rankings['average'].round(1), 0.1].max %>% on <%= @package.registry %>
-      </span><br>
-    <% end %>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+    <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry.name) %></li>
+    <li class="breadcrumb-item active" aria-current="page"><%= @package.name %></li>
+  </ol>
+</nav>
 
-    <% if @package.downloads && @package.downloads > 0 && @package.rankings.present? && @package.rankings['downloads'] && @package.rankings['downloads'] < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.rankings['downloads'].round(1), 0.1].max %>% downloads on <%= @package.registry %>
-      </span><br>
-    <% end %>
-
-    <% if @package.dependent_packages_count && @package.dependent_packages_count > 0 && @package.rankings.present? && @package.rankings['dependent_packages_count'] && @package.rankings['dependent_packages_count'] < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.rankings['dependent_packages_count'].round(1), 0.1].max %>% dependent packages on <%= @package.registry %>
-      </span><br>
-    <% end %>
-
-    <% if @package.dependent_repos_count && @package.dependent_repos_count > 0 && @package.rankings.present? && @package.rankings['dependent_repos_count'] && @package.rankings['dependent_repos_count'] < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.rankings['dependent_repos_count'].round(1), 0.1].max %>% dependent repos on <%= @package.registry %>
-      </span><br>
-    <% end %>
-
-    <% if @package.rankings.present? && @package.rankings['stars_count'] && @package.stars && @package.stars > 0 && @package.stars < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.stars.round(1), 0.1].max %>% stars on <%= @package.registry %>
-      </span><br>
-    <% end %>
-
-    <% if @package.rankings.present? && @package.rankings['forks_count'] && @package.forks && @package.forks > 0 && @package.rankings['forks_count'] < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.rankings['forks_count'].round(1), 0.1].max %>% forks on <%= @package.registry %>
-      </span><br>
-    <% end %>
-
-    <% if @package.rankings.present? && @package.rankings['docker_downloads_count'] && @package.docker_downloads_count && @package.docker_downloads_count > 0 && @package.rankings['docker_downloads_count'] < 10.05 %>
-      <span class='badge bg-secondary'>
-        Top <%= [@package.rankings['docker_downloads_count'].round(1), 0.1].max %>% docker downloads on <%= @package.registry %>
-      </span><br>
-    <% end %>
-    </div>
-  <%end %>
-
-  <h2>
-    <%= link_to @registry, registry_packages_path(@registry.name) %> : <%= @package.name %>
-  </h2>
-
-  <p>
-    <%= @package.description_with_fallback %>
-  </p>
-
-  <p>
-    <% if @package.registry_url %>
-      <%= link_to 'Registry', @package.registry_url %>
-    <% end %>
-    <% if sanitize_user_url(@package.repository_url).present? && @package.repository_url != @package.registry_url %>
-      <%= '-' if @package.registry_url %>
-      <%= link_to 'Source', sanitize_user_url(@package.repository_url), :rel => 'nofollow' %>
-    <% end %>
-    <% if sanitize_user_url(@package.homepage).present?  && @package.repository_url != @package.homepage %>
-      - <%= link_to('Homepage', sanitize_user_url(@package.homepage), :rel => 'nofollow') %>
-    <% end %>
-    <% if link = @package.documentation_url %>
-      - <%= link_to 'Documentation', link %>
-    <% end %>
-
-    - <%= link_to 'JSON', api_v1_registry_package_url(@registry, @package)%>
-    - <%= link_to 'codemeta.json', codemeta_api_v1_registry_package_url(@registry, @package)%>
-
-    <br>
-    <%= link_to 'purl', 'https://github.com/package-url/purl-spec', target: :_blank %>: <code><%= @package.purl %></code>
-
-    <% if @package.keywords&.reject(&:blank?)&.any? %>
-      <br/> Keywords: <% @package.keywords.reject(&:blank?).uniq.each_with_index do |k, i| %>
-        <% k = k.first if k.is_a?(Array) %>
-        <%= ', ' if i > 0 %><%= link_to k, keyword_registry_path(@registry.name, k.squish) %>
+<div class="card mb-4">
+  <div class="card-header">
+    <h1 class="h4 mb-0">
+      <code><%= @package.name %></code>
+      <% if @package.status && @package.status != 'active' %>
+        <span class="badge bg-warning ms-2 fs-6"><%= @package.status %></span>
       <% end %>
+    </h1>
+  </div>
+  <div class="card-body">
+    <% if @package.description_with_fallback.present? %>
+      <p class="mb-3"><%= @package.description_with_fallback %></p>
     <% end %>
 
-    <% if @package.normalized_licenses %>
-      <br/>License: <%= @package.normalized_licenses.join(',') %>
-    <% end %>
-
-    <% if @package.status %>
-      <br/>Status: <%= @package.status %>
-    <% end %>
-    <% if @package.latest_release_published_at %>
-        <br><span title="<%= @package.latest_release_published_at %>">Latest release: <%= time_ago_in_words @package.latest_release_published_at %> ago</span>
-    <% end %>
-
-    <% if @package.first_release_published_at %>
-        <br><span title="<%= @package.first_release_published_at %>">First release: <%= time_ago_in_words @package.first_release_published_at %> ago</span>
-    <% end %>
-
-    <% if @package.namespace.present? %>  
-      <br/>Namespace: <%= link_to @package.namespace, registry_namespace_path(@registry.name, @package.namespace) %>
-    <% end %>
-
-    <% if @package.dependent_packages_count && @package.dependent_packages_count > 0 %>  
-      <br/>Dependent packages: <%= number_with_delimiter(@package.dependent_packages_count) %>
-    <% end %>
-
-    <% if @package.dependent_repos_count && @package.dependent_repos_count > 0 %>
-      <br/>Dependent repositories: <%= link_to number_with_delimiter(@package.dependent_repos_count), "https://repos.ecosyste.ms/usage/#{@package.ecosystem}/#{@package.name}", target: :_blank %>
-    <% end %>
-    
-
-    <% if @package.downloads && @package.downloads_period %>
-      <br/>Downloads: <%= number_with_delimiter(@package.downloads) %> <%= download_period(@package.downloads_period) %>
-    <% end %>
-
-    <% if @package.stars %>
-      <br/>Stars: <%= number_with_delimiter(@package.stars) %> on <%= @package.repo_metadata.fetch('host',{})['name'] %>
-    <% end %>
-
-    <% if @package.forks %>
-      <br/>Forks: <%= number_with_delimiter(@package.forks) %> on <%= @package.repo_metadata.fetch('host',{})['name'] %>
-    <% end %>
-
-    <% if @package.docker_dependents_count %>
-      <br/>Docker dependents: <%= link_to number_with_delimiter(@package.docker_dependents_count), @package.docker_usage_url, target: :_blank %>
-      <br/>Docker downloads: <%= link_to number_with_delimiter(@package.docker_downloads_count), @package.docker_usage_url, target: :_blank %>
-    <% end %>
-
-    <% if @package.commit_stats.present? %>
-      <br/>Total Commits: <%= @package.commit_stats['total_commits'] %>
-      <br/>Committers: <%= @package.commit_stats['total_committers'] %>
-      <br/>Average commits per author: <%= @package.commit_stats['mean_commits'].to_f.round(3) %>
-      <br/>Development Distribution Score (<a href='https://report.opensustain.tech/chapters/development-distribution-score.html' target="_blank">DDS</a>): <%= @package.commit_stats['dds'].to_f.round(3) %>
-      <br/>More commit stats: <%= link_to 'commits.ecosyste.ms', @package.commits_url, target: :_blank %>
-    <% end %>
-
-    <% if @package.repos_url %>
-      <br/>See more repository details: <%= link_to 'repos.ecosyste.ms', @package.repos_url, target: :_blank %>
-    <% end %>    
-
-    <% if @package.funding_links.any? %>
-      <br/>Funding links: <% @package.funding_links.each_with_index do |url,i| %><%= ', ' if i > 0 %><%= link_to(url, sanitize_user_url(url), target: :_blank) %><% end %>
-    <% end %>
-
-    <% if @package.last_synced_at %>
-      <br/><span title="<%= @package.last_synced_at %>">Last synced: <%= time_ago_in_words @package.last_synced_at %> ago</span>
-    <% end %>
-  </p>
+    <div class="row">
+      <div class="col-md-4 mb-2">
+        <strong>Ecosystem</strong><br>
+        <span class="badge bg-primary fs-6"><%= @registry.name %></span>
+      </div>
+      <% if @package.latest_release_number %>
+        <div class="col-md-4 mb-2">
+          <strong>Latest Release</strong><br>
+          <code><%= @package.latest_release_number %></code>
+          <% if @package.latest_release_published_at %>
+            <br><small class="text-muted" title="<%= @package.latest_release_published_at %>"><%= time_ago_in_words(@package.latest_release_published_at) %> ago</small>
+          <% end %>
+        </div>
+      <% end %>
+      <div class="col-md-4 mb-2">
+        <strong>Versions</strong><br>
+        <%= number_with_delimiter @package.versions_count %>
+      </div>
+      <% if @package.downloads && @package.downloads_period %>
+        <div class="col-md-4 mb-2">
+          <strong>Downloads</strong><br>
+          <%= number_with_delimiter(@package.downloads) %> <%= download_period(@package.downloads_period) %>
+        </div>
+      <% end %>
+      <% if @package.dependent_packages_count && @package.dependent_packages_count > 0 %>
+        <div class="col-md-4 mb-2">
+          <strong>Dependent Packages</strong><br>
+          <%= number_with_delimiter(@package.dependent_packages_count) %>
+        </div>
+      <% end %>
+      <% if @package.dependent_repos_count && @package.dependent_repos_count > 0 %>
+        <div class="col-md-4 mb-2">
+          <strong>Dependent Repos</strong><br>
+          <%= link_to number_with_delimiter(@package.dependent_repos_count), "https://repos.ecosyste.ms/usage/#{@package.ecosystem}/#{@package.name}", target: :_blank %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/packages/_sidebar.html.erb
+++ b/app/views/packages/_sidebar.html.erb
@@ -1,0 +1,197 @@
+<div class="card mb-4">
+  <div class="card-header">
+    <h6 class="mb-0">Links</h6>
+  </div>
+  <div class="card-body">
+    <table class="table table-sm mb-0">
+      <% if @package.registry_url %>
+        <tr>
+          <td><strong>Registry</strong></td>
+          <td><%= link_to @registry.name, @package.registry_url, target: :_blank %></td>
+        </tr>
+      <% end %>
+      <% if sanitize_user_url(@package.repository_url).present? && @package.repository_url != @package.registry_url %>
+        <tr>
+          <td><strong>Source</strong></td>
+          <td><%= link_to 'Repository', sanitize_user_url(@package.repository_url), rel: 'nofollow', target: :_blank %></td>
+        </tr>
+      <% end %>
+      <% if sanitize_user_url(@package.homepage).present? && @package.repository_url != @package.homepage %>
+        <tr>
+          <td><strong>Homepage</strong></td>
+          <td><%= link_to 'Homepage', sanitize_user_url(@package.homepage), rel: 'nofollow', target: :_blank %></td>
+        </tr>
+      <% end %>
+      <% if link = @package.documentation_url %>
+        <tr>
+          <td><strong>Docs</strong></td>
+          <td><%= link_to 'Documentation', link, target: :_blank %></td>
+        </tr>
+      <% end %>
+      <tr>
+        <td><strong>JSON API</strong></td>
+        <td><%= link_to 'View JSON', api_v1_registry_package_url(@registry, @package), target: :_blank %></td>
+      </tr>
+      <tr>
+        <td><strong>CodeMeta</strong></td>
+        <td><%= link_to 'codemeta.json', codemeta_api_v1_registry_package_url(@registry, @package), target: :_blank %></td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h6 class="mb-0">Package Details</h6>
+  </div>
+  <div class="card-body">
+    <table class="table table-sm mb-0">
+      <tr>
+        <td><strong>PURL</strong></td>
+        <td>
+          <code><%= @package.purl %></code>
+          <br><small><%= link_to 'spec', 'https://github.com/package-url/purl-spec', target: :_blank %></small>
+        </td>
+      </tr>
+      <% if @package.normalized_licenses %>
+        <tr>
+          <td><strong>License</strong></td>
+          <td><%= @package.normalized_licenses.join(', ') %></td>
+        </tr>
+      <% end %>
+      <% if @package.namespace.present? %>
+        <tr>
+          <td><strong>Namespace</strong></td>
+          <td><%= link_to @package.namespace, registry_namespace_path(@registry.name, @package.namespace) %></td>
+        </tr>
+      <% end %>
+      <% if @package.first_release_published_at %>
+        <tr>
+          <td><strong>First Release</strong></td>
+          <td><span title="<%= @package.first_release_published_at %>"><%= time_ago_in_words @package.first_release_published_at %> ago</span></td>
+        </tr>
+      <% end %>
+      <% if @package.last_synced_at %>
+        <tr>
+          <td><strong>Last Synced</strong></td>
+          <td><span title="<%= @package.last_synced_at %>"><%= time_ago_in_words @package.last_synced_at %> ago</span></td>
+        </tr>
+      <% end %>
+    </table>
+
+    <% if @package.keywords&.reject(&:blank?)&.any? %>
+      <div class="mt-3">
+        <strong>Keywords</strong><br>
+        <% @package.keywords.reject(&:blank?).uniq.each do |k| %>
+          <% k = k.first if k.is_a?(Array) %>
+          <%= link_to k, keyword_registry_path(@registry.name, k.squish), class: 'badge bg-secondary text-decoration-none me-1 mb-1' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% if @package.stars || @package.forks || (@package.docker_dependents_count && @package.docker_dependents_count > 0) %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h6 class="mb-0">Repository</h6>
+    </div>
+    <div class="card-body">
+      <table class="table table-sm mb-0">
+        <% if @package.stars %>
+          <tr>
+            <td><strong>Stars</strong></td>
+            <td><%= number_with_delimiter(@package.stars) %> on <%= @package.repo_metadata.fetch('host',{})['name'] %></td>
+          </tr>
+        <% end %>
+        <% if @package.forks %>
+          <tr>
+            <td><strong>Forks</strong></td>
+            <td><%= number_with_delimiter(@package.forks) %> on <%= @package.repo_metadata.fetch('host',{})['name'] %></td>
+          </tr>
+        <% end %>
+        <% if @package.docker_dependents_count && @package.docker_dependents_count > 0 %>
+          <tr>
+            <td><strong>Docker Dependents</strong></td>
+            <td><%= link_to number_with_delimiter(@package.docker_dependents_count), @package.docker_usage_url, target: :_blank %></td>
+          </tr>
+          <tr>
+            <td><strong>Docker Downloads</strong></td>
+            <td><%= link_to number_with_delimiter(@package.docker_downloads_count), @package.docker_usage_url, target: :_blank %></td>
+          </tr>
+        <% end %>
+        <% if @package.commit_stats.present? %>
+          <tr>
+            <td><strong>Commits</strong></td>
+            <td><%= @package.commit_stats['total_commits'] %></td>
+          </tr>
+          <tr>
+            <td><strong>Committers</strong></td>
+            <td><%= @package.commit_stats['total_committers'] %></td>
+          </tr>
+          <tr>
+            <td><strong>Avg per Author</strong></td>
+            <td><%= @package.commit_stats['mean_commits'].to_f.round(3) %></td>
+          </tr>
+          <tr>
+            <td><strong><%= link_to 'DDS', 'https://report.opensustain.tech/chapters/development-distribution-score.html', target: "_blank" %></strong></td>
+            <td><%= @package.commit_stats['dds'].to_f.round(3) %></td>
+          </tr>
+        <% end %>
+      </table>
+      <% if @package.commit_stats.present? %>
+        <div class="mt-2">
+          <%= link_to 'commits.ecosyste.ms', @package.commits_url, target: :_blank, class: 'small' %>
+        </div>
+      <% end %>
+      <% if @package.repos_url %>
+        <div class="mt-2">
+          <%= link_to 'repos.ecosyste.ms', @package.repos_url, target: :_blank, class: 'btn btn-outline-secondary btn-sm w-100' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @package.rankings.present? %>
+  <%
+    ranking_items = []
+    ranking_items << { label: "Overall", value: [@package.rankings['average'].round(1), 0.1].max } if @package.rankings['average'] && @package.rankings['average'] < 10.05
+    ranking_items << { label: "Downloads", value: [@package.rankings['downloads'].round(1), 0.1].max } if @package.downloads && @package.downloads > 0 && @package.rankings['downloads'] && @package.rankings['downloads'] < 10.05
+    ranking_items << { label: "Dependent packages", value: [@package.rankings['dependent_packages_count'].round(1), 0.1].max } if @package.dependent_packages_count && @package.dependent_packages_count > 0 && @package.rankings['dependent_packages_count'] && @package.rankings['dependent_packages_count'] < 10.05
+    ranking_items << { label: "Dependent repos", value: [@package.rankings['dependent_repos_count'].round(1), 0.1].max } if @package.dependent_repos_count && @package.dependent_repos_count > 0 && @package.rankings['dependent_repos_count'] && @package.rankings['dependent_repos_count'] < 10.05
+    ranking_items << { label: "Stars", value: [@package.rankings['stars_count'].round(1), 0.1].max } if @package.rankings['stars_count'] && @package.stars && @package.stars > 0 && @package.rankings['stars_count'] < 10.05
+    ranking_items << { label: "Forks", value: [@package.rankings['forks_count'].round(1), 0.1].max } if @package.rankings['forks_count'] && @package.forks && @package.forks > 0 && @package.rankings['forks_count'] < 10.05
+    ranking_items << { label: "Docker downloads", value: [@package.rankings['docker_downloads_count'].round(1), 0.1].max } if @package.rankings['docker_downloads_count'] && @package.docker_downloads_count && @package.docker_downloads_count > 0 && @package.rankings['docker_downloads_count'] < 10.05
+  %>
+  <% if ranking_items.any? %>
+    <div class="card mb-4">
+      <div class="card-header">
+        <h6 class="mb-0">Rankings on <%= @package.registry %></h6>
+      </div>
+      <div class="card-body">
+        <% ranking_items.each do |item| %>
+          <div class="d-flex justify-content-between align-items-center mb-1">
+            <span><%= item[:label] %></span>
+            <span class="badge bg-secondary">Top <%= item[:value] %>%</span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<% if @package.funding_links.any? %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h6 class="mb-0">Funding</h6>
+    </div>
+    <div class="card-body">
+      <% @package.funding_links.each do |url| %>
+        <div class="mb-1">
+          <%= link_to url, sanitize_user_url(url), target: :_blank, class: 'small text-break' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/packages/_tabs.html.erb
+++ b/app/views/packages/_tabs.html.erb
@@ -1,82 +1,85 @@
-  <ul class="nav nav-tabs my-3">
-    <% if @package.download_url.present? %>
-      <li class="nav-item">
-        <% if action_name == 'show' %>
-          <a class="nav-link active" aria-current="page">
-        <% else %>
-          <a class="nav-link" href="<%= registry_package_path(@registry, @package) %>">
-        <% end %>
-          Readme
-        </a>
-      </li>
-    <% end %>
-    <li class="nav-item">
-      <% if @package.download_url.blank? || action_name == 'index' %>
-        <a class="nav-link active" aria-current="page">
-      <% else %>
-        <a class="nav-link" href="<%= registry_package_versions_path(@registry, @package) %>">
-      <% end %>
-        Versions
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @package.versions_count %>
-        </span>
-      </a>
-    </li>
-    <li class="nav-item">
-      <% if action_name == 'dependent_packages' %>
-        <a class="nav-link active" aria-current="page">
-      <% else %>
-        <a class="nav-link" href="<%= dependent_packages_registry_package_path(@registry, @package) %>">
-      <% end %>
-        Dependent Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @package.dependent_packages_count %>
-        </span>
-      </a>
-    </li>
-    <li class="nav-item">
-      <% if action_name == 'maintainers' %>
-        <a class="nav-link active" aria-current="page">
-      <% else %>
-        <a class="nav-link" href="<%= maintainers_registry_package_path(@registry, @package) %>">
-      <% end %>
-        Maintainers
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @package.maintainers_count %>
-        </span>
-      </a>
-    </li>
-    <% related_packages_count = @package.related_packages.count %>
-    <% if related_packages_count > 0 %>
-      <li class="nav-item">
-        <% if action_name == 'related_packages' %>
-          <a class="nav-link active" aria-current="page">
-        <% else %>
-          <a class="nav-link" href="<%= related_packages_registry_package_path(@registry, @package) %>">
-        <% end %>
-          Related Packages
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter related_packages_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
+<% versions_active = (@package.download_url.blank? && action_name == 'show') || action_name == 'index' %>
+<% versions_path = @package.download_url.present? ? registry_package_versions_path(@registry, @package) : registry_package_path(@registry, @package) %>
 
-    <% if @package.advisories.length > 0 %>
-      <li class="nav-item">
-        <% if action_name == 'advisories' %>
-          <a class="nav-link active" aria-current="page">
-        <% else %>
-          <a class="nav-link" href="<%= advisories_registry_package_path(@registry, @package) %>">
-        <% end %>
-          Security Advisories
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @package.advisories.length %>
-          </span>
-        </a>
-      </li>
+<ul class="nav nav-tabs mb-3">
+  <% if @package.download_url.present? %>
+    <li class="nav-item">
+      <% if action_name == 'show' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= registry_package_path(@registry, @package) %>">
+      <% end %>
+        Readme
+      </a>
+    </li>
+  <% end %>
+  <li class="nav-item">
+    <% if versions_active %>
+      <a class="nav-link active" aria-current="page">
+    <% else %>
+      <a class="nav-link" href="<%= versions_path %>">
     <% end %>
-    <% if ['dependent_packages', 'related_packages'].include? action_name %>
-      <%= render 'sort' %>
+      Versions
+      <span class="badge bg-secondary rounded-pill">
+        <%= number_with_delimiter @package.versions_count %>
+      </span>
+    </a>
+  </li>
+  <li class="nav-item">
+    <% if action_name == 'dependent_packages' %>
+      <a class="nav-link active" aria-current="page">
+    <% else %>
+      <a class="nav-link" href="<%= dependent_packages_registry_package_path(@registry, @package) %>">
     <% end %>
-  </ul>
+      Dependent Packages
+      <span class="badge bg-secondary rounded-pill">
+        <%= number_with_delimiter @package.dependent_packages_count %>
+      </span>
+    </a>
+  </li>
+  <li class="nav-item">
+    <% if action_name == 'maintainers' %>
+      <a class="nav-link active" aria-current="page">
+    <% else %>
+      <a class="nav-link" href="<%= maintainers_registry_package_path(@registry, @package) %>">
+    <% end %>
+      Maintainers
+      <span class="badge bg-secondary rounded-pill">
+        <%= number_with_delimiter @package.maintainers_count %>
+      </span>
+    </a>
+  </li>
+  <% related_packages_count = @package.related_packages.count %>
+  <% if related_packages_count > 0 %>
+    <li class="nav-item">
+      <% if action_name == 'related_packages' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= related_packages_registry_package_path(@registry, @package) %>">
+      <% end %>
+        Related Packages
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter related_packages_count %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+
+  <% if @package.advisories.length > 0 %>
+    <li class="nav-item">
+      <% if action_name == 'advisories' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= advisories_registry_package_path(@registry, @package) %>">
+      <% end %>
+        Security Advisories
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter @package.advisories.length %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <% if ['dependent_packages', 'related_packages'].include? action_name %>
+    <%= render 'sort' %>
+  <% end %>
+</ul>

--- a/app/views/packages/advisories.html.erb
+++ b/app/views/packages/advisories.html.erb
@@ -2,38 +2,43 @@
 <% @meta_description = "View the security advisories for the #{@package} package on the #{@registry} package registry, including their severity and publication date." %>
 
 <div class="container-sm">
-
   <%= render 'details' %>
 
-  <%= render 'tabs' %>
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'tabs' %>
 
-  <% @package.advisories.each do |advisory| %>
+      <% @package.advisories.each do |advisory| %>
+        <div class="card mb-3">
+          <div class="card-body">
+            <% if advisory['severity'] %>
+              <small class='badge bg-<%= severity_class(advisory['severity']) %> float-end'>
+                <%= advisory['severity'].humanize %>
+              </small>
+            <% end %>
+            <h5 class="card-title">
+              <%= link_to advisory['uuid'], "https://advisories.ecosyste.ms/advisories/" + advisory['uuid'] %>
+            </h5>
 
-    <div class="card mb-3">
-      <div class="card-body">
-        <% if advisory['severity'] %>
-          <small class='badge bg-<%= severity_class(advisory['severity']) %> float-end'>
-            <%= advisory['severity'].humanize %>
-          </small>
-        <% end %>
-        <h5 class="card-title">
-          <%= link_to advisory['uuid'], "https://advisories.ecosyste.ms/advisories/" + advisory['uuid'] %>
-        </h5>
+            <%= advisory['title'] %><br>
 
-        <%= advisory['title'] %><br>
-
-        <small class='text-muted'>
-          Ecosystems: <%= advisory['packages'].map{|p| p['ecosystem'] }.uniq.join(', ') %><br>
-          Packages: <%= advisory['packages'].map{|p| p['package_name'] }.uniq.join(', ') %><br>
-          Source: <%= advisory['source_kind'] %><br>
-          <span title="<%= advisory['published_at'] %>">Published: <%= time_ago_in_words advisory['published_at'] %> ago</span>
-          <% if advisory['withdrawn_at'] %>
-            <br>
-            <span title="<%= advisory['withdrawn_at'] %>">Withdrawn: <%= time_ago_in_words advisory['withdrawn_at'] %> ago</span>
-          <% end %>
-        </small>
-      </div>
+            <small class='text-muted'>
+              Ecosystems: <%= advisory['packages'].map{|p| p['ecosystem'] }.uniq.join(', ') %><br>
+              Packages: <%= advisory['packages'].map{|p| p['package_name'] }.uniq.join(', ') %><br>
+              Source: <%= advisory['source_kind'] %><br>
+              <span title="<%= advisory['published_at'] %>">Published: <%= time_ago_in_words advisory['published_at'] %> ago</span>
+              <% if advisory['withdrawn_at'] %>
+                <br>
+                <span title="<%= advisory['withdrawn_at'] %>">Withdrawn: <%= time_ago_in_words advisory['withdrawn_at'] %> ago</span>
+              <% end %>
+            </small>
+          </div>
+        </div>
+      <% end %>
     </div>
-  <% end %>
 
+    <div class="col-lg-4">
+      <%= render 'sidebar' %>
+    </div>
+  </div>
 </div>

--- a/app/views/packages/dependent_packages.html.erb
+++ b/app/views/packages/dependent_packages.html.erb
@@ -2,57 +2,58 @@
 <% @meta_description = "View the packages that depend on the #{@package} package on the #{@registry} package registry, including their kind and latest version." %>
 
 <div class="container-sm">
-
   <%= render 'details' %>
 
-  <%= render 'tabs' %>
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'tabs' %>
 
-  <% if @dependent_packages.any? %>
-    <div class='row'>
-      <div class='col-md-9'>
+      <% if @dependent_packages.any? %>
         <%= render @dependent_packages %>
-        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-      </div>
-      <div class='col-md-3'>
-        <div class='card mb-3'>
-          <div class='card-header'>
-            Past Dependents
-          </div>
-          <div class='card-body'>
-            <% latest = params[:latest] == 'false' ? nil : 'false' %>
-            <%= link_to dependent_packages_registry_package_path(@registry, @package, latest: latest, kind: params[:kind]), class: 'text-decoration-none text-dark' do %>
-              <% if latest %>
-                <%= bootstrap_icon "square" %> Include Past Dependents
-              <% else %>
-                <%= bootstrap_icon "check-square-fill" %> Include Past Dependents
-              <% end %>
-            <% end %>
-            <p class="mt-2 mb-0 small text-muted">Check this option to include packages that no longer depend on this package in their latest version but previously did.</p>
-          </div>
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+      <% else %>
+        <div class="alert alert-info" role="alert">
+          No dependent packages found.
         </div>
+      <% end %>
+    </div>
 
-        <div class='card'>
-          <div class='card-header'>
-            Filter by kind
-          </div>
-          <div class='list-group list-group-flush'>
-            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind].blank? %>" href="<%= dependent_packages_registry_package_path(@registry, @package, latest: params[:latest]) %>">
-              All kinds
+    <div class="col-lg-4">
+      <div class='card mb-4'>
+        <div class='card-header'>
+          <h6 class="mb-0">Past Dependents</h6>
+        </div>
+        <div class='card-body'>
+          <% latest = params[:latest] == 'false' ? nil : 'false' %>
+          <%= link_to dependent_packages_registry_package_path(@registry, @package, latest: latest, kind: params[:kind]), class: 'text-decoration-none text-dark' do %>
+            <% if latest %>
+              <%= bootstrap_icon "square" %> Include Past Dependents
+            <% else %>
+              <%= bootstrap_icon "check-square-fill" %> Include Past Dependents
+            <% end %>
+          <% end %>
+          <p class="mt-2 mb-0 small text-muted">Check this option to include packages that no longer depend on this package in their latest version but previously did.</p>
+        </div>
+      </div>
+
+      <div class='card mb-4'>
+        <div class='card-header'>
+          <h6 class="mb-0">Filter by Kind</h6>
+        </div>
+        <div class='list-group list-group-flush'>
+          <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind].blank? %>" href="<%= dependent_packages_registry_package_path(@registry, @package, latest: params[:latest]) %>">
+            All kinds
+          </a>
+          <% @kinds.sort_by(&:last).reverse.first(100).each do |kind, count| %>
+            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind] == kind %>" href="<%= dependent_packages_registry_package_path(@registry, @package, kind: kind, latest: params[:latest]) %>">
+              <%= kind %>
+              <span class='badge bg-primary rounded-pill'><%= number_with_delimiter count %></span>
             </a>
-            <% @kinds.sort_by(&:last).reverse.first(100).each do |kind, count| %>
-              <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind] == kind %>" href="<%= dependent_packages_registry_package_path(@registry, @package, kind: kind, latest: params[:latest]) %>">
-                <%= kind %>
-                <span class='badge bg-primary rounded-pill'><%= number_with_delimiter count %></span>
-              </a>
-            <% end %>
-          </div>
+          <% end %>
         </div>
       </div>
-    </div>
-  <% else %>
-    <div class="alert alert-info" role="alert">
-      No dependent packages found.
-    </div>
-  <% end %>
-</div>
 
+      <%= render 'sidebar' %>
+    </div>
+  </div>
+</div>

--- a/app/views/packages/index.html.erb
+++ b/app/views/packages/index.html.erb
@@ -2,56 +2,57 @@
 <% @meta_description = "View the packages on the #{@registry} package registry, including their maintainers, namespaces, and keywords." %>
 
 <div class="container-sm">
-  <h2>
-    <%= @registry %>
-    <% if params[:keyword].present? %>
-    "<%= params[:keyword] %>"
-    <% end %>
-    packages 
-  </h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item active" aria-current="page">
+        <%= @registry %>
+        <% if params[:keyword].present? %>
+          / "<%= params[:keyword] %>"
+        <% end %>
+      </li>
+    </ol>
+  </nav>
 
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link active" aria-current="page">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @registry.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% if @registry.maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_maintainers_path(@registry) %>">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_namespaces_path(@registry) %>">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.keywords_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= keywords_registry_path(@registry) %>">
-          Keywords
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.keywords_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <%= render 'sort' %>
-  </ul>
+  <div class="card mb-4">
+    <div class="card-header">
+      <div class="d-flex justify-content-between align-items-center">
+        <h1 class="h4 mb-0">
+          <img src="<%= @registry.icon_url %>" class="rounded me-2" height='24' width='24' onerror="this.style.display='none'">
+          <%= @registry %>
+        </h1>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col-md-3 col-6 mb-2 text-center">
+          <h4 class="text-primary mb-1"><%= number_with_delimiter @registry.packages_count %></h4>
+          <p class="small text-muted mb-0">Packages</p>
+        </div>
+        <% if @registry.versions_count && @registry.versions_count > 0 %>
+          <div class="col-md-3 col-6 mb-2 text-center">
+            <h4 class="text-success mb-1"><%= number_with_delimiter @registry.versions_count %></h4>
+            <p class="small text-muted mb-0">Versions</p>
+          </div>
+        <% end %>
+        <% if @registry.maintainers_count > 0 %>
+          <div class="col-md-3 col-6 mb-2 text-center">
+            <h4 class="text-warning mb-1"><%= number_with_delimiter @registry.maintainers_count %></h4>
+            <p class="small text-muted mb-0">Maintainers</p>
+          </div>
+        <% end %>
+        <% if @registry.downloads && @registry.downloads > 0 %>
+          <div class="col-md-3 col-6 mb-2 text-center">
+            <h4 class="text-info mb-1"><%= number_with_delimiter @registry.downloads %></h4>
+            <p class="small text-muted mb-0">Downloads</p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <%= render 'registries/tabs' %>
 
   <%= render @packages %>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/packages/maintainers.html.erb
+++ b/app/views/packages/maintainers.html.erb
@@ -2,18 +2,24 @@
 <% @meta_description = "View the maintainers of the #{@package.name} package on the #{@registry.name} package registry, including their contact information and contributions." %>
 
 <div class="container-sm">
-
   <%= render 'details' %>
 
-  <%= render 'tabs' %>
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'tabs' %>
 
-  <% if @maintainers.any? %>
-    <%= render @maintainers %>
-    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-  <% else %>
-    <div class="alert alert-info" role="alert">
-      No maintainers found.
+      <% if @maintainers.any? %>
+        <%= render @maintainers %>
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+      <% else %>
+        <div class="alert alert-info" role="alert">
+          No maintainers found.
+        </div>
+      <% end %>
     </div>
-  <% end %>
 
+    <div class="col-lg-4">
+      <%= render 'sidebar' %>
+    </div>
+  </div>
 </div>

--- a/app/views/packages/related_packages.html.erb
+++ b/app/views/packages/related_packages.html.erb
@@ -2,57 +2,24 @@
 <% @meta_description = "View the related packages for the #{@package.name} package on the #{@registry.name} package registry, including their maintainers, versions, and dependencies." %>
 
 <div class="container-sm">
-
   <%= render 'details' %>
 
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_package_path(@registry, @package) %>">
-        Versions
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @package.versions_count %>
-        </span>
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="<%= dependent_packages_registry_package_path(@registry, @package) %>">
-        Dependent Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @package.dependent_packages_count %>
-        </span>
-      </a>
-    </li>
-    <% if @package.maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= maintainers_registry_package_path(@registry, @package) %>">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @package.maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% related_packages_count = @package.related_packages.count %>
-    <% if related_packages_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Related Packages
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter related_packages_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <%= render 'sort' %>
-  </ul>
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'tabs' %>
 
-  <% if @related_packages.any? %>
-    <%= render @related_packages %>
-    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-  <% else %>
-    <div class="alert alert-info" role="alert">
-      No related packages found.
+      <% if @related_packages.any? %>
+        <%= render @related_packages %>
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+      <% else %>
+        <div class="alert alert-info" role="alert">
+          No related packages found.
+        </div>
+      <% end %>
     </div>
-  <% end %>
-</div>
 
+    <div class="col-lg-4">
+      <%= render 'sidebar' %>
+    </div>
+  </div>
+</div>

--- a/app/views/packages/show.html.erb
+++ b/app/views/packages/show.html.erb
@@ -7,26 +7,31 @@
 <% end %>
 
 <div class="container-sm">
-
   <%= render 'details' %>
 
-  
-  <%= render 'tabs' %>
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'tabs' %>
 
-  <% if @package.download_url.present? %>
-    <div class='card' id="files" data-url="<%= @package.download_url %>" data-basename="<%= @package.archive_basename %>" data-path="<%= params[:path] %>">
-      <div id='files-header' class="card-header"></div>
-      <ul id="files-list" class="list-group list-group-flush"></ul>
-      <div id="files-content" class="card-body">Loading...</div>
+      <% if @package.download_url.present? %>
+        <div class='card' id="files" data-url="<%= @package.download_url %>" data-basename="<%= @package.archive_basename %>" data-path="<%= params[:path] %>">
+          <div id='files-header' class="card-header"></div>
+          <ul id="files-list" class="list-group list-group-flush"></ul>
+          <div id="files-content" class="card-body">Loading...</div>
+        </div>
+
+        <div class='card mt-3' id="readme" data-url="<%= @package.download_url %>">
+          <div id='readme-header' class="card-header">Readme</div>
+          <div id="readme-content" class="card-body">Loading...</div>
+        </div>
+      <% elsif @versions.any? %>
+        <%= render @versions %>
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+      <% end %>
     </div>
 
-    <div class='card mt-3' id="readme" data-url="<%= @package.download_url %>">
-      <div id='readme-header' class="card-header">Readme</div>
-      <div id="readme-content" class="card-body">Loading...</div>
+    <div class="col-lg-4">
+      <%= render 'sidebar' %>
     </div>
-  
-  <% elsif @versions.any? %>
-    <%= render @versions %>
-    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-  <% end %>
+  </div>
 </div>

--- a/app/views/registries/_tabs.html.erb
+++ b/app/views/registries/_tabs.html.erb
@@ -1,0 +1,61 @@
+<ul class="nav nav-tabs mb-3">
+  <li class="nav-item">
+    <% if controller_name == 'packages' && action_name == 'index' %>
+      <a class="nav-link active" aria-current="page">
+    <% else %>
+      <a class="nav-link" href="<%= registry_packages_path(@registry) %>">
+    <% end %>
+      Packages
+      <span class="badge bg-secondary rounded-pill">
+        <%= number_with_delimiter @registry.packages_count %>
+      </span>
+    </a>
+  </li>
+  <% if @registry.maintainers_count > 0 %>
+    <li class="nav-item">
+      <% if controller_name == 'maintainers' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= registry_maintainers_path(@registry) %>">
+      <% end %>
+        Maintainers
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter @registry.maintainers_count %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <% if @registry.namespaces_count > 0 %>
+    <li class="nav-item">
+      <% if controller_name == 'namespaces' %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= registry_namespaces_path(@registry) %>">
+      <% end %>
+        Namespaces
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter @registry.namespaces_count %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <% if @registry.keywords_count > 0 %>
+    <li class="nav-item">
+      <% if (controller_name == 'registries' && action_name == 'keywords') %>
+        <a class="nav-link active" aria-current="page">
+      <% else %>
+        <a class="nav-link" href="<%= keywords_registry_path(@registry) %>">
+      <% end %>
+        Keywords
+        <span class="badge bg-secondary rounded-pill">
+          <%= number_with_delimiter @registry.keywords_count %>
+        </span>
+      </a>
+    </li>
+  <% end %>
+  <% if controller_name == 'packages' && ['index', 'dependent_packages', 'related_packages'].include?(action_name) %>
+    <%= render 'packages/sort' %>
+  <% elsif controller_name == 'maintainers' %>
+    <%= render 'maintainers/sort' %>
+  <% end %>
+</ul>

--- a/app/views/registries/keyword.html.erb
+++ b/app/views/registries/keyword.html.erb
@@ -2,80 +2,39 @@
 <% @meta_description = "View the packages on the #{@registry} package registry that are tagged with the #{@keyword} keyword." %>
 
 <div class="container-sm">
-  <h2>
-    <%= @registry %>
-    "<%= @keyword %>"
-    keyword
-  </h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item"><%= link_to "Keywords", keywords_registry_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= @keyword %></li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the packages on the <%= @registry %> package registry that are tagged with the "<%= @keyword %>" keyword.
-  </p>
+  <h1 class="h4 mb-3"><%= @registry %> "<%= @keyword %>" keyword</h1>
 
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_packages_path(@registry) %>">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @registry.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% if @registry.maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_maintainers_path(@registry) %>">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_namespaces_path(@registry) %>">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.keywords_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Keywords
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.keywords_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <%= render 'packages/sort' %>
-  </ul>
+  <%= render 'tabs' %>
 
   <div class='row'>
-    <div class='col-md-8'>
+    <div class='col-lg-8'>
       <%= render @packages %>
-      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-    </div>  
-    <div class='col-md-4'>
+      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+    </div>
+    <div class='col-lg-4'>
       <div class="card">
         <div class="card-header">
-          Related Keywords
+          <h6 class="mb-0">Related Keywords</h6>
         </div>
         <div class="list-group list-group-flush">
           <% @related_keywords.each do |keyword, count| %>
             <% next if keyword.blank? %>
             <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="<%= keyword_registry_path(@registry.name, keyword.squish) rescue nil %>">
               <%= keyword %>
-              <span class="badge bg-primary rounded-pill"><%= number_with_delimiter count%></span>
+              <span class="badge bg-primary rounded-pill"><%= number_with_delimiter count %></span>
             </a>
           <% end %>
-        </ul>
+        </div>
       </div>
-
-
     </div>
   </div>
 </div>

--- a/app/views/registries/keywords.html.erb
+++ b/app/views/registries/keywords.html.erb
@@ -2,54 +2,19 @@
 <% @meta_description = "View the keywords on the #{@registry} package registry, including their packages." %>
 
 <div class="container-sm">
-  <h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Keywords</li>
+    </ol>
+  </nav>
+
+  <h1 class='h4 mb-3'>
     <%= @registry %> keywords
-  </h2>
+  </h1>
 
-  <p class='lead'>
-    View the keywords on the <%= @registry %> package registry, including their packages.
-  </p>
-
-  <ul class="nav nav-tabs my-3">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= registry_packages_path(@registry) %>">
-        Packages
-        <span class="badge bg-secondary rounded-pill">
-          <%= number_with_delimiter @registry.packages_count %>
-        </span>
-      </a>
-    </li>
-    <% if @registry.maintainers_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_maintainers_path(@registry) %>">
-          Maintainers
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.maintainers_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.namespaces_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= registry_namespaces_path(@registry) %>">
-          Namespaces
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.namespaces_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-    <% if @registry.keywords_count > 0 %>
-      <li class="nav-item">
-        <a class="nav-link active" aria-current="page">
-          Keywords
-          <span class="badge bg-secondary rounded-pill">
-            <%= number_with_delimiter @registry.keywords_count %>
-          </span>
-        </a>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'tabs' %>
 
   <div class="row">
     <% @keywords.each do |keyword, count| %>
@@ -68,5 +33,5 @@
       </div>
     <% end %>
   </div>
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/registries/status.html.erb
+++ b/app/views/registries/status.html.erb
@@ -2,35 +2,63 @@
 <% @meta_description = "View the status of all registries, including the number of packages, active packages, and outdated packages." %>
 
 <div class="container-sm">
-  <h1 class='mb-3'>Registry Statuses</h1>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item active" aria-current="page">Status</li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the status of all registries, including the number of packages, active packages, and outdated packages.
-  </p>
+  <h1 class="h4 mb-4">Registry Statuses</h1>
 
-  Total registries: <%= number_with_delimiter @registries.length %><br/>
-  Total packages: <%= number_with_delimiter @registries.sum(&:packages_count) %><br/>
-  Total active packages: <%= number_with_delimiter @registries.sum(&:active_packages_count) %><br/>
-  Outdated registries: <%= number_with_delimiter @registries.length %> (<%= (@registries.length / @registries.length.to_f * 100).round(2) %>%)<br/>
-  Total outdated packages: <%= number_with_delimiter @registries.sum(&:outdated_packages_count) %> (<%= (@registries.sum(&:outdated_packages_count).to_f/@registries.sum(&:active_packages_count)*100).round(2) %>%)<br/>
-  <br/><br/>
+  <div class="row mb-4">
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-primary mb-1"><%= number_with_delimiter @registries.length %></h4>
+          <p class="card-text small text-muted mb-0">Registries</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-success mb-1"><%= number_with_delimiter @registries.sum(&:packages_count) %></h4>
+          <p class="card-text small text-muted mb-0">Total Packages</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-info mb-1"><%= number_with_delimiter @registries.sum(&:active_packages_count) %></h4>
+          <p class="card-text small text-muted mb-0">Active Packages</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 col-6 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h4 class="card-title text-warning mb-1"><%= number_with_delimiter @registries.sum(&:outdated_packages_count) %> (<%= (@registries.sum(&:outdated_packages_count).to_f / @registries.sum(&:active_packages_count) * 100).round(1) %>%)</h4>
+          <p class="card-text small text-muted mb-0">Outdated Packages</p>
+        </div>
+      </div>
+    </div>
+  </div>
 
-  <% @registries.each do |registry|%>
+  <% @registries.each do |registry| %>
     <div class="card mb-3 d-flex" id="registry_<%= registry.id %>">
       <div class="card-body pb-1">
         <div class="d-flex">
-          
           <div class="flex-grow-1 ms-3 text-break">
             <h5 class='card-title'>
               <%= link_to registry, registry_packages_path(registry.name) %>
             </h5>
-          
             <p class="card-subtitle mb-2 text-muted">
               <%= number_with_delimiter registry.packages_count %> packages<br/>
               Active: <%= number_with_delimiter registry.active_packages_count %> packages<br/>
-              Outdated: <%= number_with_delimiter registry.outdated_packages_count %> packages (<%= registry.outdated_percentage.round(2) %>%) <br/>
+              Outdated: <%= number_with_delimiter registry.outdated_packages_count %> packages (<%= registry.outdated_percentage.round(2) %>%)
             </p>
-
             <% if registry.outdated_packages_count > 0 && registry.least_recently_synced_package.present? %>
               <p class="card-subtitle mb-2 text-muted">
                 Least recently synced package: <%= link_to registry.least_recently_synced_package.name, [registry, registry.least_recently_synced_package] %> <span title='<%= registry.least_recently_synced_package.last_synced_at %>'>(<%= time_ago_in_words(registry.least_recently_synced_package.last_synced_at) %> ago)</span>
@@ -39,10 +67,9 @@
           </div>
           <div class="flex-shrink-0">
             <img src="<%= registry.icon_url %>" class="rounded" height='40' width='40' onerror="this.style.display='none'">
-          </div>  
+          </div>
         </div>
       </div>
     </div>
-
   <% end %>
 </div>

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -7,26 +7,31 @@
 <% end %>
 
 <div class="container-sm">
-
   <%= render 'packages/details' %>
 
-  
+  <div class="row">
+    <div class="col-lg-8">
+      <%= render 'packages/tabs' %>
 
-  <%= render 'packages/tabs' %>
+      <% if @versions.any? %>
+        <%= render @versions %>
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
+      <% elsif @package.download_url.present? %>
+        <div class='card' id="files" data-url="<%= @package.download_url %>" data-basename="<%= @package.archive_basename %>" data-path="<%= params[:path] %>">
+          <div id='files-header' class="card-header"></div>
+          <ul id="files-list" class="list-group list-group-flush"></ul>
+          <div id="files-content" class="card-body">Loading...</div>
+        </div>
 
-  <% if @versions.any? %>
-    <%= render @versions %>
-    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
-  <% elsif @package.download_url.present? %>
-    <div class='card' id="files" data-url="<%= @package.download_url %>" data-basename="<%= @package.archive_basename %>" data-path="<%= params[:path] %>">
-      <div id='files-header' class="card-header"></div>
-      <ul id="files-list" class="list-group list-group-flush"></ul>
-      <div id="files-content" class="card-body">Loading...</div>
+        <div class='card mt-3' id="readme" data-url="<%= @package.download_url %>">
+          <div id='readme-header' class="card-header">Readme</div>
+          <div id="readme-content" class="card-body">Loading...</div>
+        </div>
+      <% end %>
     </div>
 
-    <div class='card mt-3' id="readme" data-url="<%= @package.download_url %>">
-      <div id='readme-header' class="card-header">Readme</div>
-      <div id="readme-content" class="card-body">Loading...</div>
+    <div class="col-lg-4">
+      <%= render 'packages/sidebar' %>
     </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/versions/recent.html.erb
+++ b/app/views/versions/recent.html.erb
@@ -2,15 +2,17 @@
 <% @meta_description = "View the recent versions of packages on the #{@registry.name} package registry." %>
 
 <div class="container-sm">
-  <h2>
-    <%= @registry %> recent versions
-  </h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry) %></li>
+      <li class="breadcrumb-item active" aria-current="page">Recent Versions</li>
+    </ol>
+  </nav>
 
-  <p class='lead'>
-    View the recent versions of packages on the <%= @registry %> package registry.
-  </p>
+  <h1 class="h4 mb-3"><%= @registry %> recent versions</h1>
 
   <%= render partial: "version_with_package", collection: @versions, as: :version %>
 
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>  
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages && @pagy.pages > 1 %>
 </div>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -7,76 +7,172 @@
 <% end %>
 
 <div class="container-sm">
-  <h2><%= link_to @registry.name, registry_packages_path(@registry.name) %> : <%= link_to @package.name, registry_package_path(@registry.name, @package.name) %> : <%= @version.number %></h2>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><%= link_to "Registries", registries_path %></li>
+      <li class="breadcrumb-item"><%= link_to @registry.name, registry_packages_path(@registry.name) %></li>
+      <li class="breadcrumb-item"><%= link_to @package.name, registry_package_path(@registry.name, @package.name) %></li>
+      <li class="breadcrumb-item active" aria-current="page"><%= @version.number %></li>
+    </ol>
+  </nav>
 
-  <p>
-    <%= @package.description_with_fallback %>
-  </p>
-
-  <p>
-    <% if @version.registry_url.present? %>
-      <%= link_to 'Registry', @version.registry_url, target: :_blank %> - 
-    <% end %>
-    <% if @version.documentation_url.present? %>
-      <%= link_to 'Documentation', @version.documentation_url, target: :_blank %> - 
-    <% end %>
-    <% if @version.download_url.present? %>
-      <%= link_to 'Download', @version.download_url, target: :_blank %> -
-    <% end %>
-    <%= link_to 'JSON', api_v1_registry_package_version_url(@registry, @package, @version)%> -
-    <%= link_to 'codemeta.json', codemeta_api_v1_registry_package_version_url(@registry, @package, @version)%>
-    <% if @version.integrity.present? %>
-      <br>Integrity: <span title='<%= @version.integrity %>'><%= truncate(@version.integrity) %> -
-    <% end %>
-    <br>
-    <%= link_to 'purl', 'https://github.com/package-url/purl-spec', target: :_blank %>: <code><%= @version.purl %></code>
-    <br>Published: <time datetime="<%= @version.published_at %>"><%= time_ago_in_words @version.published_at %> ago</time>
-    <br>Indexed: <time datetime="<%= @version.created_at %>"><%= time_ago_in_words @version.created_at %> ago</time>
-    <% if @version.related_tag %>
-      <br>Related tag:
-      <% if @version.related_tag["html_url"] %>
-        <%= link_to @version.related_tag["name"], @version.related_tag["html_url"] %>
-      <% else %>
-        <%= @version.related_tag["name"] %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h1 class="h4 mb-0">
+        <code><%= @package.name %></code>
+        <span class="text-muted">@</span>
+        <code><%= @version.number %></code>
+      </h1>
+    </div>
+    <div class="card-body">
+      <% if @package.description_with_fallback.present? %>
+        <p class="mb-3"><%= @package.description_with_fallback %></p>
       <% end %>
-    <% end %>
-  </p>
 
-  <% if @version.download_url.present? %>
-    <div class='card' id="files" data-url="<%= @version.download_url %>" data-basename="Files" data-path="<%= params[:path] %>">
-      <div id='files-header' class="card-header"></div>
-      <ul id="files-list" class="list-group list-group-flush"></ul>
-      <div id="files-content" class="card-body">Loading...</div>
-    </div>
-  
-    <div class='card mt-3' id="readme" data-url="<%= @version.download_url %>">
-      <div id='readme-header' class="card-header">Readme</div>
-      <div id="readme-content" class="card-body">Loading...</div>
-    </div>
-  
-  <% end %>
-
-
-
-  <% if @version.dependencies.any? %>
-      <div class="card my-3">
-        <div class="card-header">Dependencies</div>
-        <ul class="list-group list-group-flush">
-          <% @version.dependencies.sort_by{|d| [d.kind.to_s, d.package_name.to_s]}.each do |dependency| %>
-            <li class="list-group-item">
-              <%= link_to dependency.package_name, registry_package_path(@registry.name, dependency.package_name) %>
-              <i><%= dependency.requirements %></i>
-              <small class='text-muted'>
-              <% if dependency.kind != 'runtime' %>
-                <%= dependency.kind %>
-              <% end %>
-              <% if dependency.optional %>
-                (optional)
-              <% end %>
-              </small>
-            </li>
-          <% end %>
-        </ul>
+      <div class="row">
+        <div class="col-md-4 mb-2">
+          <strong>Published</strong><br>
+          <time datetime="<%= @version.published_at %>" title="<%= @version.published_at %>"><%= time_ago_in_words @version.published_at %> ago</time>
+        </div>
+        <div class="col-md-4 mb-2">
+          <strong>Indexed</strong><br>
+          <time datetime="<%= @version.created_at %>" title="<%= @version.created_at %>"><%= time_ago_in_words @version.created_at %> ago</time>
+        </div>
+        <% if @version.dependencies.any? %>
+          <div class="col-md-4 mb-2">
+            <strong>Dependencies</strong><br>
+            <%= @version.dependencies.size %>
+          </div>
+        <% end %>
       </div>
-  <% end %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-8">
+      <% if @version.download_url.present? %>
+        <div class='card' id="files" data-url="<%= @version.download_url %>" data-basename="Files" data-path="<%= params[:path] %>">
+          <div id='files-header' class="card-header"></div>
+          <ul id="files-list" class="list-group list-group-flush"></ul>
+          <div id="files-content" class="card-body">Loading...</div>
+        </div>
+
+        <div class='card mt-3' id="readme" data-url="<%= @version.download_url %>">
+          <div id='readme-header' class="card-header">Readme</div>
+          <div id="readme-content" class="card-body">Loading...</div>
+        </div>
+      <% end %>
+
+      <% if @version.dependencies.any? %>
+        <div class="card mt-3">
+          <div class="card-header">
+            <h6 class="mb-0">Dependencies</h6>
+          </div>
+          <ul class="list-group list-group-flush">
+            <% @version.dependencies.sort_by{ |d| [d.kind.to_s, d.package_name.to_s] }.each do |dependency| %>
+              <li class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                  <%= link_to dependency.package_name, registry_package_path(@registry.name, dependency.package_name) %>
+                  <code class="ms-1"><%= dependency.requirements %></code>
+                </div>
+                <div>
+                  <% if dependency.kind != 'runtime' %>
+                    <span class="badge bg-secondary"><%= dependency.kind %></span>
+                  <% end %>
+                  <% if dependency.optional %>
+                    <span class="badge bg-warning">optional</span>
+                  <% end %>
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="col-lg-4">
+      <div class="card mb-4">
+        <div class="card-header">
+          <h6 class="mb-0">Links</h6>
+        </div>
+        <div class="card-body">
+          <table class="table table-sm mb-0">
+            <% if @version.registry_url.present? %>
+              <tr>
+                <td><strong>Registry</strong></td>
+                <td><%= link_to @registry.name, @version.registry_url, target: :_blank %></td>
+              </tr>
+            <% end %>
+            <% if @version.documentation_url.present? %>
+              <tr>
+                <td><strong>Docs</strong></td>
+                <td><%= link_to 'Documentation', @version.documentation_url, target: :_blank %></td>
+              </tr>
+            <% end %>
+            <% if @version.download_url.present? %>
+              <tr>
+                <td><strong>Download</strong></td>
+                <td><%= link_to 'Download', @version.download_url, target: :_blank %></td>
+              </tr>
+            <% end %>
+            <tr>
+              <td><strong>JSON API</strong></td>
+              <td><%= link_to 'View JSON', api_v1_registry_package_version_url(@registry, @package, @version), target: :_blank %></td>
+            </tr>
+            <tr>
+              <td><strong>CodeMeta</strong></td>
+              <td><%= link_to 'codemeta.json', codemeta_api_v1_registry_package_version_url(@registry, @package, @version), target: :_blank %></td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h6 class="mb-0">Version Details</h6>
+        </div>
+        <div class="card-body">
+          <table class="table table-sm mb-0">
+            <tr>
+              <td><strong>PURL</strong></td>
+              <td>
+                <code><%= @version.purl %></code>
+                <br><small><%= link_to 'spec', 'https://github.com/package-url/purl-spec', target: :_blank %></small>
+              </td>
+            </tr>
+            <% if @version.licenses.present? %>
+              <tr>
+                <td><strong>License</strong></td>
+                <td><%= @version.licenses %></td>
+              </tr>
+            <% end %>
+            <% if @version.integrity.present? %>
+              <tr>
+                <td><strong>Integrity</strong></td>
+                <td><code title="<%= @version.integrity %>"><%= truncate(@version.integrity, length: 30) %></code></td>
+              </tr>
+            <% end %>
+            <% if @version.related_tag %>
+              <tr>
+                <td><strong>Tag</strong></td>
+                <td>
+                  <% if @version.related_tag["html_url"] %>
+                    <%= link_to @version.related_tag["name"], @version.related_tag["html_url"], target: :_blank %>
+                  <% else %>
+                    <%= @version.related_tag["name"] %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            <% if @version.status.present? %>
+              <tr>
+                <td><strong>Status</strong></td>
+                <td><%= @version.status %></td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Redesigns all views to follow the ecosyste.ms styleguide and match the visual patterns used in the dependabot app.

- Breadcrumb navigation on all pages
- Card-based headers with key stats grids on package, version, and maintainer show pages
- Two-column layouts (col-lg-8/col-lg-4) with metadata sidebars on detail pages
- Homepage and registry status stats use centered colored stat cards
- New shared partials: packages/_sidebar, registries/_tabs, maintainers/_maintainer_tabs, namespaces/_namespace_tabs
- Fixes Versions tab incorrectly marked active on unrelated package pages
- related_packages view now uses the shared _tabs partial instead of inline duplicate
- Keywords show pages use col-lg-8/col-lg-4 layout with related keywords sidebar

29 files changed across all view directories.