### PR TITLE
Add CTAN as a registry

### DIFF
--- a/app/models/ecosystem/ctan.rb
+++ b/app/models/ecosystem/ctan.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Ctan < Base
+
+    SPDX_MAP = {
+      'lppl1.3c' => 'LPPL-1.3c',
+      'lppl1.3a' => 'LPPL-1.3a',
+      'lppl1.3' => 'LPPL-1.3a',
+      'lppl1.2' => 'LPPL-1.2',
+      'lppl1' => 'LPPL-1.0',
+      'lppl' => 'LPPL-1.0',
+      'gpl' => 'GPL-2.0-or-later',
+      'gpl2' => 'GPL-2.0-only',
+      'gpl2+' => 'GPL-2.0-or-later',
+      'gpl3' => 'GPL-3.0-only',
+      'gpl3+' => 'GPL-3.0-or-later',
+      'lgpl' => 'LGPL-2.1-or-later',
+      'lgpl2.1' => 'LGPL-2.1-only',
+      'lgpl3' => 'LGPL-3.0-only',
+      'agpl3' => 'AGPL-3.0-only',
+      'bsd' => 'BSD-2-Clause',
+      'bsd2' => 'BSD-2-Clause',
+      'bsd3' => 'BSD-3-Clause',
+      'bsd4' => 'BSD-4-Clause',
+      'mit' => 'MIT',
+      'apache2' => 'Apache-2.0',
+      'cc-by-4' => 'CC-BY-4.0',
+      'cc-by-sa-4' => 'CC-BY-SA-4.0',
+      'cc-by-nc-4' => 'CC-BY-NC-4.0',
+      'cc-by-nc-sa-4' => 'CC-BY-NC-SA-4.0',
+      'cc-by-3' => 'CC-BY-3.0',
+      'cc-by-sa-3' => 'CC-BY-SA-3.0',
+      'cc0' => 'CC0-1.0',
+      'ofl' => 'OFL-1.1',
+      'pd' => 'Public Domain',
+      'fdl' => 'GFDL-1.3-or-later',
+      'isc' => 'ISC',
+      'artistic' => 'Artistic-1.0',
+      'artistic2' => 'Artistic-2.0',
+    }.freeze
+
+    def registry_url(package, _version = nil)
+      "https://ctan.org/pkg/#{package.name}"
+    end
+
+    def download_url(package, _version = nil)
+      ctan_path = package.metadata&.dig('ctan_path')
+      return nil unless ctan_path.present?
+      "https://mirrors.ctan.org#{ctan_path}.zip"
+    end
+
+    def install_command(package, _version = nil)
+      "tlmgr install #{package.name}"
+    end
+
+    def check_status(package)
+      pkg = fetch_package_metadata(package.name)
+      return nil if pkg.present? && pkg.is_a?(Hash) && pkg["id"].present?
+
+      url = check_status_url(package)
+      response = Faraday.head(url)
+      return "removed" if [400, 404, 410].include?(response.status)
+    end
+
+    def all_package_names
+      get("https://ctan.org/json/2.0/packages").map { |p| p["key"] }.uniq
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      u = "https://ctan.org/ctan-ann/rss"
+      titles = SimpleRSS.parse(get_raw(u)).items.map(&:title)
+      titles.map { |t| t.split(": ").last }.uniq
+    rescue
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      get("https://ctan.org/json/2.0/pkg/#{name}")
+    rescue
+      {}
+    end
+
+    def map_package_metadata(package)
+      return false unless package.present?
+
+      description = package.dig("descriptions", 0, "text")
+      description = Rails::Html::FullSanitizer.new.sanitize(description).squish if description.present?
+      description = package["caption"] if description.blank?
+
+      license_field = package["license"]
+      licenses = Array(license_field).map { |l| SPDX_MAP[l] || l }.join(" and ")
+
+      {
+        name: package["id"],
+        description: description,
+        licenses: licenses.presence,
+        repository_url: repo_fallback(package["repository"].to_s, ""),
+        keywords_array: package["topics"],
+        metadata: {
+          'ctan_path' => package.dig("ctan", "path"),
+          'texlive' => package["texlive"],
+          'miktex' => package["miktex"],
+          'version_number' => package.dig("version", "number"),
+          'version_date' => package.dig("version", "date"),
+        }
+      }
+    end
+
+    def versions_metadata(pkg_metadata, _existing_version_numbers = [])
+      number = pkg_metadata.dig(:metadata, 'version_number')
+      date = pkg_metadata.dig(:metadata, 'version_date')
+      return [] if number.blank?
+
+      [
+        {
+          number: number,
+          published_at: date,
+        },
+      ]
+    end
+
+    def maintainers_metadata(name)
+      pkg = fetch_package_metadata(name)
+      return [] unless pkg.present? && pkg["authors"].present?
+
+      pkg["authors"].select { |a| a["active"] }.map do |author|
+        author_data = get("https://ctan.org/json/2.0/author/#{author['id']}")
+        name_parts = [author_data["givenname"], author_data["von"], author_data["familyname"]].select(&:present?)
+        {
+          uuid: author["id"],
+          name: name_parts.any? ? name_parts.join(" ") : (author_data["pseudonym"] || author["id"]),
+        }
+      end
+    rescue StandardError
+      []
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,6 +47,7 @@ default_registries = [
   {name: 'nexus.gael.cloud', url: 'https://nexus.gael.cloud/repository/maven-public', ecosystem: 'maven', github: 'gael-systems', default: false},
   {name: 'registry.terraform.io', url: 'https://registry.terraform.io', ecosystem: 'terraform', github: 'hashicorp', default: true},
   {name: 'artifacthub.io', url: 'https://artifacthub.io', ecosystem: 'helm', github: 'artifacthub', default: true},
+  {name: 'ctan.org', url: 'https://ctan.org', ecosystem: 'ctan', github: 'TeX-82', default: true},
 ]
 
 default_registries.each do |data|

--- a/test/fixtures/files/ctan/author-samcarter.json
+++ b/test/fixtures/files/ctan/author-samcarter.json
@@ -1,0 +1,9 @@
+{
+  "key": "samcarter",
+  "givenname": "Sam",
+  "von": "",
+  "familyname": "Carter",
+  "junior": "",
+  "female": false,
+  "died": false
+}

--- a/test/fixtures/files/ctan/jigsaw.json
+++ b/test/fixtures/files/ctan/jigsaw.json
@@ -1,0 +1,47 @@
+{
+  "id": "jigsaw",
+  "name": "jigsaw",
+  "aliases": [],
+  "caption": "Draw jigsaw pieces with TikZ",
+  "authors": [
+    {
+      "id": "samcarter",
+      "active": true
+    }
+  ],
+  "copyright": [],
+  "license": "lppl1.3c",
+  "version": {
+    "number": "0.5",
+    "date": "2024-04-25"
+  },
+  "descriptions": [
+    {
+      "language": null,
+      "text": "<p>\n      This is a small LaTeX package to draw jigsaw pieces with TikZ.\n      It is possible to draw individual pieces and adjust their shape,\n      create tile patterns or automatically generate complete jigsaws.\n    </p>"
+    }
+  ],
+  "documentation": [
+    {
+      "language": null,
+      "details": "Readme",
+      "href": "ctan:/graphics/pgf/contrib/jigsaw/README.md"
+    },
+    {
+      "language": null,
+      "details": "Package documentation",
+      "href": "ctan:/graphics/pgf/contrib/jigsaw/jigsaw-doc.pdf"
+    }
+  ],
+  "support": "https://github.com/samcarter/jigsaw/issues",
+  "repository": "https://github.com/samcarter/jigsaw",
+  "ctan": {
+    "path": "/graphics/pgf/contrib/jigsaw",
+    "file": true
+  },
+  "miktex": "jigsaw",
+  "texlive": "jigsaw",
+  "topics": [
+    "pgf-tikz"
+  ]
+}

--- a/test/fixtures/files/ctan/packages.json
+++ b/test/fixtures/files/ctan/packages.json
@@ -1,0 +1,5 @@
+[
+  {"key":"a0poster","name":"a0poster","caption":"Support for designing posters on large paper"},
+  {"key":"a2ac","name":"a2ac","caption":"AFM to AFM plus Composites"},
+  {"key":"a2ping","name":"a2ping","caption":"Advanced PS, PDF, EPS converter"}
+]

--- a/test/fixtures/files/ctan/rss.xml
+++ b/test/fixtures/files/ctan/rss.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>ctan-ann</title>
+    <link>https://www.ctan.org/ctan-ann/rss</link>
+    <description>CTAN announcements mailing list - recent</description>
+    <pubDate>Mon, 23 Feb 2026 10:19:09 +0100</pubDate>
+    <language>en-US</language>
+    <item>
+      <title>New on CTAN: fariscovernew</title>
+      <link>https://www.ctan.org/ctan-ann/id/example1</link>
+      <pubDate>Sun, 22 Feb 2026 17:25:34 +0100</pubDate>
+    </item>
+    <item>
+      <title>CTAN update: prooftrees</title>
+      <link>https://www.ctan.org/ctan-ann/id/example2</link>
+      <pubDate>Sun, 22 Feb 2026 09:17:54 +0100</pubDate>
+    </item>
+    <item>
+      <title>New on CTAN: memoize-ext</title>
+      <link>https://www.ctan.org/ctan-ann/id/example3</link>
+      <pubDate>Sun, 22 Feb 2026 12:03:43 +0100</pubDate>
+    </item>
+    <item>
+      <title>CTAN update: tkz-elements</title>
+      <link>https://www.ctan.org/ctan-ann/id/example4</link>
+      <pubDate>Sat, 21 Feb 2026 15:31:28 +0100</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/test/models/ecosystem/ctan_test.rb
+++ b/test/models/ecosystem/ctan_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+
+class CtanTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'CTAN', url: 'https://ctan.org', ecosystem: 'ctan')
+    @ecosystem = Ecosystem::Ctan.new(@registry)
+    @package = Package.new(ecosystem: 'ctan', name: 'jigsaw', metadata: { 'ctan_path' => '/graphics/pgf/contrib/jigsaw' })
+    @version = @package.versions.build(number: '0.5')
+  end
+
+  test 'registry_url' do
+    registry_url = @ecosystem.registry_url(@package)
+    assert_equal registry_url, 'https://ctan.org/pkg/jigsaw'
+  end
+
+  test 'registry_url with version' do
+    registry_url = @ecosystem.registry_url(@package, @version)
+    assert_equal registry_url, 'https://ctan.org/pkg/jigsaw'
+  end
+
+  test 'download_url' do
+    download_url = @ecosystem.download_url(@package, @version)
+    assert_equal download_url, 'https://mirrors.ctan.org/graphics/pgf/contrib/jigsaw.zip'
+  end
+
+  test 'install_command' do
+    install_command = @ecosystem.install_command(@package)
+    assert_equal install_command, 'tlmgr install jigsaw'
+  end
+
+  test 'install_command with version' do
+    install_command = @ecosystem.install_command(@package, @version.number)
+    assert_equal install_command, 'tlmgr install jigsaw'
+  end
+
+  test 'check_status_url' do
+    check_status_url = @ecosystem.check_status_url(@package)
+    assert_equal check_status_url, 'https://ctan.org/pkg/jigsaw'
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal purl, 'pkg:ctan/jigsaw'
+    assert Purl.parse(purl)
+  end
+
+  test 'purl with version' do
+    purl = @ecosystem.purl(@package, @version)
+    assert_equal purl, 'pkg:ctan/jigsaw@0.5'
+    assert Purl.parse(purl)
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, "https://ctan.org/json/2.0/packages")
+      .to_return({ status: 200, body: file_fixture('ctan/packages.json') })
+    all_package_names = @ecosystem.all_package_names
+    assert_equal all_package_names.length, 3
+    assert_equal all_package_names.last, 'a2ping'
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, "https://ctan.org/ctan-ann/rss")
+      .to_return({ status: 200, body: file_fixture('ctan/rss.xml') })
+    recently_updated_package_names = @ecosystem.recently_updated_package_names
+    assert_equal recently_updated_package_names.length, 4
+    assert_equal recently_updated_package_names.first, 'fariscovernew'
+  end
+
+  test 'package_metadata' do
+    stub_request(:get, "https://ctan.org/json/2.0/pkg/jigsaw")
+      .to_return({ status: 200, body: file_fixture('ctan/jigsaw.json') })
+    package_metadata = @ecosystem.package_metadata('jigsaw')
+
+    assert_equal package_metadata[:name], "jigsaw"
+    assert_equal package_metadata[:description], "This is a small LaTeX package to draw jigsaw pieces with TikZ. It is possible to draw individual pieces and adjust their shape, create tile patterns or automatically generate complete jigsaws."
+    assert_equal package_metadata[:licenses], "LPPL-1.3c"
+    assert_equal package_metadata[:repository_url], "https://github.com/samcarter/jigsaw"
+    assert_equal package_metadata[:keywords_array], ["pgf-tikz"]
+  end
+
+  test 'versions_metadata' do
+    stub_request(:get, "https://ctan.org/json/2.0/pkg/jigsaw")
+      .to_return({ status: 200, body: file_fixture('ctan/jigsaw.json') })
+    package_metadata = @ecosystem.package_metadata('jigsaw')
+    versions_metadata = @ecosystem.versions_metadata(package_metadata)
+
+    assert_equal versions_metadata, [{ number: "0.5", published_at: "2024-04-25" }]
+  end
+
+  test 'maintainers_metadata' do
+    stub_request(:get, "https://ctan.org/json/2.0/pkg/jigsaw")
+      .to_return({ status: 200, body: file_fixture('ctan/jigsaw.json') })
+    stub_request(:get, "https://ctan.org/json/2.0/author/samcarter")
+      .to_return({ status: 200, body: file_fixture('ctan/author-samcarter.json') })
+
+    maintainers = @ecosystem.maintainers_metadata('jigsaw')
+
+    assert_equal maintainers.length, 1
+    assert_equal maintainers.first[:uuid], "samcarter"
+    assert_equal maintainers.first[:name], "Sam Carter"
+  end
+
+  test 'check_status reuses memoized metadata without extra HTTP request' do
+    stub_request(:get, "https://ctan.org/json/2.0/pkg/jigsaw")
+      .to_return({ status: 200, body: file_fixture('ctan/jigsaw.json') })
+
+    @ecosystem.package_metadata('jigsaw')
+
+    status = @ecosystem.check_status(@package)
+    assert_nil status
+
+    assert_requested(:get, "https://ctan.org/json/2.0/pkg/jigsaw", times: 1)
+    assert_not_requested(:head, "https://ctan.org/pkg/jigsaw")
+  end
+
+  test 'license mapping' do
+    assert_equal Ecosystem::Ctan::SPDX_MAP['lppl1.3c'], 'LPPL-1.3c'
+    assert_equal Ecosystem::Ctan::SPDX_MAP['gpl3'], 'GPL-3.0-only'
+    assert_equal Ecosystem::Ctan::SPDX_MAP['mit'], 'MIT'
+    assert_equal Ecosystem::Ctan::SPDX_MAP['apache2'], 'Apache-2.0'
+    assert_equal Ecosystem::Ctan::SPDX_MAP['cc0'], 'CC0-1.0'
+    assert_equal Ecosystem::Ctan::SPDX_MAP['ofl'], 'OFL-1.1'
+    assert_equal Ecosystem::Ctan::SPDX_MAP['pd'], 'Public Domain'
+    assert_nil Ecosystem::Ctan::SPDX_MAP['unknown-license']
+  end
+end


### PR DESCRIPTION
Add support for the Comprehensive TeX Archive Network (CTAN) as a package ecosystem with PURL type `ctan`.

Fetches package metadata from the CTAN JSON API at `ctan.org/json/2.0/`, maps CTAN license shorthand (lppl1.3c, gpl3, mit, etc.) to SPDX identifiers, parses the ctan-ann RSS feed for recently updated packages, and resolves author names from the author API endpoint. Install command uses `tlmgr install`.