### PR TITLE
Fix dependent_packages timeout for popular packages

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -220,6 +220,8 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
 
     scope = scope.created_after(params[:created_after]) if params[:created_after].present?
     scope = scope.updated_after(params[:updated_after]) if params[:updated_after].present?
+    scope = scope.where("(repo_metadata ->> 'stargazers_count')::int >= ?", params[:min_stars].to_i) if params[:min_stars].present?
+    scope = scope.where("downloads >= ?", params[:min_downloads].to_i) if params[:min_downloads].present?
 
     if params[:sort].present? || params[:order].present?
       sort = params[:sort] || 'updated_at'


### PR DESCRIPTION
The dependent_packages endpoint times out for popular packages like uvicorn. The old code used `pluck` to materialize all dependent package IDs into a Ruby array, then passed them into a `WHERE IN (...)` clause. Against a 165 GB dependencies table and 111 GB versions table, this is too slow.

- Replaced `pluck` + `WHERE IN` with subqueries so Postgres can use semi-joins and short-circuit with LIMIT from pagination
- Removed the unnecessary join through the packages table (versions.package_id gives the same result with one fewer join)
- Added `min_stars` and `min_downloads` filter params to the API dependent_packages endpoint