### PR TITLE
Use async jobs for batch registry outdated sync

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -45,7 +45,7 @@ class Registry < ApplicationRecord
   end
 
   def self.sync_in_batches_outdated
-    Registry.sync_in_batches.each{|r| r.packages.active.outdated.limit(1000).each(&:sync)};nil
+    Registry.sync_in_batches.each{|r| r.packages.active.outdated.limit(1000).each(&:sync_async)};nil
   end
 
   def to_param


### PR DESCRIPTION
sync_in_batches_outdated was calling .sync (synchronous HTTP calls) on each package, blocking the rake process. Switch to .sync_async to queue Sidekiq jobs like every other sync task.