### PR TITLE
Reduce memory usage in sync_missing cron job

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -33,7 +33,10 @@ class Registry < ApplicationRecord
   end
 
   def self.sync_all_missing_packages_async
-    frequently_synced.each(&:sync_missing_packages_async)
+    frequently_synced.each do |registry|
+      registry.sync_missing_packages_async
+      GC.start
+    end
   end
 
   def sync_in_batches?
@@ -91,8 +94,15 @@ class Registry < ApplicationRecord
   def missing_package_names
     all_names = all_package_names
     all_names = all_names.keys if all_names.is_a?(Hash)
-    existing = existing_package_names.to_set
-    Array(all_names).reject { |name| existing.include?(name) }
+    all_names = Array(all_names)
+    return [] if all_names.empty?
+
+    missing = []
+    all_names.each_slice(10_000) do |batch|
+      existing_in_batch = packages.where(name: batch).pluck(:name).to_set
+      missing.concat(batch.reject { |name| existing_in_batch.include?(name) })
+    end
+    missing
   rescue => e
     Rails.logger.error("Error in missing_package_names for registry #{id} (#{ecosystem}): #{e.message}")
     []
@@ -141,7 +151,9 @@ class Registry < ApplicationRecord
   end
 
   def sync_packages_async(package_names)
-    SyncPackageWorker.perform_bulk(package_names.map{|name| [id, name]})
+    package_names.each_slice(1_000) do |batch|
+      SyncPackageWorker.perform_bulk(batch.map{|name| [id, name]})
+    end
   end
 
   def sync_package(name, force: false)

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -33,21 +33,20 @@ class RegistryTest < ActiveSupport::TestCase
   end
 
   test 'missing_package_names' do
+    @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)
     @registry.expects(:all_package_names).returns(['foo', 'bar', 'baz'])
-    @registry.expects(:existing_package_names).returns(['foo'])
-    assert_equal @registry.missing_package_names, ['bar', 'baz']
+    assert_equal @registry.missing_package_names.sort, ['bar', 'baz']
   end
 
   test 'missing_package_names handles Hash from all_package_names' do
     # This can happen when an ecosystem's API returns unexpected data
+    @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)
     @registry.expects(:all_package_names).returns({'foo' => 'data', 'bar' => 'data', 'baz' => 'data'})
-    @registry.expects(:existing_package_names).returns(['foo'])
     assert_equal @registry.missing_package_names.sort, ['bar', 'baz']
   end
 
   test 'missing_package_names handles nil from all_package_names' do
     @registry.expects(:all_package_names).returns(nil)
-    @registry.expects(:existing_package_names).returns(['foo'])
     assert_equal @registry.missing_package_names, []
   end
 


### PR DESCRIPTION
The `packages:sync_missing` midnight cron job (`cron.14235`) was climbing to 8GB RAM over ~8 hours. The issue is `missing_package_names` loading all existing package names into a Ruby Set via `pluck(:name).to_set` for each registry, plus `sync_packages_async` building a single giant array for `perform_bulk`. With ~14M packages across registries these collections add up fast and Ruby's GC can't keep pace.

Three changes:

- `missing_package_names` now checks existing names in batches of 10,000 via `WHERE name IN (...)` queries instead of loading the full set into Ruby memory
- `sync_packages_async` chunks `perform_bulk` calls into batches of 1,000 instead of building one array with millions of `[id, name]` tuples
- `sync_all_missing_packages_async` forces `GC.start` between registries so large string arrays from one registry get cleaned up before the next starts

The remote `all_package_names` list still has to fit in memory (comes from upstream APIs), but the DB side and intermediate processing no longer hold millions of strings simultaneously.