### PR TITLE
Do not cache error responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,5 @@
 class ErrorsController < ApplicationController
-  before_action :set_no_cache_headers
+  skip_before_action :set_cache_headers
 
   def not_found
     respond_to do |format|
@@ -23,11 +23,5 @@ class ErrorsController < ApplicationController
       format.json { render json: { error: "internal server error" }, status: :internal_server_error }
       format.any { head :internal_server_error }
     end
-  end
-
-  private
-
-  def set_no_cache_headers
-    response.headers['Cache-Control'] = 'no-store'
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  before_action :set_no_cache_headers
+
   def not_found
     respond_to do |format|
       format.html { render status: :not_found }
@@ -21,5 +23,11 @@ class ErrorsController < ApplicationController
       format.json { render json: { error: "internal server error" }, status: :internal_server_error }
       format.any { head :internal_server_error }
     end
+  end
+
+  private
+
+  def set_no_cache_headers
+    response.headers['Cache-Control'] = 'no-store'
   end
 end

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -18,4 +18,32 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     assert_response :internal_server_error
     assert_template 'errors/internal'
   end
+
+  test '500 is not publicly cacheable' do
+    get '/500'
+    cache_control = response.headers['Cache-Control'].to_s
+    refute_includes cache_control, 'public', "got: #{cache_control}"
+    refute_includes cache_control, 's-maxage', "got: #{cache_control}"
+  end
+
+  test '404 is not publicly cacheable' do
+    get '/404'
+    cache_control = response.headers['Cache-Control'].to_s
+    refute_includes cache_control, 'public', "got: #{cache_control}"
+    refute_includes cache_control, 's-maxage', "got: #{cache_control}"
+  end
+
+  test '422 is not publicly cacheable' do
+    get '/422'
+    cache_control = response.headers['Cache-Control'].to_s
+    refute_includes cache_control, 'public', "got: #{cache_control}"
+    refute_includes cache_control, 's-maxage', "got: #{cache_control}"
+  end
+
+  test 'json 500 is not publicly cacheable' do
+    get '/500', as: :json
+    cache_control = response.headers['Cache-Control'].to_s
+    refute_includes cache_control, 'public', "got: #{cache_control}"
+    refute_includes cache_control, 's-maxage', "got: #{cache_control}"
+  end
 end


### PR DESCRIPTION
## Summary

`ErrorsController` inherits `ApplicationController`'s `set_cache_headers` `before_action`, which emits `Cache-Control: public, max-age=86400` on every GET response (in Rails 8, `stale_if_error: 1.day` appears to also set `max-age` to the same value). Because the header says `public`, CDNs such as Cloudflare cache 500 responses for up to 24 hours instead of passing them through to the origin on the next request.

**Live example at time of writing** — fetching page 1 of npm package names returns a transient `500 Internal Server Error` whose body is `{"error":"internal server error"}`, and Cloudflare is serving that cached error to every subsequent caller:

```
GET https://packages.ecosyste.ms/api/v1/registries/npmjs.org/package_names?page=1&per_page=500&sort=docker_downloads_count

HTTP/3 500
cache-control: public, max-age=86400, stale-while-revalidate=21600, stale-if-error=86400, s-maxage=21600
cf-cache-status: HIT
age: 50
```

`cf-cache-status: HIT` with a 500 status confirms Cloudflare stored and is replaying the error. Note: this URL is only reproducible at the time this PR was opened — once the cached entry expires or is purged, the error will no longer be visible there.

## Changes

- Add `before_action :set_no_cache_headers` to `ErrorsController` that sets `Cache-Control: no-store`, overriding the inherited `set_cache_headers` before_action for all error responses (404, 422, 500).

## Testing

1. Trigger a 404/500 from the API (e.g. request a non-existent registry).
2. Confirm the response includes `Cache-Control: no-store` and does **not** include `public` or `max-age`.
3. Confirm that a successful endpoint response still carries the normal public cache headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)