### PR TITLE
Fix Maven license detection and SPDX normalization

### DIFF
--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -556,25 +556,31 @@ module Ecosystem
         .flat_map(&:nodes).map{|s| s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') }
       return xml_licenses if xml_licenses.any?
 
-      # Enhanced license detection from comments and URLs
+      spdx_expression = licenses_from_spdx_identifier(xml)
+      return spdx_expression if spdx_expression.any?
+
       licenses_from_comments(xml) + licenses_from_urls(xml)
+    end
+
+    def licenses_from_spdx_identifier(xml)
+      xml.locate("*/^Comment").flat_map do |c|
+        c.value.scan(/SPDX-License-Identifier:\s*(.+?)\s*$/).flatten
+      end.reject(&:blank?)
     end
 
     def licenses_from_comments(xml)
       comments = xml.locate("*/^Comment")
       license_comment_map = {
         "http://www.apache.org/licenses/LICENSE-2.0" => "Apache-2.0",
-        "http://www.eclipse.org/legal/epl-v10" => "Eclipse Public License (EPL), Version 1.0",
-        "http://www.eclipse.org/legal/epl-2.0" => "Eclipse Public License (EPL), Version 2.0",
-        "http://www.eclipse.org/org/documents/edl-v10" => "Eclipse Distribution License (EDL), Version 1.0",
+        "http://www.eclipse.org/legal/epl-v10" => "EPL-1.0",
+        "http://www.eclipse.org/legal/epl-2.0" => "EPL-2.0",
+        "http://www.eclipse.org/org/documents/edl-v10" => "BSD-3-Clause",
         "Apache License" => "Apache-2.0",
         "MIT License" => "MIT",
-        "GPL" => "GPL",
-        "BSD" => "BSD"
       }
-      
-      license_comment_map.select { |string, _| 
-        comments.any? { |c| c.value.include?(string) } 
+
+      license_comment_map.select { |string, _|
+        comments.any? { |c| c.value.include?(string) }
       }.map(&:last)
     end
 
@@ -585,10 +591,10 @@ module Ecosystem
         "https://www.apache.org/licenses/LICENSE-2.0" => "Apache-2.0",
         "http://opensource.org/licenses/MIT" => "MIT",
         "https://opensource.org/licenses/MIT" => "MIT",
-        "http://www.eclipse.org/legal/epl-v10.html" => "Eclipse Public License (EPL), Version 1.0",
-        "http://www.eclipse.org/legal/epl-v20.html" => "Eclipse Public License (EPL), Version 2.0"
+        "http://www.eclipse.org/legal/epl-v10.html" => "EPL-1.0",
+        "http://www.eclipse.org/legal/epl-v20.html" => "EPL-2.0"
       }
-      
+
       license_urls.map { |url| url_license_map[url.strip] }.compact
     end
 

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -289,6 +289,8 @@ class Package < ApplicationRecord
   NON_SPDX_LICENSE_VALUES = %w[other unknown none noassertion proprietary custom see\ license].freeze
 
   def spdx_license
+    return Spdx.parse_spdx(licenses).licenses if Spdx.valid_spdx?(licenses)
+
     licenses
       .downcase
       .sub(/^\(/, "")
@@ -297,16 +299,18 @@ class Package < ApplicationRecord
       .flat_map { |l| l.split(" and ") }
       .map { |l| manual_license_format(l) }
       .flat_map { |l| l.split(/[,\/]/) }
-      .map { |l| NON_SPDX_LICENSE_VALUES.include?(l.strip) ? nil : Spdx.find(l) }
+      .map(&:strip)
+      .reject { |l| l.blank? || l.match?(/\A(version\s+)?[\d.]+\z/) }
+      .map { |l| NON_SPDX_LICENSE_VALUES.include?(l) ? nil : Spdx.find(l) }
       .compact
       .map(&:id)
   end
 
   def manual_license_format(license)
-    # fixes "Apache License, Version 2.0" being incorrectly split on the comma
+    # fixes "Apache License, Version 2.0" etc being incorrectly split on the comma
     license
-      .gsub("apache license, version", "apache license version")
-      .gsub("apache software license, version", "apache software license version")
+      .gsub(/\b(license|licence)( \([a-z]+\))?, version\b/, 'license\2 version')
+      .gsub(/\b(license|licence)( \([a-z]+\))?, v(\d)/, 'license\2 v\3')
   end
 
   def sync

--- a/test/fixtures/files/maven/tyrus-bundles-2.2.2.pom
+++ b/test/fixtures/files/maven/tyrus-bundles-2.2.2.pom
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glassfish.tyrus.bundles</groupId>
+    <artifactId>tyrus-bundles</artifactId>
+    <version>2.2.2</version>
+    <packaging>pom</packaging>
+    <name>Tyrus Bundles</name>
+</project>

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -540,6 +540,45 @@ class MavenTest < ActiveSupport::TestCase
 
   end
 
+  test 'licenses extracts SPDX-License-Identifier from POM comments' do
+    xml = Ox.parse(file_fixture('maven/tyrus-bundles-2.2.2.pom').read)
+    assert_equal ["EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0"], @ecosystem.licenses(xml)
+  end
+
+  test 'licenses prefers license element over SPDX-License-Identifier comment' do
+    pom = <<~XML
+      <?xml version="1.0"?>
+      <!-- SPDX-License-Identifier: MIT -->
+      <project>
+        <licenses><license><name>Apache-2.0</name></license></licenses>
+      </project>
+    XML
+    xml = Ox.parse(pom)
+    assert_equal ["Apache-2.0"], @ecosystem.licenses(xml)
+  end
+
+  test 'licenses_from_comments emits SPDX ids without commas' do
+    pom = <<~XML
+      <?xml version="1.0"?>
+      <!-- See http://www.eclipse.org/legal/epl-2.0 for terms -->
+      <project><artifactId>x</artifactId></project>
+    XML
+    xml = Ox.parse(pom)
+    result = @ecosystem.licenses_from_comments(xml)
+    assert_equal ["EPL-2.0"], result
+    assert result.none? { |l| l.include?(",") }
+  end
+
+  test 'licenses_from_comments does not greedily match GPL substring' do
+    pom = <<~XML
+      <?xml version="1.0"?>
+      <!-- This software is LGPL licensed -->
+      <project><artifactId>x</artifactId></project>
+    XML
+    xml = Ox.parse(pom)
+    assert_equal [], @ecosystem.licenses_from_comments(xml)
+  end
+
   test 'download_pom is memoized within an instance' do
     pom_stub = stub_request(:get, "https://repo1.maven.org/maven2/com/example/test-package/1.0.0/test-package-1.0.0.pom")
       .to_return({ status: 200, body: file_fixture('maven/zio-aws-autoscaling_3-5.17.225.2.pom'), headers: { 'last-modified' => 'Tue, 12 Jul 2022 12:10:25 GMT' } })

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -67,6 +67,30 @@ class PackageTest < ActiveSupport::TestCase
     assert_equal ["Apache-2.0", "BSD-3-Clause"], package.normalized_licenses
   end
 
+  test 'normalize_licenses parses valid SPDX expressions directly' do
+    package = @registry.packages.create(name: 'test_spdx', ecosystem: @registry.ecosystem, licenses: 'EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0')
+    package.normalize_licenses
+    assert_equal ["EPL-2.0", "GPL-2.0"], package.normalized_licenses
+  end
+
+  test 'normalize_licenses handles license names containing commas' do
+    package = @registry.packages.create(name: 'test_comma', ecosystem: @registry.ecosystem, licenses: 'GNU General Public License, version 2 with the GNU Classpath Exception')
+    package.normalize_licenses
+    assert_equal ["GPL-2.0-with-classpath-exception"], package.normalized_licenses
+  end
+
+  test 'normalize_licenses ignores orphaned version fragments' do
+    package = @registry.packages.create(name: 'test_ver', ecosystem: @registry.ecosystem, licenses: 'Some License, Version 2.0')
+    package.normalize_licenses
+    assert_not_includes package.normalized_licenses, "libpng-2.0"
+  end
+
+  test 'normalize_licenses still handles Apache License, Version 2.0' do
+    package = @registry.packages.create(name: 'test_apache', ecosystem: @registry.ecosystem, licenses: 'Apache License, Version 2.0')
+    package.normalize_licenses
+    assert_equal ["Apache-2.0"], package.normalized_licenses
+  end
+
   test 'set_latest_release_published_at' do
     @package.set_latest_release_published_at
     assert_equal @package.latest_release_published_at, @version2.published_at


### PR DESCRIPTION
Fixes #1574

`tyrus-standalone-client` was showing `normalized_licenses: ["EPL-1.0", "libpng-2.0", "GPL-2.0+"]` when the actual licenses are EPL-2.0 and GPL-2.0 with Classpath exception.

The leaf POM has no `<licenses>` element so we walk to the parent `tyrus-bundles`, which also has no `<licenses>` but does have a header comment. `licenses_from_comments` substring-matched that comment to `["Eclipse Public License (EPL), Version 2.0", "GPL"]`, joined them with `,`, and then `Package#spdx_license` split on `,` into three fragments. `Spdx.find(" version 2.0")` fuzzy-matched to `libpng-2.0`.

Changes:

- Parse `SPDX-License-Identifier:` from POM header comments and prefer it over substring heuristics
- Comment/URL maps now emit SPDX IDs (`EPL-2.0`, `BSD-3-Clause`) instead of comma-containing prose
- Removed greedy `"GPL"` and `"BSD"` substring matchers that fired on LGPL/AGPL
- `Package#spdx_license` short-circuits via `Spdx.parse_spdx` when the raw string is already a valid SPDX expression so `WITH` clauses aren't fuzzy-matched
- `manual_license_format` generalised to any `... License, Version X` / `... License (XXX), Version X` pattern
- Orphaned fragments like `version 2.0` or bare `2.0` are dropped before `Spdx.find`

After resync tyrus will store `EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0` and normalize to `["EPL-2.0", "GPL-2.0"]`. Existing stored strings renormalize to `["EPL-2.0", "GPL-2.0+"]` (no more libpng) even before resync.

To find affected packages on production:

```ruby
Package.where("'libpng-2.0' = ANY(normalized_licenses)").where.not("licenses ILIKE '%libpng%'").count
```