### PR TITLE
Replace mvn help:effective-pom with git-pkgs/pom binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Install pom
+        env:
+          POM_VERSION: 0.1.2
+        run: |
+          curl -fsSL "https://github.com/git-pkgs/pom/releases/download/v${POM_VERSION}/pom_${POM_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin pom
+          pom -version
+
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Install pom
+        env:
+          POM_VERSION: 0.1.7
+        run: |
+          curl -fsSL "https://github.com/git-pkgs/pom/releases/download/v${POM_VERSION}/pom_${POM_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin pom
+          pom -version
+
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,14 @@ RUN apk add --update \
     yaml-dev \
     libffi-dev \
     jemalloc \
-    maven \
     brotli \
-    coreutils \
- && rm -rf /var/cache/apk/* 
+ && rm -rf /var/cache/apk/*
+
+ARG POM_VERSION=0.1.2
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN curl -fsSL "https://github.com/git-pkgs/pom/releases/download/v${POM_VERSION}/pom_${POM_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin pom
 
 # Will invalidate cache as soon as the Gemfile changes
 COPY Gemfile Gemfile.lock $APP_ROOT/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,14 @@ RUN apk add --update \
     yaml-dev \
     libffi-dev \
     jemalloc \
-    maven \
     brotli \
-    coreutils \
- && rm -rf /var/cache/apk/* 
+ && rm -rf /var/cache/apk/*
+
+ARG POM_VERSION=0.1.7
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN curl -fsSL "https://github.com/git-pkgs/pom/releases/download/v${POM_VERSION}/pom_${POM_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin pom
 
 # Will invalidate cache as soon as the Gemfile changes
 COPY Gemfile Gemfile.lock $APP_ROOT/

--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -421,87 +421,20 @@ module Ecosystem
     def generate_effective_pom(xml_body)
       return xml_body unless ENV['ENABLE_MAVEN_EFFECTIVE_POM'] == 'true'
 
-      Tempfile.create(%w[pom_ .xml]) do |input_file|
-        File.write(input_file.path, xml_body)
-        input_file.flush
+      stdout, stderr, status = Open3.capture3(
+        "pom", "-f", "-", "-xml", "-repo", @registry_url, "-timeout", "30s",
+        stdin_data: xml_body
+      )
 
-        # Run Maven to generate effective POM
-        Tempfile.create(%w[effective_pom_ .xml]) do |output_file|
-          # Throttle based on concurrent Maven processes
-          wait_for_maven_capacity
-
-          begin
-            # Build command - use timeout/nice in production (Docker has coreutils)
-            # Fallback to plain mvn on dev machines
-            if File.exist?("/usr/bin/timeout") || File.exist?("/bin/timeout")
-              cmd = ["timeout", "180s", "nice", "-n", "10", "mvn", "help:effective-pom", "-B", "-q", "-f", input_file.path, "-Doutput=#{output_file.path}"]
-            else
-              cmd = ["mvn", "help:effective-pom", "-B", "-q", "-f", input_file.path, "-Doutput=#{output_file.path}"]
-            end
-
-            env = {
-              "MAVEN_OPTS" => "-Xmx128m -Xms64m -XX:+UseSerialGC -XX:MaxMetaspaceSize=64m -XX:ActiveProcessorCount=1"
-            }
-
-            stdout, stderr, status = Open3.capture3(env, *cmd)
-
-            unless status.success?
-              return xml_body
-            end
-
-            # Parse the effective POM
-            File.read(output_file.path)
-          ensure
-            release_maven_capacity
-          end
-        end
+      unless status.success?
+        Rails.logger.warn("pom: effective-pom failed: #{stderr.strip}")
+        return xml_body
       end
 
+      stdout
     rescue => e
+      Rails.logger.warn("pom: #{e.class}: #{e.message}")
       xml_body
-    end
-
-    def wait_for_maven_capacity
-      max_concurrent = ENV.fetch('MAX_CONCURRENT_MAVEN', '10').to_i
-      redis_key = 'maven:running_processes'
-      max_wait = 300
-
-      started_at = Time.now
-
-      lua_script = <<-LUA
-        local key = KEYS[1]
-        local max = tonumber(ARGV[1])
-        local current = tonumber(redis.call('get', key) or 0)
-        if current < max then
-          redis.call('incr', key)
-          redis.call('expire', key, 300)
-          return 1
-        else
-          return 0
-        end
-      LUA
-
-      loop do
-        result = REDIS.eval(lua_script, keys: [redis_key], argv: [max_concurrent])
-        break if result == 1
-
-        if Time.now - started_at > max_wait
-          Rails.logger.error("Timed out waiting for Maven capacity after #{max_wait}s")
-          raise "Maven capacity timeout"
-        end
-
-        sleep(0.5)
-      end
-    rescue => e
-      Rails.logger.error("Failed to acquire Maven capacity: #{e.message}")
-      raise
-    end
-
-    def release_maven_capacity
-      redis_key = 'maven:running_processes'
-      REDIS.decr(redis_key)
-    rescue => e
-      Rails.logger.error("Failed to release Maven capacity: #{e.message}")
     end
 
     def download_pom(group_id, artifact_id, version)

--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -432,89 +432,77 @@ module Ecosystem
     end
 
     def generate_effective_pom(xml_body)
+      capacity_acquired = false
       return xml_body unless ENV['ENABLE_MAVEN_EFFECTIVE_POM'] == 'true'
 
-      Tempfile.create(%w[pom_ .xml]) do |input_file|
-        File.write(input_file.path, xml_body)
-        input_file.flush
+      capacity_acquired = wait_for_pom_capacity
+      return xml_body unless capacity_acquired
 
-        # Run Maven to generate effective POM
-        Tempfile.create(%w[effective_pom_ .xml]) do |output_file|
-          # Throttle based on concurrent Maven processes
-          wait_for_maven_capacity
+      stdout, stderr, status = Open3.capture3(
+        "pom", "-f", "-", "-xml", "-repo", @registry_url, "-timeout", "30s",
+        stdin_data: xml_body
+      )
 
-          begin
-            # Build command - use timeout/nice in production (Docker has coreutils)
-            # Fallback to plain mvn on dev machines
-            if File.exist?("/usr/bin/timeout") || File.exist?("/bin/timeout")
-              cmd = ["timeout", "180s", "nice", "-n", "10", "mvn", "help:effective-pom", "-B", "-q", "-f", input_file.path, "-Doutput=#{output_file.path}"]
-            else
-              cmd = ["mvn", "help:effective-pom", "-B", "-q", "-f", input_file.path, "-Doutput=#{output_file.path}"]
-            end
-
-            env = {
-              "MAVEN_OPTS" => "-Xmx128m -Xms64m -XX:+UseSerialGC -XX:MaxMetaspaceSize=64m -XX:ActiveProcessorCount=1"
-            }
-
-            stdout, stderr, status = Open3.capture3(env, *cmd)
-
-            unless status.success?
-              return xml_body
-            end
-
-            # Parse the effective POM
-            File.read(output_file.path)
-          ensure
-            release_maven_capacity
-          end
-        end
+      unless status.success?
+        Rails.logger.warn("pom: effective-pom failed: #{stderr.strip}")
+        return xml_body
       end
 
+      stdout
     rescue => e
+      Rails.logger.warn("pom: #{e.class}: #{e.message}")
       xml_body
+    ensure
+      release_pom_capacity if capacity_acquired
     end
 
-    def wait_for_maven_capacity
-      max_concurrent = ENV.fetch('MAX_CONCURRENT_MAVEN', '10').to_i
-      redis_key = 'maven:running_processes'
-      max_wait = 300
-
-      started_at = Time.now
-
-      lua_script = <<-LUA
+    def wait_for_pom_capacity
+      max_concurrent = [ENV.fetch('MAX_CONCURRENT_POM', '5').to_i, 1].max
+      wait_timeout = [ENV.fetch('POM_CAPACITY_WAIT_TIMEOUT', '5').to_f, 0].max
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait_timeout
+      redis_key = 'pom:running_processes'
+      lua_script = <<~LUA
         local key = KEYS[1]
         local max = tonumber(ARGV[1])
         local current = tonumber(redis.call('get', key) or 0)
         if current < max then
           redis.call('incr', key)
-          redis.call('expire', key, 300)
+          redis.call('expire', key, ARGV[2])
           return 1
-        else
-          return 0
         end
+        return 0
       LUA
 
       loop do
-        result = REDIS.eval(lua_script, keys: [redis_key], argv: [max_concurrent])
-        break if result == 1
+        result = REDIS.eval(lua_script, keys: [redis_key], argv: [max_concurrent, 60])
+        return true if result == 1
 
-        if Time.now - started_at > max_wait
-          Rails.logger.error("Timed out waiting for Maven capacity after #{max_wait}s")
-          raise "Maven capacity timeout"
+        if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+          Rails.logger.warn("pom: capacity limit reached after #{wait_timeout}s")
+          return false
         end
 
-        sleep(0.5)
+        sleep(0.1)
       end
     rescue => e
-      Rails.logger.error("Failed to acquire Maven capacity: #{e.message}")
-      raise
+      Rails.logger.warn("pom: failed to acquire capacity: #{e.message}")
+      false
     end
 
-    def release_maven_capacity
-      redis_key = 'maven:running_processes'
-      REDIS.decr(redis_key)
+    def release_pom_capacity
+      redis_key = 'pom:running_processes'
+      lua_script = <<~LUA
+        local key = KEYS[1]
+        local current = tonumber(redis.call('get', key) or 0)
+        if current <= 1 then
+          redis.call('del', key)
+          return 0
+        end
+        return redis.call('decr', key)
+      LUA
+      REDIS.eval(lua_script, keys: [redis_key])
     rescue => e
-      Rails.logger.error("Failed to release Maven capacity: #{e.message}")
+      Rails.logger.warn("pom: failed to release capacity: #{e.message}")
     end
 
     def download_pom(group_id, artifact_id, version)

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -504,6 +504,43 @@ class MavenTest < ActiveSupport::TestCase
     assert_nil versions_metadata[1][:published_at]
   end
 
+  def with_effective_pom_enabled
+    old = ENV['ENABLE_MAVEN_EFFECTIVE_POM']
+    ENV['ENABLE_MAVEN_EFFECTIVE_POM'] = 'true'
+    yield
+  ensure
+    old.nil? ? ENV.delete('ENABLE_MAVEN_EFFECTIVE_POM') : ENV['ENABLE_MAVEN_EFFECTIVE_POM'] = old
+  end
+
+  test 'generate_effective_pom uses pom binary' do
+    skip 'pom binary not on PATH' unless system('which pom > /dev/null 2>&1')
+
+    raw = file_fixture('maven/zio-aws-autoscaling_3-5.17.225.2.pom').read
+    out = with_effective_pom_enabled { @ecosystem.generate_effective_pom(raw) }
+
+    refute_equal raw, out
+    xml = Ox.parse(out)
+    assert_equal 'dev.zio', xml.locate('project/groupId/?[0]').first
+    assert_equal 'zio-aws-autoscaling_3', xml.locate('project/artifactId/?[0]').first
+    assert_equal '5.17.225.2', xml.locate('project/version/?[0]').first
+    assert_equal 'APL2', xml.locate('project/licenses/license/name/?[0]').first
+
+    deps = xml.locate('project/dependencies/dependency')
+    assert_equal 6, deps.length
+    core = deps.find { |d| d.locate('artifactId/?[0]').first == 'zio-aws-core_3' }
+    assert_equal '5.17.225.2', core.locate('version/?[0]').first
+  end
+
+  test 'generate_effective_pom falls back to input on failure' do
+    out = with_effective_pom_enabled { @ecosystem.generate_effective_pom('not xml') }
+    assert_equal 'not xml', out
+  end
+
+  test 'generate_effective_pom is a no-op when disabled' do
+    raw = file_fixture('maven/zio-aws-autoscaling_3-5.17.225.2.pom').read
+    assert_equal raw, @ecosystem.generate_effective_pom(raw)
+  end
+
   test 'dependencies_metadata netty-nio-client' do # skip: requires ENABLE_MAVEN_EFFECTIVE_POM
     skip unless ENV['ENABLE_MAVEN_EFFECTIVE_POM'] == 'true'
     stub_request(:get, "https://repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.5.6/netty-nio-client-2.5.6.pom")

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -505,6 +505,86 @@ class MavenTest < ActiveSupport::TestCase
     assert_nil versions_metadata[1][:published_at]
   end
 
+  def with_environment(name, value)
+    old = ENV[name]
+    value.nil? ? ENV.delete(name) : ENV[name] = value
+    yield
+  ensure
+    old.nil? ? ENV.delete(name) : ENV[name] = old
+  end
+
+  def with_effective_pom_enabled(&block)
+    with_environment('ENABLE_MAVEN_EFFECTIVE_POM', 'true', &block)
+  end
+
+  test 'dependencies_metadata uses pom binary' do
+    skip 'pom binary not on PATH' unless system('which pom > /dev/null 2>&1')
+
+    raw = file_fixture('maven/zio-aws-autoscaling_3-5.17.225.2.pom').read
+    stub_request(:get, "https://repo1.maven.org/maven2/dev/zio/zio-aws-autoscaling_3/5.17.225.2/zio-aws-autoscaling_3-5.17.225.2.pom")
+      .to_return(status: 200, body: raw)
+    @ecosystem.stubs(:wait_for_pom_capacity).returns(true)
+    @ecosystem.expects(:release_pom_capacity).once
+
+    dependencies = with_effective_pom_enabled do
+      @ecosystem.dependencies_metadata('dev.zio:zio-aws-autoscaling_3', '5.17.225.2', nil)
+    end
+
+    assert_equal 6, dependencies.length
+    core = dependencies.find { |dependency| dependency[:package_name] == 'dev.zio:zio-aws-core_3' }
+    assert_equal '5.17.225.2', core[:requirements]
+    assert_equal 'compile', core[:kind]
+  end
+
+  test 'generate_effective_pom falls back to input on failure' do
+    @ecosystem.stubs(:wait_for_pom_capacity).returns(true)
+    @ecosystem.expects(:release_pom_capacity).once
+    out = with_effective_pom_enabled { @ecosystem.generate_effective_pom('not xml') }
+    assert_equal 'not xml', out
+  end
+
+  test 'generate_effective_pom is a no-op when disabled' do
+    raw = file_fixture('maven/zio-aws-autoscaling_3-5.17.225.2.pom').read
+    assert_equal raw, @ecosystem.generate_effective_pom(raw)
+  end
+
+  test 'wait_for_pom_capacity defaults to five processes' do
+    REDIS.expects(:eval)
+      .with(kind_of(String), keys: ['pom:running_processes'], argv: [5, 60])
+      .returns(1)
+
+    acquired = with_environment('MAX_CONCURRENT_POM', nil) { @ecosystem.wait_for_pom_capacity }
+    assert acquired
+  end
+
+  test 'wait_for_pom_capacity uses the configured process limit' do
+    REDIS.expects(:eval)
+      .with(kind_of(String), keys: ['pom:running_processes'], argv: [2, 60])
+      .returns(1)
+
+    acquired = with_environment('MAX_CONCURRENT_POM', '2') { @ecosystem.wait_for_pom_capacity }
+    assert acquired
+  end
+
+  test 'generate_effective_pom falls back when pom capacity is unavailable' do
+    REDIS.expects(:eval).returns(0)
+    Open3.expects(:capture3).never
+
+    out = with_environment('POM_CAPACITY_WAIT_TIMEOUT', '0') do
+      with_effective_pom_enabled { @ecosystem.generate_effective_pom('raw pom') }
+    end
+
+    assert_equal 'raw pom', out
+  end
+
+  test 'release_pom_capacity decrements the shared counter' do
+    REDIS.expects(:eval)
+      .with(kind_of(String), keys: ['pom:running_processes'])
+      .returns(0)
+
+    assert_equal 0, @ecosystem.release_pom_capacity
+  end
+
   test 'dependencies_metadata netty-nio-client' do # skip: requires ENABLE_MAVEN_EFFECTIVE_POM
     skip unless ENV['ENABLE_MAVEN_EFFECTIVE_POM'] == 'true'
     stub_request(:get, "https://repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.5.6/netty-nio-client-2.5.6.pom")


### PR DESCRIPTION
Swaps the JVM-based `mvn help:effective-pom` shell-out for `pom` (https://github.com/git-pkgs/pom), a pure-Go effective-POM resolver.

`generate_effective_pom` now pipes the POM bytes to `pom -f - -xml -repo <registry_url>` and reads the merged XML back on stdout. The contract is unchanged (returns an XML string, falls back to the raw input on any error) so `Bibliothecary::Parsers::Maven` and `mapping_from_pom_xml` are untouched. Still gated on `ENABLE_MAVEN_EFFECTIVE_POM`.

The Redis-backed `wait_for_maven_capacity` / `release_maven_capacity` throttle is gone since the new binary is a few ms of CPU and a few hundred KB resident, versus ~1-2s and ~128MB per JVM. `maven` and `coreutils` are dropped from the Docker image and the `pom` binary (v0.1.2) is fetched from the GitHub release.

The emitted XML carries `groupId`, `artifactId`, `version`, `packaging`, `name`, `description`, `url`, `licenses`, `scm`, `properties`, `distributionManagement/relocation`, and interpolated `dependencies`. It does not include `<repositories>` or `<distributionManagement>` repository URLs, so `metadata.repositories` will be empty for POMs that only declare those in a parent. The five existing `ENABLE_MAVEN_EFFECTIVE_POM`-gated tests are still skipped in CI; their expectations around `repositories` and `properties` will need a pass when someone runs them locally.

Three new tests cover the happy path through the binary (using the parent-less zio fixture so it's hermetic), the failure fallback, and the disabled-env no-op. CI installs `pom` from the release tarball so the first of those runs on every push.