### PR TITLE
Add Lean ecosystem for reservoir.lean-lang.org

### DIFF
--- a/app/models/ecosystem/lean.rb
+++ b/app/models/ecosystem/lean.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Lean < Base
+
+    def sync_in_batches?
+      true
+    end
+
+    def purl_params(package, version = nil)
+      {
+        type: purl_type,
+        namespace: package.name.split('/').first,
+        name: package.name.split('/').last,
+        version: version.try(:number).try(:encode, 'iso-8859-1', invalid: :replace, undef: :replace, replace: '')
+      }
+    end
+
+    def registry_url(package, _version = nil)
+      owner, name = package.name.split('/', 2)
+      "#{@registry_url}/@#{owner}/#{name}"
+    end
+
+    def download_url(package, version = nil)
+      return nil if package.repository_url.blank?
+      return nil unless package.repository_url.include?('/github.com/')
+      full_name = package.repository_url.gsub('https://github.com/', '').gsub(/\.git$/, '')
+      if version.present?
+        "https://codeload.github.com/#{full_name}/tar.gz/#{version.number}"
+      else
+        branch = package.metadata&.dig('default_branch') || 'main'
+        "https://codeload.github.com/#{full_name}/tar.gz/refs/heads/#{branch}"
+      end
+    end
+
+    def check_status(package)
+      return "removed" if fetch_package_metadata(package.name).blank?
+    end
+
+    def manifest
+      @manifest ||= get_json("#{@registry_url}/index/manifest.json")
+    end
+
+    def packages
+      @packages ||= manifest['packages'].index_by { |p| p['fullName'] }
+    rescue
+      {}
+    end
+
+    def all_package_names
+      packages.keys
+    end
+
+    def recently_updated_package_names
+      packages.values.sort_by { |p| p['updatedAt'].to_s }.last(100).reverse.map { |p| p['fullName'] }
+    rescue
+      []
+    end
+
+    def namespace_package_names(namespace)
+      packages.values.select { |p| p['owner'] == namespace }.map { |p| p['fullName'] }
+    end
+
+    def fetch_package_metadata_uncached(name)
+      packages[name]
+    end
+
+    def map_package_metadata(pkg)
+      return false if pkg.blank? || pkg['fullName'].blank?
+
+      source = Array(pkg['sources']).first || {}
+      repo_url = source['repoUrl'] || source['gitUrl']
+
+      {
+        name: pkg['fullName'],
+        description: pkg['description'],
+        homepage: pkg['homepage'],
+        licenses: pkg['license'],
+        keywords_array: pkg['keywords'],
+        repository_url: repo_fallback(repo_url, pkg['homepage']),
+        namespace: pkg['owner'],
+        versions: pkg['versions'],
+        metadata: {
+          stars: pkg['stars'],
+          created_at: pkg['createdAt'],
+          updated_at: pkg['updatedAt'],
+          default_branch: source['defaultBranch'],
+          git_url: source['gitUrl'],
+        }.compact
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      versions = pkg_metadata[:versions] || []
+      versions.uniq { |v| v['revision'] }.map do |v|
+        {
+          number: v['revision'],
+          published_at: v['date'],
+          licenses: v['license'],
+          metadata: {
+            version: v['version'],
+            tag: v['tag'],
+            toolchain: v['toolchain'],
+            platform_independent: v['platformIndependent'],
+          }.compact
+        }
+      end
+    end
+
+    def dependencies_metadata(_name, version, pkg_metadata)
+      versions = pkg_metadata[:versions] || []
+      ver = versions.find { |v| v['revision'] == version }
+      return [] unless ver
+      Array(ver['dependencies']).reject { |d| d['transitive'] }.map do |dep|
+        package_name = dep['fullName'].presence || [dep['scope'], dep['name']].compact.join('/')
+        next if package_name.blank?
+        {
+          package_name: package_name,
+          requirements: dep['inputRev'].presence || dep['rev'].presence || dep['version'].presence || '*',
+          kind: 'runtime',
+          ecosystem: self.class.name.demodulize.downcase
+        }
+      end.compact
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,6 +49,7 @@ default_registries = [
   {name: 'registry.terraform.io', url: 'https://registry.terraform.io', ecosystem: 'terraform', github: 'hashicorp', default: true},
   {name: 'artifacthub.io', url: 'https://artifacthub.io', ecosystem: 'helm', github: 'artifacthub', default: true},
   {name: 'ctan.org', url: 'https://ctan.org', ecosystem: 'ctan', github: 'TeX-82', default: true},
+  {name: 'reservoir.lean-lang.org', url: 'https://reservoir.lean-lang.org', ecosystem: 'lean', github: 'leanprover', default: true},
 ]
 
 default_registries.each do |data|

--- a/test/fixtures/files/lean/manifest.json
+++ b/test/fixtures/files/lean/manifest.json
@@ -1,0 +1,293 @@
+{
+  "bundledAt": "2026-04-27T20:45:20Z",
+  "toolchains": [],
+  "packages": [
+    {
+      "name": "mathlib",
+      "owner": "leanprover-community",
+      "fullName": "leanprover-community/mathlib",
+      "description": "The math library of Lean 4",
+      "keywords": [],
+      "homepage": "https://leanprover-community.github.io/mathlib4_docs",
+      "license": "Apache-2.0",
+      "createdAt": "2021-05-09T07:52:01Z",
+      "updatedAt": "2026-04-27T20:25:11Z",
+      "stars": 3221,
+      "sources": [
+        {
+          "type": "git",
+          "host": "github",
+          "id": "R_kgDOFcwZ1Q",
+          "fullName": "leanprover-community/mathlib4",
+          "repoUrl": "https://github.com/leanprover-community/mathlib4",
+          "gitUrl": "https://github.com/leanprover-community/mathlib4",
+          "defaultBranch": "master"
+        }
+      ],
+      "dependents": [],
+      "versions": [
+        {
+          "version": "0.0.0",
+          "revision": "7e1d43ce0de119bf21df45cee606d4a9468e7989",
+          "date": "2026-04-27T13:42:09Z",
+          "tag": null,
+          "toolchain": "leanprover/lean4:v4.30.0-rc2",
+          "platformIndependent": null,
+          "license": null,
+          "licenseFiles": [
+            "/home/runner/work/reservoir/reservoir/testbed/repo/LICENSE"
+          ],
+          "readmeFile": "README.md",
+          "dependencies": [
+            {
+              "type": "git",
+              "name": "plausible",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "293af9b2a383eed4d04d66b898d608d0a44b750f",
+              "inputRev": "main",
+              "url": "https://github.com/leanprover-community/plausible",
+              "fullName": "leanprover-community/plausible"
+            },
+            {
+              "type": "git",
+              "name": "LeanSearchClient",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "c5d5b8fe6e5158def25cd28eb94e4141ad97c843",
+              "inputRev": "main",
+              "url": "https://github.com/leanprover-community/LeanSearchClient",
+              "fullName": "leanprover-community/LeanSearchClient"
+            },
+            {
+              "type": "git",
+              "name": "importGraph",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "cdab3938ccabbdb044be6896e251b5814bec932e",
+              "inputRev": "main",
+              "url": "https://github.com/leanprover-community/import-graph",
+              "fullName": "leanprover-community/importGraph"
+            },
+            {
+              "type": "git",
+              "name": "proofwidgets",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "2db6054a44326f8c0230ee0570e2ddb894816511",
+              "inputRev": "v0.0.98",
+              "url": "https://github.com/leanprover-community/ProofWidgets4",
+              "fullName": "leanprover-community/proofwidgets"
+            },
+            {
+              "type": "git",
+              "name": "aesop",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "f0c6e183ea26531e82773feb4b73ab6595ca17a5",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/aesop",
+              "fullName": "leanprover-community/aesop"
+            },
+            {
+              "type": "git",
+              "name": "Qq",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "1cc7e819b9b9bc1e87c9edcccb62e0269e00a809",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/quote4",
+              "fullName": "leanprover-community/Qq"
+            },
+            {
+              "type": "git",
+              "name": "batteries",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "5c57f3857ba81924a88b2cdf4f062e34ec04ff11",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/batteries",
+              "fullName": "leanprover-community/batteries"
+            },
+            {
+              "type": "git",
+              "name": "Cli",
+              "scope": "leanprover",
+              "version": "0.0.0",
+              "transitive": true,
+              "rev": "13567aed1ac4f12aea9484178e07e51f8c9f7658",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover/lean4-cli",
+              "fullName": "leanprover/Cli"
+            }
+          ]
+        },
+        {
+          "version": "0.0.0",
+          "revision": "5450b53e5ddc75d46418fabb605edbf36bd0beb6",
+          "date": "2026-04-18T10:41:35Z",
+          "tag": "v4.30.0-rc2",
+          "toolchain": "leanprover/lean4:v4.30.0-rc2",
+          "platformIndependent": null,
+          "license": null,
+          "licenseFiles": [
+            "/home/runner/work/reservoir/reservoir/testbed/repo/LICENSE"
+          ],
+          "readmeFile": "README.md",
+          "dependencies": [
+            {
+              "type": "git",
+              "name": "plausible",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "86210d4ad1b08b086d0bd638637a75246523dbb8",
+              "inputRev": "main",
+              "url": "https://github.com/leanprover-community/plausible",
+              "fullName": "leanprover-community/plausible"
+            },
+            {
+              "type": "git",
+              "name": "LeanSearchClient",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "c5d5b8fe6e5158def25cd28eb94e4141ad97c843",
+              "inputRev": "main",
+              "url": "https://github.com/leanprover-community/LeanSearchClient",
+              "fullName": "leanprover-community/LeanSearchClient"
+            },
+            {
+              "type": "git",
+              "name": "importGraph",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "cdab3938ccabbdb044be6896e251b5814bec932e",
+              "inputRev": "main",
+              "url": "https://github.com/leanprover-community/import-graph",
+              "fullName": "leanprover-community/importGraph"
+            },
+            {
+              "type": "git",
+              "name": "proofwidgets",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "2db6054a44326f8c0230ee0570e2ddb894816511",
+              "inputRev": "v0.0.98",
+              "url": "https://github.com/leanprover-community/ProofWidgets4",
+              "fullName": "leanprover-community/proofwidgets"
+            },
+            {
+              "type": "git",
+              "name": "aesop",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "f0c6e183ea26531e82773feb4b73ab6595ca17a5",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/aesop",
+              "fullName": "leanprover-community/aesop"
+            },
+            {
+              "type": "git",
+              "name": "Qq",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "1cc7e819b9b9bc1e87c9edcccb62e0269e00a809",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/quote4",
+              "fullName": "leanprover-community/Qq"
+            },
+            {
+              "type": "git",
+              "name": "batteries",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "5c57f3857ba81924a88b2cdf4f062e34ec04ff11",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/batteries",
+              "fullName": "leanprover-community/batteries"
+            },
+            {
+              "type": "git",
+              "name": "Cli",
+              "scope": "leanprover",
+              "version": "0.0.0",
+              "transitive": true,
+              "rev": "13567aed1ac4f12aea9484178e07e51f8c9f7658",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover/lean4-cli",
+              "fullName": "leanprover/Cli"
+            }
+          ]
+        }
+      ],
+      "builds": []
+    },
+    {
+      "name": "aesop",
+      "owner": "leanprover-community",
+      "fullName": "leanprover-community/aesop",
+      "description": "White-box automation for Lean 4",
+      "keywords": [],
+      "homepage": null,
+      "license": "Apache-2.0",
+      "createdAt": "2021-06-01T13:02:59Z",
+      "updatedAt": "2026-04-27T17:57:13Z",
+      "stars": 359,
+      "sources": [
+        {
+          "type": "git",
+          "host": "github",
+          "id": "R_kgDOFjj3ZA",
+          "fullName": "leanprover-community/aesop",
+          "repoUrl": "https://github.com/leanprover-community/aesop",
+          "gitUrl": "https://github.com/leanprover-community/aesop",
+          "defaultBranch": "master"
+        }
+      ],
+      "dependents": [],
+      "versions": [
+        {
+          "version": "0.0.0",
+          "revision": "7f1693468a9e6276b614a2cc52f77dd46fb6244a",
+          "date": "2026-04-22T03:28:12Z",
+          "tag": null,
+          "toolchain": "leanprover/lean4:v4.30.0-rc2",
+          "platformIndependent": true,
+          "license": null,
+          "licenseFiles": [
+            "/home/runner/work/reservoir/reservoir/testbed/repo/LICENSE"
+          ],
+          "readmeFile": "README.md",
+          "dependencies": [
+            {
+              "type": "git",
+              "name": "batteries",
+              "scope": "leanprover-community",
+              "version": "0.0.0",
+              "transitive": false,
+              "rev": "5c57f3857ba81924a88b2cdf4f062e34ec04ff11",
+              "inputRev": "v4.30.0-rc2",
+              "url": "https://github.com/leanprover-community/batteries",
+              "fullName": "leanprover-community/batteries"
+            }
+          ]
+        }
+      ],
+      "builds": []
+    }
+  ],
+  "packageAliases": {}
+}

--- a/test/models/ecosystem/lean_test.rb
+++ b/test/models/ecosystem/lean_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class LeanTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'reservoir.lean-lang.org', url: 'https://reservoir.lean-lang.org', ecosystem: 'lean')
+    @ecosystem = Ecosystem::Lean.new(@registry)
+    @package = Package.new(ecosystem: 'lean', name: 'leanprover-community/mathlib', repository_url: 'https://github.com/leanprover-community/mathlib4', metadata: { 'default_branch' => 'master' })
+    @version = @package.versions.build(number: '7e1d43ce0de119bf21df45cee606d4a9468e7989')
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://reservoir.lean-lang.org/@leanprover-community/mathlib', @ecosystem.registry_url(@package)
+  end
+
+  test 'install_command' do
+    assert_nil @ecosystem.install_command(@package)
+  end
+
+  test 'download_url' do
+    assert_equal 'https://codeload.github.com/leanprover-community/mathlib4/tar.gz/7e1d43ce0de119bf21df45cee606d4a9468e7989', @ecosystem.download_url(@package, @version)
+  end
+
+  test 'download_url without version uses default branch' do
+    assert_equal 'https://codeload.github.com/leanprover-community/mathlib4/tar.gz/refs/heads/master', @ecosystem.download_url(@package, nil)
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:lean/leanprover-community/mathlib', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'purl with version' do
+    purl = @ecosystem.purl(@package, @version)
+    assert_equal 'pkg:lean/leanprover-community/mathlib@7e1d43ce0de119bf21df45cee606d4a9468e7989', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'check_status_url' do
+    assert_equal 'https://reservoir.lean-lang.org/@leanprover-community/mathlib', @ecosystem.check_status_url(@package)
+  end
+
+  test 'sync_in_batches' do
+    assert @ecosystem.sync_in_batches?
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    all_package_names = @ecosystem.all_package_names
+    assert_equal 2, all_package_names.length
+    assert_includes all_package_names, 'leanprover-community/mathlib'
+    assert_includes all_package_names, 'leanprover-community/aesop'
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    names = @ecosystem.recently_updated_package_names
+    assert_equal 2, names.length
+    assert_equal 'leanprover-community/mathlib', names.first
+  end
+
+  test 'namespace_package_names' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    names = @ecosystem.namespace_package_names('leanprover-community')
+    assert_equal 2, names.length
+  end
+
+  test 'package_metadata' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    package_metadata = @ecosystem.package_metadata('leanprover-community/mathlib')
+
+    assert_equal 'leanprover-community/mathlib', package_metadata[:name]
+    assert_equal 'The math library of Lean 4', package_metadata[:description]
+    assert_equal 'https://leanprover-community.github.io/mathlib4_docs', package_metadata[:homepage]
+    assert_equal 'Apache-2.0', package_metadata[:licenses]
+    assert_equal 'https://github.com/leanprover-community/mathlib4', package_metadata[:repository_url]
+    assert_equal 'leanprover-community', package_metadata[:namespace]
+    assert_equal 'master', package_metadata[:metadata][:default_branch]
+  end
+
+  test 'versions_metadata' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    package_metadata = @ecosystem.package_metadata('leanprover-community/mathlib')
+    versions_metadata = @ecosystem.versions_metadata(package_metadata)
+
+    assert_equal 2, versions_metadata.length
+    assert_equal '7e1d43ce0de119bf21df45cee606d4a9468e7989', versions_metadata.first[:number]
+    assert_equal '0.0.0', versions_metadata.first[:metadata][:version]
+    assert_equal 'leanprover/lean4:v4.30.0-rc2', versions_metadata.first[:metadata][:toolchain]
+    assert versions_metadata.first[:published_at].present?
+  end
+
+  test 'dependencies_metadata' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    package_metadata = @ecosystem.package_metadata('leanprover-community/mathlib')
+    deps = @ecosystem.dependencies_metadata('leanprover-community/mathlib', '7e1d43ce0de119bf21df45cee606d4a9468e7989', package_metadata)
+
+    assert deps.length > 0
+    dep_names = deps.map { |d| d[:package_name] }
+    assert_includes dep_names, 'leanprover-community/aesop'
+    refute_includes dep_names, 'leanprover/Cli'
+    deps.each do |dep|
+      assert_equal 'runtime', dep[:kind]
+      assert_equal 'lean', dep[:ecosystem]
+    end
+  end
+
+  test 'check_status removed when not in manifest' do
+    stub_request(:get, "https://reservoir.lean-lang.org/index/manifest.json")
+      .to_return({ status: 200, body: file_fixture('lean/manifest.json') })
+    missing = Package.new(ecosystem: 'lean', name: 'foo/bar')
+    assert_equal 'removed', @ecosystem.check_status(missing)
+    assert_nil @ecosystem.check_status(@package)
+  end
+end


### PR DESCRIPTION
Adds support for the Lean package registry at https://reservoir.lean-lang.org (Lake package manager).

Data is pulled from the bundled `index/manifest.json` (currently ~617 packages) and synced in batches. Package names are scoped as `owner/name`. Reservoir tracks git revisions rather than semver releases (most packages report `0.0.0`), so the revision SHA is used as the version number with the declared version, tag and toolchain stored in version metadata. Transitive dependencies are filtered out.

There is no registered purl type for Lean yet so `pkg:lean/owner/name` is used.