### PR TITLE
Expose requested PURL version in lookup results

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -86,6 +86,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
       scope = scope.where(ecosystem: params[:ecosystem]) if params[:ecosystem].present?
     elsif params[:purl].present?
       scope = lookup_by_purl(params[:purl])
+      @purl_version = parsed_purl_version(params[:purl])
     else
       params[:name] = "library/#{params[:name]}" if params[:ecosystem] == 'docker' && !params[:name].include?('/')
       scope = scope.where(name: params[:name])
@@ -131,6 +132,12 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     end
 
     fresh_when @packages, public: true
+  end
+
+  def parsed_purl_version(purl_string)
+    Purl.parse(purl_string.gsub('npm/@', 'npm/%40')).version.presence
+  rescue
+    nil
   end
 
   def bulk_lookup

--- a/app/views/api/v1/packages/lookup.json.jbuilder
+++ b/app/views/api/v1/packages/lookup.json.jbuilder
@@ -1,5 +1,6 @@
 json.array! @packages do |package|
   json.partial! 'api/v1/packages/package', package: package
+  json.version @purl_version if @purl_version.present?
 
   json.registry do
     json.extract!package.registry, :name, :url, :ecosystem, :default, :packages_count, :maintainers_count, :namespaces_count, :keywords_count, :github, :metadata, :icon_url, :created_at, :updated_at

--- a/test/controllers/api/v1/packages_controller_test.rb
+++ b/test/controllers/api/v1/packages_controller_test.rb
@@ -127,6 +127,18 @@ class ApiV1PackagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal actual_response.length, 1
     assert_equal actual_response.first['name'], @package.name
+    assert_equal '0.8.0', actual_response.first['version']
+  end
+
+  test 'lookup by purl without version omits version field' do
+    get lookup_api_v1_packages_path(purl: 'pkg:cargo/rand')
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal actual_response.length, 1
+    assert_equal actual_response.first['name'], @package.name
+    assert_not actual_response.first.key?('version')
   end
 
   test 'lookup by purl with missing type' do


### PR DESCRIPTION
Fixes #512

## Summary
- Preserves the version from a package URL lookup request when the PURL includes one.
- Adds the requested `version` field to lookup JSON results only when a version was present in the `purl` parameter.
- Keeps versionless PURL lookup responses unchanged.
- Adds controller coverage for both versioned and versionless lookup responses.

## Validation
- `bundle install`
- `bundle exec ruby -c app/controllers/api/v1/packages_controller.rb`
- `bundle exec ruby -c test/controllers/api/v1/packages_controller_test.rb`
- `git diff --check`

Note: targeted Rails controller test execution is blocked locally because PostgreSQL is not running on `/tmp/.s.PGSQL.5432`.