### PR TITLE
Expose lookup version published_at

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -86,6 +86,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
       scope = scope.where(ecosystem: params[:ecosystem]) if params[:ecosystem].present?
     elsif params[:purl].present?
       scope = lookup_by_purl(params[:purl])
+      @purl_version = parsed_purl_version(params[:purl])
     else
       params[:name] = "library/#{params[:name]}" if params[:ecosystem] == 'docker' && !params[:name].include?('/')
       scope = scope.where(name: params[:name])
@@ -102,6 +103,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     end
 
     @pagy, @packages = pagy_countless(scope.includes(:registry, {maintainers: :registry}))
+    @lookup_versions_by_package_id = lookup_versions_by_package_id(@packages, @purl_version) if @purl_version.present?
 
     # if packages are not found, try to sync them
     if @packages.empty?
@@ -131,6 +133,18 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     end
 
     fresh_when @packages, public: true
+  end
+
+  def parsed_purl_version(purl_string)
+    Purl.parse(purl_string.gsub('npm/@', 'npm/%40')).version.presence
+  rescue
+    nil
+  end
+
+  def lookup_versions_by_package_id(packages, version_number)
+    Version.where(package_id: packages.map(&:id))
+           .where('lower(number) = ?', version_number.downcase)
+           .index_by(&:package_id)
   end
 
   def bulk_lookup

--- a/app/views/api/v1/packages/lookup.json.jbuilder
+++ b/app/views/api/v1/packages/lookup.json.jbuilder
@@ -1,6 +1,10 @@
 json.array! @packages do |package|
   json.partial! 'api/v1/packages/package', package: package
 
+  if @lookup_versions_by_package_id.present? && @lookup_versions_by_package_id[package.id].present?
+    json.published_at @lookup_versions_by_package_id[package.id].published_at
+  end
+
   json.registry do
     json.extract!package.registry, :name, :url, :ecosystem, :default, :packages_count, :maintainers_count, :namespaces_count, :keywords_count, :github, :metadata, :icon_url, :created_at, :updated_at
     json.packages_url api_v1_registry_packages_url(registry_id:package.registry.name)

--- a/test/controllers/api/v1/packages_controller_test.rb
+++ b/test/controllers/api/v1/packages_controller_test.rb
@@ -129,6 +129,44 @@ class ApiV1PackagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal actual_response.first['name'], @package.name
   end
 
+  test 'lookup by versioned purl includes version published_at' do
+    published_at = Time.zone.parse('2024-02-07 12:34:56')
+    @package.versions.create!(registry: @registry, number: '0.8.0', published_at: published_at)
+
+    get lookup_api_v1_packages_path(purl: 'pkg:cargo/rand@0.8.0')
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal @package.name, actual_response.first['name']
+    assert_equal published_at.as_json, actual_response.first['published_at']
+  end
+
+  test 'lookup by versionless purl does not include published_at' do
+    @package.versions.create!(registry: @registry, number: '0.8.0', published_at: Time.zone.parse('2024-02-07 12:34:56'))
+
+    get lookup_api_v1_packages_path(purl: 'pkg:cargo/rand')
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    refute actual_response.first.key?('published_at')
+  end
+
+  test 'lookup by versioned purl without matching version does not include published_at' do
+    @package.versions.create!(registry: @registry, number: '0.8.0', published_at: Time.zone.parse('2024-02-07 12:34:56'))
+
+    get lookup_api_v1_packages_path(purl: 'pkg:cargo/rand@0.8.1')
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    refute actual_response.first.key?('published_at')
+  end
+
   test 'lookup by purl with missing type' do
     invalid_purl = 'pkg:/software.amazon.awssdk%3Ametrics-spi'
   


### PR DESCRIPTION
Fixes #644

## Summary

- Parses the version component from versioned lookup PURLs.
- Adds the matching package version's `published_at` to lookup responses when a version is present and found.
- Keeps versionless lookup responses unchanged and omits `published_at` when the requested version is not known.
- Adds controller coverage for versioned, versionless, and unknown-version lookup responses.

## Validation

- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/controllers/api/v1/packages_controller.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/views/api/v1/packages/lookup.json.jbuilder`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c test/controllers/api/v1/packages_controller_test.rb`
- `git diff --check`

Note: targeted Rails controller tests are blocked locally because PostgreSQL is not running on `/tmp/.s.PGSQL.5432`.