### PR TITLE
Add RSS and Atom package feeds

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -20,6 +20,12 @@ class PackagesController < ApplicationController
 
     @pagy, @packages = pagy_countless(scope)
     fresh_when(@packages, public: true)
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def recent_versions_data
@@ -35,6 +41,12 @@ class PackagesController < ApplicationController
     @package = find_package_with_normalization!(@registry, params[:id])
     @pagy, @versions = pagy_countless(@package.versions.order('published_at DESC, created_at DESC'))
     fresh_when(@package, public: true)
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def dependent_packages

--- a/app/views/packages/index.atom.builder
+++ b/app/views/packages/index.atom.builder
@@ -1,0 +1,17 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title "#{@registry.name} packages"
+  xml.id registry_packages_url(@registry)
+  xml.link href: registry_packages_url(@registry)
+  xml.link href: registry_packages_url(@registry, format: :atom), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@packages.first&.updated_at || Time.current).iso8601)
+  @packages.each do |package|
+    xml.entry do
+      xml.title package.name
+      xml.id registry_package_url(@registry, package)
+      xml.link href: registry_package_url(@registry, package)
+      xml.updated((package.updated_at || Time.current).iso8601)
+      xml.summary package.description if package.description.present?
+    end
+  end
+end

--- a/app/views/packages/index.html.erb
+++ b/app/views/packages/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, registry_packages_url(@registry, request.query_parameters.merge(format: :rss)), title: "Package List RSS") %>
+  <%= auto_discovery_link_tag(:atom, registry_packages_url(@registry, request.query_parameters.merge(format: :atom)), title: "Package List Atom") %>
+<% end %>
+
 <% @meta_title = "#{@registry} packages" %>
 <% @meta_description = "View the packages on the #{@registry} package registry, including their maintainers, namespaces, and keywords." %>
 

--- a/app/views/packages/index.rss.builder
+++ b/app/views/packages/index.rss.builder
@@ -1,0 +1,18 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title "#{@registry.name} packages"
+    xml.description "Latest packages for #{@registry.name}"
+    xml.link registry_packages_url(@registry)
+    xml.language 'en'
+    @packages.each do |package|
+      xml.item do
+        xml.title package.name
+        xml.description package.description if package.description.present?
+        xml.link registry_package_url(@registry, package)
+        xml.guid registry_package_url(@registry, package), isPermaLink: true
+        xml.pubDate(package.updated_at.rfc2822) if package.updated_at.present?
+      end
+    end
+  end
+end

--- a/app/views/packages/show.atom.builder
+++ b/app/views/packages/show.atom.builder
@@ -1,0 +1,16 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title "#{@package.name} versions"
+  xml.id registry_package_url(@registry, @package)
+  xml.link href: registry_package_url(@registry, @package)
+  xml.link href: registry_package_url(@registry, @package, format: :atom), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@versions.first&.published_at || @versions.first&.created_at || Time.current).iso8601)
+  @versions.each do |version|
+    xml.entry do
+      xml.title version.number
+      xml.id registry_package_version_url(@registry, @package, version)
+      xml.link href: registry_package_version_url(@registry, @package, version)
+      xml.updated((version.published_at || version.created_at || Time.current).iso8601)
+    end
+  end
+end

--- a/app/views/packages/show.html.erb
+++ b/app/views/packages/show.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, registry_package_url(@registry, @package, format: :rss), title: "Package Versions RSS") %>
+  <%= auto_discovery_link_tag(:atom, registry_package_url(@registry, @package, format: :atom), title: "Package Versions Atom") %>
+<% end %>
+
 <% @meta_description = @package.description_with_fallback %>
 <% @meta_title = "#{@package.name} | #{@registry.name}" %>
 

--- a/app/views/packages/show.rss.builder
+++ b/app/views/packages/show.rss.builder
@@ -1,0 +1,17 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title "#{@package.name} versions"
+    xml.description "Latest versions for #{@package.name}"
+    xml.link registry_package_url(@registry, @package)
+    xml.language 'en'
+    @versions.each do |version|
+      xml.item do
+        xml.title version.number
+        xml.link registry_package_version_url(@registry, @package, version)
+        xml.guid registry_package_version_url(@registry, @package, version), isPermaLink: true
+        xml.pubDate((version.published_at || version.created_at).rfc2822) if (version.published_at || version.created_at)
+      end
+    end
+  end
+end

--- a/test/controllers/packages_controller_test.rb
+++ b/test/controllers/packages_controller_test.rb
@@ -18,6 +18,41 @@ class PackagesControllerTest < ActionDispatch::IntegrationTest
     assert_template 'packages/show', file: 'packages/show.html.erb'
   end
 
+
+  test 'package list provides RSS and Atom discovery links' do
+    get registry_packages_path(registry_id: @registry.name)
+
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"]'
+    assert_select 'link[rel="alternate"][type="application/atom+xml"]'
+  end
+
+  test 'renders package list RSS feed' do
+    get registry_packages_path(registry_id: @registry.name, format: :rss)
+
+    assert_response :success
+    assert_equal 'application/rss+xml', response.media_type
+    assert_includes response.body, '<rss'
+    assert_includes response.body, @package.name
+  end
+
+  test 'renders package list Atom feed' do
+    get registry_packages_path(registry_id: @registry.name, format: :atom)
+
+    assert_response :success
+    assert_equal 'application/atom+xml', response.media_type
+    assert_includes response.body, '<feed'
+    assert_includes response.body, @package.name
+  end
+
+  test 'package page provides RSS and Atom discovery links' do
+    get registry_package_path(registry_id: @registry.name, id: @package.name)
+
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"]'
+    assert_select 'link[rel="alternate"][type="application/atom+xml"]'
+  end
+
   test 'list packages for a nixpkgs registry' do
     nix_registry = Registry.create(name: 'nixpkgs-23.05', url: 'https://channels.nixos.org/nixos-23.05', ecosystem: 'nixpkgs', version: '23.05')
     nix_registry.packages.create(ecosystem: 'nixpkgs', name: 'python313Packages.numpy', metadata: { 'position' => 'pkgs/development/python-modules/numpy/2.nix:205' })


### PR DESCRIPTION
Refs #334

## Summary
- adds RSS and Atom feed responses for registry package list pages
- adds RSS and Atom feed responses for package version list pages
- adds feed auto-discovery links in the HTML head for both pages
- adds controller coverage for discovery links and feed responses

## Validation
- `ruby -c app/controllers/packages_controller.rb`
- `ruby -c app/views/packages/index.rss.builder`
- `ruby -c app/views/packages/index.atom.builder`
- `ruby -c app/views/packages/show.rss.builder`
- `ruby -c app/views/packages/show.atom.builder`
- `ruby -c test/controllers/packages_controller_test.rb`
- `git diff --check`

Full controller test execution is locally blocked because the lockfile requires Bundler 4.0.10 and this system Ruby cannot activate it.