### PR TITLE
Add Amazon ECR Public package support

### DIFF
--- a/app/models/ecosystem/docker.rb
+++ b/app/models/ecosystem/docker.rb
@@ -3,8 +3,12 @@
 module Ecosystem
   class Docker < Base
 
+    ECR_PUBLIC_API_URL = "https://api.us-east-1.gallery.ecr.aws"
+
     def registry_url(package, version = nil)
-      if version && version['metadata']['images'].present?
+      if ecr_public_registry?
+        "https://gallery.ecr.aws/#{package.name}"
+      elsif version && version['metadata']['images'].present?
         "https://hub.docker.com/layers/#{package.name}/#{version['number']}/images/#{version['metadata']['images'].first['digest']}"
       else
         "https://hub.docker.com/r/#{package.name}"
@@ -12,12 +16,13 @@ module Ecosystem
     end
 
     def install_command(package, version = nil)
-      "docker pull #{package.name}" + (version ? ":#{version}" : "")
+      image_name = ecr_public_registry? ? "public.ecr.aws/#{package.name}" : package.name
+      "docker pull #{image_name}" + (version ? ":#{version}" : "")
     end
 
     def check_status(package)
       pkg = fetch_package_metadata(package.name)
-      return nil if pkg.present? && pkg.is_a?(Hash) && pkg["name"].present?
+      return nil if pkg.present? && pkg.is_a?(Hash) && (pkg["name"].present? || pkg["catalogData"].present?)
 
       # Fall back to a direct request if not cached
       url = check_status_url(package)
@@ -26,12 +31,27 @@ module Ecosystem
     end
 
     def check_status_url(package)
-      "https://hub.docker.com/v2/repositories/#{package.name}"
+      if ecr_public_registry?
+        "https://gallery.ecr.aws/#{package.name}"
+      else
+        "https://hub.docker.com/v2/repositories/#{package.name}"
+      end
     end
 
     def fetch_package_metadata_uncached(name)
-      name = "library/#{name}" if name.split('/').length == 1
-      get_json("https://hub.docker.com/v2/repositories/#{name}/")
+      if ecr_public_registry?
+        registry_alias_name, repository_name = ecr_public_package_parts(name)
+        return {} if registry_alias_name.blank? || repository_name.blank?
+
+        metadata = ecr_public_post("getRepositoryCatalogData", {
+          registryAliasName: registry_alias_name,
+          repositoryName: repository_name
+        }) || {}
+        metadata.merge("registryAliasName" => registry_alias_name, "repositoryName" => repository_name)
+      else
+        name = "library/#{name}" if name.split('/').length == 1
+        get_json("https://hub.docker.com/v2/repositories/#{name}/")
+      end
     rescue
       {}
     end
@@ -58,27 +78,39 @@ module Ecosystem
     end
 
     def all_package_names
-      official_packages = namespace_package_names('library')
-      community_packages = get_json("https://repos.ecosyste.ms/api/v1/package_names/docker")
-      (official_packages + community_packages).uniq
+      if ecr_public_registry?
+        ecr_public_search_results.map do |repository|
+          [repository["primaryRegistryAliasName"], repository["repositoryName"]].compact.join("/")
+        end.uniq
+      else
+        official_packages = namespace_package_names('library')
+        community_packages = get_json("https://repos.ecosyste.ms/api/v1/package_names/docker")
+        (official_packages + community_packages).uniq
+      end
     rescue
       []
     end
 
     def map_package_metadata(package)
-      return nil unless package && package["name"]
-      package_name = "#{package["namespace"]}/#{package["name"]}"
-      {
-        name: package_name,
-        description: package["description"],
-        repository_url: load_repository_url(package_name),
-        namespace: package["namespace"],
-        downloads: package["pull_count"],
-        downloads_period: "total",
-      }
+      if ecr_public_registry?
+        map_ecr_public_package_metadata(package)
+      else
+        return nil unless package && package["name"]
+        package_name = "#{package["namespace"]}/#{package["name"]}"
+        {
+          name: package_name,
+          description: package["description"],
+          repository_url: load_repository_url(package_name),
+          namespace: package["namespace"],
+          downloads: package["pull_count"],
+          downloads_period: "total",
+        }
+      end
     end
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      return ecr_public_versions_metadata(pkg_metadata) if ecr_public_registry?
+
       page = 1
       tags = []
       while page < 10
@@ -110,6 +142,85 @@ module Ecosystem
       return unless o
       return unless o['provider'] == 'Github'
       "https://github.com/#{o['owner']}/#{o['repository']}"
+    end
+
+    private
+
+    def ecr_public_registry?
+      registry_url.to_s.include?("gallery.ecr.aws")
+    end
+
+    def ecr_public_post(action, body)
+      response = Faraday.post("#{ECR_PUBLIC_API_URL}/#{action}") do |request|
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Accept"] = "application/json"
+        request.headers["User-Agent"] = "packages.ecosyste.ms"
+        request.body = body.to_json
+      end
+      return nil unless response.success?
+
+      Oj.load(response.body)
+    rescue
+      nil
+    end
+
+    def ecr_public_package_parts(name)
+      name.to_s.split("/", 2)
+    end
+
+    def ecr_public_search_results
+      next_token = nil
+      repositories = []
+
+      loop do
+        body = { maxResults: 100 }
+        body[:nextToken] = next_token if next_token.present?
+        response = ecr_public_post("searchRepositoryCatalogData", body)
+        break if response.blank?
+
+        repositories.concat(response["repositoryCatalogSearchResultList"] || [])
+        next_token = response["nextToken"]
+        break if next_token.blank?
+      end
+
+      repositories
+    end
+
+    def map_ecr_public_package_metadata(package)
+      catalog_data = package["catalogData"] || package
+      registry_alias_name = package["registryAliasName"] || package["primaryRegistryAliasName"]
+      repository_name = package["repositoryName"]
+      return nil if registry_alias_name.blank? || repository_name.blank?
+
+      {
+        name: "#{registry_alias_name}/#{repository_name}",
+        description: catalog_data["description"],
+        homepage: catalog_data["sourceCodeRepository"],
+        repository_url: repo_fallback(catalog_data["sourceCodeRepository"], catalog_data["aboutText"]),
+        namespace: registry_alias_name,
+        downloads: catalog_data["downloadCount"] || package["downloadCount"],
+        downloads_period: "total",
+        metadata: catalog_data.except("description", "downloadCount")
+      }
+    end
+
+    def ecr_public_versions_metadata(pkg_metadata)
+      registry_alias_name, repository_name = ecr_public_package_parts(pkg_metadata[:name])
+      response = ecr_public_post("describeImageTags", {
+        registryAliasName: registry_alias_name,
+        repositoryName: repository_name,
+        maxResults: 100
+      })
+
+      Array(response && response["imageTagDetails"]).map do |tag|
+        {
+          number: tag["imageTag"],
+          published_at: tag["createdAt"] || tag.dig("imageDetail", "imagePushedAt"),
+          metadata: tag.except("imageTag")
+        }
+      end
+    rescue
+      []
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,7 @@ default_registries = [
   {name: 'anaconda.org', url: 'https://anaconda.org', ecosystem: 'conda', github: 'Anaconda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'}, default: true},
   {name: 'conda-forge.org', url: 'https://conda-forge.org', ecosystem: 'conda', github: 'conda-forge', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'}, default: false},
   {name: 'hub.docker.com', url: 'https://hub.docker.com', ecosystem: 'docker', github: 'docker', metadata: {api_url: 'https://registry-1.docker.io'}, default: true},
+  {name: 'gallery.ecr.aws', url: 'https://gallery.ecr.aws', ecosystem: 'docker', github: 'aws', metadata: {api_url: 'https://api.us-east-1.gallery.ecr.aws'}, default: false},
   {name: 'swiftpackageindex.com', url: 'https://swiftpackageindex.com', ecosystem: 'swiftpm', github: 'SwiftPackageIndex', default: true},
   {name: 'vcpkg.io', url: 'https://vcpkg.io', ecosystem: 'vcpkg', github: 'vcpkg', default: true},
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},

--- a/test/models/ecosystem/docker_test.rb
+++ b/test/models/ecosystem/docker_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class DockerTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(name: "Amazon ECR Public", url: "https://gallery.ecr.aws", ecosystem: "docker", default: false)
+    @ecosystem = Ecosystem::Docker.new(@registry)
+    @package = Package.new(ecosystem: "docker", name: "docker/library/busybox", namespace: "docker")
+    @version = @package.versions.build(number: "latest", metadata: { "images" => [{ "digest" => "sha256:abc" }] })
+  end
+
+  test "amazon ecr public registry_url" do
+    assert_equal "https://gallery.ecr.aws/docker/library/busybox", @ecosystem.registry_url(@package)
+  end
+
+  test "amazon ecr public install_command" do
+    assert_equal "docker pull public.ecr.aws/docker/library/busybox", @ecosystem.install_command(@package)
+    assert_equal "docker pull public.ecr.aws/docker/library/busybox:latest", @ecosystem.install_command(@package, "latest")
+  end
+
+  test "amazon ecr public package_metadata" do
+    stub_request(:post, "https://api.us-east-1.gallery.ecr.aws/getRepositoryCatalogData")
+      .with(body: { registryAliasName: "docker", repositoryName: "library/busybox" }.to_json)
+      .to_return(
+        status: 200,
+        body: {
+          catalogData: {
+            description: "Busybox base image",
+            sourceCodeRepository: "https://github.com/docker-library/busybox",
+            downloadCount: 123,
+            architectures: ["x86-64"],
+            operatingSystems: ["Linux"]
+          },
+          registryAliasName: "docker",
+          repositoryName: "library/busybox"
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    metadata = @ecosystem.package_metadata("docker/library/busybox")
+
+    assert_equal "docker/library/busybox", metadata[:name]
+    assert_equal "Busybox base image", metadata[:description]
+    assert_equal "docker", metadata[:namespace]
+    assert_equal 123, metadata[:downloads]
+    assert_equal "total", metadata[:downloads_period]
+    assert_equal "https://github.com/docker-library/busybox", metadata[:repository_url]
+  end
+
+  test "amazon ecr public versions_metadata" do
+    stub_request(:post, "https://api.us-east-1.gallery.ecr.aws/describeImageTags")
+      .with(body: { registryAliasName: "docker", repositoryName: "library/busybox", maxResults: 100 }.to_json)
+      .to_return(
+        status: 200,
+        body: {
+          imageTagDetails: [
+            {
+              imageTag: "1.36.0",
+              createdAt: "2023-05-12T03:22:40.827Z",
+              imageDetail: {
+                imageDigest: "sha256:abc",
+                imageSizeInBytes: 2_592_208
+              }
+            }
+          ]
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    versions = @ecosystem.versions_metadata({ name: "docker/library/busybox" })
+
+    assert_equal 1, versions.length
+    assert_equal "1.36.0", versions.first[:number]
+    assert_equal "2023-05-12T03:22:40.827Z", versions.first[:published_at]
+    assert_equal "sha256:abc", versions.first[:metadata]["imageDetail"]["imageDigest"]
+  end
+
+  test "amazon ecr public all_package_names" do
+    stub_request(:post, "https://api.us-east-1.gallery.ecr.aws/searchRepositoryCatalogData")
+      .with(body: { maxResults: 100 }.to_json)
+      .to_return(
+        status: 200,
+        body: {
+          repositoryCatalogSearchResultList: [
+            { primaryRegistryAliasName: "docker", repositoryName: "library/busybox" },
+            { primaryRegistryAliasName: "public", repositoryName: "eks/aws-load-balancer-controller" }
+          ]
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    assert_equal ["docker/library/busybox", "public/eks/aws-load-balancer-controller"], @ecosystem.all_package_names
+  end
+end


### PR DESCRIPTION
## Summary
- add Amazon ECR Public support to the Docker ecosystem integration
- seed `gallery.ecr.aws` as a non-default Docker registry
- map ECR Public package metadata, package names, install commands, registry URLs, and image tags via the public Gallery APIs
- add model coverage for the new ECR Public path

Refs #336

## Validation
- `ruby -c app/models/ecosystem/docker.rb`
- `ruby -c db/seeds.rb`
- `ruby -c test/models/ecosystem/docker_test.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
