### PR TITLE
Add EasyBuild package ecosystem support

### DIFF
--- a/app/models/ecosystem/easybuild.rb
+++ b/app/models/ecosystem/easybuild.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Easybuild < Base
+    REPOSITORY = "easybuilders/easybuild-easyconfigs"
+    BRANCH = "develop"
+
+    def sync_in_batches?
+      true
+    end
+
+    def has_dependent_repos?
+      false
+    end
+
+    def registry_url(package, version = nil)
+      if version&.metadata&.dig("path").present?
+        "https://github.com/#{REPOSITORY}/blob/#{BRANCH}/#{version.metadata['path']}"
+      else
+        "https://docs.easybuild.io/version-specific/supported-software/#{package.name.downcase}/"
+      end
+    end
+
+    def install_command(package, version = nil)
+      "eb #{package.name}" + (version ? "-#{version}.eb" : "")
+    end
+
+    def documentation_url(package, version = nil)
+      registry_url(package, version)
+    end
+
+    def check_status(package)
+      return "removed" if package_easyconfigs(package.name).empty?
+    end
+
+    def all_package_names
+      easyconfig_paths.map { |path| path.split("/")[-2] }.compact.uniq.sort
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      feed = SimpleRSS.parse(get_raw("https://github.com/#{REPOSITORY}/commits/#{BRANCH}.atom"))
+      feed.items.map { |item| item.title.scan(%r{easyconfigs/[a-z0-9]/([^/]+)/}).flatten }.flatten.uniq
+    rescue
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      paths = package_easyconfigs(name)
+      latest_path = paths.max_by { |path| version_from_path(path, name).to_s }
+      return {} if latest_path.blank?
+
+      easyconfig = fetch_easyconfig(latest_path)
+      parse_easyconfig(easyconfig).merge("name" => name, "path" => latest_path, "paths" => paths)
+    rescue
+      {}
+    end
+
+    def map_package_metadata(package)
+      return false if package["name"].blank?
+
+      {
+        name: package["name"],
+        description: package["description"],
+        homepage: package["homepage"],
+        repository_url: repo_fallback(package["homepage"], package["homepage"]),
+        licenses: Array(package["license"]),
+        metadata: {
+          easyblock: package["easyblock"],
+          toolchain: package["toolchain"],
+          easyconfig_path: package["path"]
+        }.compact,
+        versions: package["paths"]
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      Array(pkg_metadata[:versions]).map do |path|
+        version = version_from_path(path, pkg_metadata[:name])
+        next if version.blank?
+
+        metadata = parse_easyconfig(fetch_easyconfig(path))
+        {
+          number: version,
+          metadata: {
+            path: path,
+            toolchain: metadata["toolchain"],
+            versionsuffix: metadata["versionsuffix"],
+            source_urls: metadata["source_urls"],
+            sources: metadata["sources"]
+          }.compact
+        }
+      end.compact
+    rescue
+      []
+    end
+
+    def dependencies_metadata(name, version, package)
+      path = version&.metadata&.dig("path")
+      return [] if path.blank?
+
+      metadata = parse_easyconfig(fetch_easyconfig(path))
+      Array(metadata["dependencies"]).map do |dependency|
+        {
+          package_name: dependency,
+          requirements: "*",
+          kind: "runtime",
+          ecosystem: self.class.name.demodulize.downcase
+        }
+      end
+    rescue
+      []
+    end
+
+    private
+
+    def easyconfig_paths
+      @easyconfig_paths ||= begin
+        tree = get_json("https://api.github.com/repos/#{REPOSITORY}/git/trees/#{BRANCH}?recursive=1")
+        Array(tree["tree"]).map { |node| node["path"] }.select { |path| path.end_with?(".eb") }
+      end
+    end
+
+    def package_easyconfigs(name)
+      first = name[0].downcase
+      easyconfig_paths.select { |path| path.start_with?("easybuild/easyconfigs/#{first}/#{name}/") }
+    end
+
+    def fetch_easyconfig(path)
+      get_raw("https://raw.githubusercontent.com/#{REPOSITORY}/#{BRANCH}/#{path}")
+    end
+
+    def version_from_path(path, name)
+      file = File.basename(path, ".eb")
+      file.delete_prefix("#{name}-").split("-").first
+    end
+
+    def parse_easyconfig(content)
+      {
+        "easyblock" => string_assignment(content, "easyblock"),
+        "name" => string_assignment(content, "name"),
+        "version" => string_assignment(content, "version"),
+        "versionsuffix" => string_assignment(content, "versionsuffix"),
+        "homepage" => string_assignment(content, "homepage"),
+        "description" => string_assignment(content, "description"),
+        "license" => string_assignment(content, "license"),
+        "toolchain" => hash_assignment(content, "toolchain"),
+        "source_urls" => list_assignment(content, "source_urls"),
+        "sources" => list_assignment(content, "sources"),
+        "dependencies" => dependencies_assignment(content)
+      }.compact
+    end
+
+    def string_assignment(content, name)
+      content[/^#{name}\s*=\s*(['"])(.*?)\1/m, 2] || content[/^#{name}\s*=\s*"""(.*?)"""/m, 1]&.strip
+    end
+
+    def hash_assignment(content, name)
+      body = content[/^#{name}\s*=\s*\{([^\n]+)\}/, 1]
+      return nil if body.blank?
+
+      body.scan(/['"]([^'"]+)['"]\s*:\s*['"]([^'"]+)['"]/).to_h
+    end
+
+    def list_assignment(content, name)
+      body = content[/^#{name}\s*=\s*\[(.*?)\]/m, 1]
+      return [] if body.blank?
+
+      body.scan(/['"]([^'"]+)['"]/).flatten
+    end
+
+    def dependencies_assignment(content)
+      body = content[/^dependencies\s*=\s*\[(.*?)\]/m, 1]
+      return [] if body.blank?
+
+      body.scan(/\(\s*['"]([^'"]+)['"]/).flatten.uniq
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@ default_registries = [
   {name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems', github: 'rubygems', default: true},
   {name: 'gem.coop', url: 'https://gem.coop', ecosystem: 'rubygems', github: 'gem-coop', default: false},
   {name: 'spack.io', url: 'https://packages.spack.io', ecosystem: 'spack', github: 'spack', default: true},
+  {name: 'docs.easybuild.io', url: 'https://docs.easybuild.io', ecosystem: 'easybuild', github: 'easybuilders', default: true},
   {name: 'hackage.haskell.org', url: 'https://hackage.haskell.org', ecosystem: 'hackage', github: 'haskell-infra', default: true},
   {name: 'cran.r-project.org', url: 'https://cran.r-project.org', ecosystem: 'cran', github: 'r-project-org', metadata: {'icon_url' => 'https://cran.r-project.org/CRANlogo.png'}, default: true},
   {name: 'f-droid.org', url: 'https://f-droid.org', ecosystem: 'fdroid', github: 'f-droid', default: true},

--- a/test/models/ecosystem/easybuild_test.rb
+++ b/test/models/ecosystem/easybuild_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class EasybuildTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(name: "docs.easybuild.io", url: "https://docs.easybuild.io", ecosystem: "easybuild", default: true)
+    @ecosystem = Ecosystem::Easybuild.new(@registry)
+    @package = Package.new(ecosystem: "easybuild", name: "zlib")
+    @version = @package.versions.build(number: "1.3.1", metadata: { "path" => "easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-13.2.0.eb" })
+  end
+
+  test "registry_url" do
+    assert_equal "https://docs.easybuild.io/version-specific/supported-software/zlib/", @ecosystem.registry_url(@package)
+  end
+
+  test "registry_url with version" do
+    assert_equal "https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-13.2.0.eb", @ecosystem.registry_url(@package, @version)
+  end
+
+  test "install_command" do
+    assert_equal "eb zlib", @ecosystem.install_command(@package)
+    assert_equal "eb zlib-1.3.1.eb", @ecosystem.install_command(@package, "1.3.1")
+  end
+
+  test "all_package_names" do
+    @ecosystem.stubs(:get_json).returns(
+      "tree" => [
+        { "path" => "easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-13.2.0.eb" },
+        { "path" => "easybuild/easyconfigs/r/Redis/Redis-7.2.4-GCCcore-13.2.0.eb" },
+        { "path" => "README.md" }
+      ]
+    )
+
+    assert_equal ["Redis", "zlib"], @ecosystem.all_package_names
+  end
+
+  test "package_metadata" do
+    stub_tree
+    stub_easyconfig("zlib-1.3.1-GCCcore-13.2.0.eb", easyconfig_content)
+
+    metadata = @ecosystem.package_metadata("zlib")
+
+    assert_equal "zlib", metadata[:name]
+    assert_equal "A free, general-purpose data compression library.", metadata[:description]
+    assert_equal "https://zlib.net/", metadata[:homepage]
+    assert_equal "Zlib", metadata[:metadata][:easyblock]
+    assert_equal({ "name" => "GCCcore", "version" => "13.2.0" }, metadata[:metadata][:toolchain])
+  end
+
+  test "versions_metadata" do
+    stub_easyconfig("zlib-1.3.1-GCCcore-13.2.0.eb", easyconfig_content)
+
+    versions = @ecosystem.versions_metadata({ name: "zlib", versions: ["easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-13.2.0.eb"] })
+
+    assert_equal 1, versions.length
+    assert_equal "1.3.1", versions.first[:number]
+    assert_equal "easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-13.2.0.eb", versions.first[:metadata][:path]
+    assert_equal({ "name" => "GCCcore", "version" => "13.2.0" }, versions.first[:metadata][:toolchain])
+  end
+
+  test "dependencies_metadata" do
+    stub_easyconfig("zlib-1.3.1-GCCcore-13.2.0.eb", easyconfig_content)
+
+    dependencies = @ecosystem.dependencies_metadata("zlib", @version, @package)
+
+    assert_equal ["binutils"], dependencies.map { |dependency| dependency[:package_name] }
+    assert_equal "runtime", dependencies.first[:kind]
+    assert_equal "easybuild", dependencies.first[:ecosystem]
+  end
+
+  private
+
+  def stub_tree
+    @ecosystem.stubs(:get_json).returns(
+      "tree" => [
+        { "path" => "easybuild/easyconfigs/z/zlib/zlib-1.2.13-GCCcore-12.3.0.eb" },
+        { "path" => "easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-13.2.0.eb" }
+      ]
+    )
+  end
+
+  def stub_easyconfig(file, body)
+    stub_request(:get, "https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/z/zlib/#{file}")
+      .to_return(status: 200, body: body)
+  end
+
+  def easyconfig_content
+    <<~EASYCONFIG
+      easyblock = 'Zlib'
+      name = 'zlib'
+      version = '1.3.1'
+      homepage = 'https://zlib.net/'
+      description = """A free, general-purpose data compression library."""
+      toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+      source_urls = ['https://zlib.net/fossils/']
+      sources = ['%(name)s-%(version)s.tar.gz']
+      dependencies = [
+          ('binutils', '2.40'),
+      ]
+    EASYCONFIG
+  end
+end


### PR DESCRIPTION
## Summary
- add an EasyBuild ecosystem adapter backed by the easybuilders/easybuild-easyconfigs repository
- maps supported package names from easyconfig paths
- maps package metadata, versions, source metadata, dependencies, registry/documentation URLs, and install commands
- seeds `docs.easybuild.io` as the default EasyBuild registry
- adds model coverage for package discovery, metadata, versions, dependencies, URLs, and install commands

Refs #659

## Validation
- `ruby -c app/models/ecosystem/easybuild.rb`
- `ruby -c db/seeds.rb`
- `ruby -c test/models/ecosystem/easybuild_test.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
