### PR TITLE
Add winget package ecosystem support

### DIFF
--- a/app/models/ecosystem/winget.rb
+++ b/app/models/ecosystem/winget.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Winget < Base
+    REPOSITORY = "microsoft/winget-pkgs"
+    BRANCH = "master"
+
+    def sync_in_batches?
+      true
+    end
+
+    def has_dependent_repos?
+      false
+    end
+
+    def registry_url(package, version = nil)
+      if version&.metadata&.dig("path").present?
+        "https://github.com/#{REPOSITORY}/tree/#{BRANCH}/#{version.metadata['path']}"
+      else
+        "https://github.com/#{REPOSITORY}/tree/#{BRANCH}/#{package_path(package.name)}"
+      end
+    end
+
+    def install_command(package, version = nil)
+      "winget install --id #{package.name}" + (version ? " --version #{version}" : "")
+    end
+
+    def documentation_url(package, version = nil)
+      registry_url(package, version)
+    end
+
+    def check_status(package)
+      return "removed" if package_versions(package.name).empty?
+    end
+
+    def all_package_names
+      manifest_paths.map { |path| identifier_from_path(path) }.compact.uniq.sort
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      feed = SimpleRSS.parse(get_raw("https://github.com/#{REPOSITORY}/commits/#{BRANCH}.atom"))
+      feed.items.map { |item| item.title.scan(/Manifests\/[^:]+:\s+([^\s]+)/).flatten }.flatten.uniq
+    rescue
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      versions = package_versions(name)
+      latest_path = versions.max_by { |path| File.basename(path) }
+      return {} if latest_path.blank?
+
+      metadata = fetch_version_manifest(name, latest_path)
+      metadata.merge("name" => name, "path" => latest_path, "paths" => versions)
+    rescue
+      {}
+    end
+
+    def map_package_metadata(package)
+      return false if package["name"].blank?
+
+      {
+        name: package["name"],
+        description: package["Description"] || package["ShortDescription"],
+        homepage: package["PackageUrl"] || package["PublisherUrl"],
+        repository_url: repo_fallback(package["PackageUrl"], package["PublisherUrl"]),
+        licenses: Array(package["License"]),
+        keywords_array: Array(package["Tags"]),
+        metadata: {
+          publisher: package["Publisher"],
+          moniker: package["Moniker"],
+          manifest_path: package["path"]
+        }.compact,
+        versions: package["paths"]
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      Array(pkg_metadata[:versions]).map do |path|
+        metadata = fetch_version_manifest(pkg_metadata[:name], path)
+        version = metadata["PackageVersion"] || File.basename(path)
+        {
+          number: version,
+          metadata: {
+            path: path,
+            manifest_version: metadata["ManifestVersion"],
+            installer_type: metadata["InstallerType"],
+            scope: metadata["Scope"]
+          }.compact
+        }
+      end
+    rescue
+      []
+    end
+
+    private
+
+    def manifest_paths
+      @manifest_paths ||= begin
+        tree = get_json("https://api.github.com/repos/#{REPOSITORY}/git/trees/#{BRANCH}?recursive=1")
+        Array(tree["tree"]).map { |node| node["path"] }.select { |path| path.end_with?(".yaml") && path.start_with?("manifests/") }
+      end
+    end
+
+    def package_path(name)
+      parts = name.split(".")
+      first = parts.first.to_s[0].downcase
+      (["manifests", first] + parts).join("/")
+    end
+
+    def package_versions(name)
+      prefix = package_path(name)
+      manifest_paths.select do |path|
+        path.start_with?("#{prefix}/") && path.end_with?("#{name}.yaml")
+      end.map { |path| File.dirname(path) }.uniq
+    end
+
+    def identifier_from_path(path)
+      File.basename(path, ".yaml") if path.match?(%r{/[^/]+/[^/]+\.yaml\z})
+    end
+
+    def fetch_version_manifest(name, path)
+      base = path.delete_suffix("/")
+      version_manifest = fetch_yaml("#{base}/#{name}.yaml")
+      locale_manifest = fetch_first_yaml("#{base}/#{name}.locale.*.yaml")
+      installer_manifest = fetch_first_yaml("#{base}/#{name}.installer.yaml")
+      version_manifest.merge(locale_manifest).merge(installer_manifest)
+    end
+
+    def fetch_first_yaml(pattern)
+      path = manifest_paths.find { |manifest_path| File.fnmatch(pattern, manifest_path) }
+      path ? fetch_yaml(path) : {}
+    end
+
+    def fetch_yaml(path)
+      YAML.safe_load(get_raw("https://raw.githubusercontent.com/#{REPOSITORY}/#{BRANCH}/#{path}")) || {}
+    rescue
+      {}
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,6 +37,7 @@ default_registries = [
   {name: 'hub.docker.com', url: 'https://hub.docker.com', ecosystem: 'docker', github: 'docker', metadata: {api_url: 'https://registry-1.docker.io'}, default: true},
   {name: 'swiftpackageindex.com', url: 'https://swiftpackageindex.com', ecosystem: 'swiftpm', github: 'SwiftPackageIndex', default: true},
   {name: 'vcpkg.io', url: 'https://vcpkg.io', ecosystem: 'vcpkg', github: 'vcpkg', default: true},
+  {name: 'winget-pkgs', url: 'https://github.com/microsoft/winget-pkgs', ecosystem: 'winget', github: 'microsoft', default: true},
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},
   {name: "carthage", url: "https://github.com/Carthage/Carthage", ecosystem: "carthage", github: "Carthage", default: true},
   {name: 'github actions', url: 'https://github.com/marketplace/actions/', ecosystem: 'actions', github: 'actions', default: true},

--- a/test/models/ecosystem/winget_test.rb
+++ b/test/models/ecosystem/winget_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class WingetTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(name: "winget-pkgs", url: "https://github.com/microsoft/winget-pkgs", ecosystem: "winget", default: true)
+    @ecosystem = Ecosystem::Winget.new(@registry)
+    @package = Package.new(ecosystem: "winget", name: "Microsoft.VisualStudioCode")
+    @version = @package.versions.build(number: "1.90.0", metadata: { "path" => "manifests/m/Microsoft/VisualStudioCode/1.90.0" })
+  end
+
+  test "registry_url" do
+    assert_equal "https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Microsoft/VisualStudioCode", @ecosystem.registry_url(@package)
+  end
+
+  test "registry_url with version" do
+    assert_equal "https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Microsoft/VisualStudioCode/1.90.0", @ecosystem.registry_url(@package, @version)
+  end
+
+  test "install_command" do
+    assert_equal "winget install --id Microsoft.VisualStudioCode", @ecosystem.install_command(@package)
+    assert_equal "winget install --id Microsoft.VisualStudioCode --version 1.90.0", @ecosystem.install_command(@package, "1.90.0")
+  end
+
+  test "all_package_names" do
+    stub_tree
+
+    assert_equal ["Microsoft.VisualStudioCode"], @ecosystem.all_package_names
+  end
+
+  test "package_metadata" do
+    stub_tree
+    stub_manifests
+
+    metadata = @ecosystem.package_metadata("Microsoft.VisualStudioCode")
+
+    assert_equal "Microsoft.VisualStudioCode", metadata[:name]
+    assert_equal "Code editing. Redefined.", metadata[:description]
+    assert_equal "https://code.visualstudio.com/", metadata[:homepage]
+    assert_equal ["MIT"], metadata[:licenses]
+    assert_equal "Microsoft Corporation", metadata[:metadata][:publisher]
+  end
+
+  test "versions_metadata" do
+    stub_tree
+    stub_manifests
+
+    versions = @ecosystem.versions_metadata({ name: "Microsoft.VisualStudioCode", versions: ["manifests/m/Microsoft/VisualStudioCode/1.90.0"] })
+
+    assert_equal 1, versions.length
+    assert_equal "1.90.0", versions.first[:number]
+    assert_equal "manifests/m/Microsoft/VisualStudioCode/1.90.0", versions.first[:metadata][:path]
+    assert_equal "1.6.0", versions.first[:metadata][:manifest_version]
+  end
+
+  private
+
+  def stub_tree
+    @ecosystem.stubs(:get_json).returns(
+      "tree" => [
+        { "path" => "manifests/m/Microsoft/VisualStudioCode/1.90.0/Microsoft.VisualStudioCode.yaml" },
+        { "path" => "manifests/m/Microsoft/VisualStudioCode/1.90.0/Microsoft.VisualStudioCode.locale.en-US.yaml" },
+        { "path" => "manifests/m/Microsoft/VisualStudioCode/1.90.0/Microsoft.VisualStudioCode.installer.yaml" },
+        { "path" => "README.md" }
+      ]
+    )
+  end
+
+  def stub_manifests
+    base = "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests/m/Microsoft/VisualStudioCode/1.90.0"
+    stub_request(:get, "#{base}/Microsoft.VisualStudioCode.yaml")
+      .to_return(status: 200, body: <<~YAML)
+        PackageIdentifier: Microsoft.VisualStudioCode
+        PackageVersion: 1.90.0
+        DefaultLocale: en-US
+        ManifestVersion: 1.6.0
+      YAML
+    stub_request(:get, "#{base}/Microsoft.VisualStudioCode.locale.en-US.yaml")
+      .to_return(status: 200, body: <<~YAML)
+        PackageIdentifier: Microsoft.VisualStudioCode
+        PackageVersion: 1.90.0
+        PackageLocale: en-US
+        Publisher: Microsoft Corporation
+        PackageName: Microsoft Visual Studio Code
+        License: MIT
+        ShortDescription: Code editing. Redefined.
+        PackageUrl: https://code.visualstudio.com/
+        Tags:
+          - editor
+          - vscode
+        ManifestVersion: 1.6.0
+      YAML
+    stub_request(:get, "#{base}/Microsoft.VisualStudioCode.installer.yaml")
+      .to_return(status: 200, body: <<~YAML)
+        PackageIdentifier: Microsoft.VisualStudioCode
+        PackageVersion: 1.90.0
+        InstallerType: exe
+        Scope: user
+        ManifestVersion: 1.6.0
+      YAML
+  end
+end


### PR DESCRIPTION
## Summary
- add a winget ecosystem adapter backed by the microsoft/winget-pkgs manifest repository
- maps package names from manifest paths and reads version, locale, and installer manifests
- maps package metadata, versions, registry/documentation URLs, install commands, and status checks
- seeds `winget-pkgs` as the default winget registry
- adds model coverage for package discovery, metadata, versions, URLs, and install commands

Refs #658

## Validation
- `ruby -c app/models/ecosystem/winget.rb`
- `ruby -c db/seeds.rb`
- `ruby -c test/models/ecosystem/winget_test.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
