### PR TITLE
Add WordPress plugin ecosystem support

### DIFF
--- a/app/models/ecosystem/wordpress.rb
+++ b/app/models/ecosystem/wordpress.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Wordpress < Base
+    API_URL = "https://api.wordpress.org/plugins/info/1.2/".freeze
+
+    def registry_url(package, _version = nil)
+      "https://wordpress.org/plugins/#{package.name}/"
+    end
+
+    def download_url(package, version = nil)
+      metadata = fetch_package_metadata(package.name)
+      return metadata["download_link"] if version.blank?
+
+      metadata.dig("versions", version.to_s)
+    end
+
+    def documentation_url(package, _version = nil)
+      registry_url(package)
+    end
+
+    def install_command(package, _version = nil)
+      "wp plugin install #{package.name}"
+    end
+
+    def check_status(package)
+      pkg = fetch_package_metadata(package.name)
+      return nil if pkg.present? && pkg.is_a?(Hash) && pkg["slug"].present?
+
+      "removed"
+    end
+
+    def all_package_names
+      query_plugins(page: 1, per_page: 250).map { |plugin| plugin["slug"] }.compact
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      query_plugins(page: 1, per_page: 100, browse: "updated").map { |plugin| plugin["slug"] }.compact
+    rescue
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      request = URI.encode_www_form(
+        "action" => "plugin_information",
+        "request[slug]" => name,
+        "request[fields][versions]" => 1
+      )
+      get_json("#{API_URL}?#{request}")
+    rescue
+      nil
+    end
+
+    def map_package_metadata(package)
+      return false unless package.present?
+
+      {
+        name: package["slug"],
+        description: package["short_description"].presence || package["name"],
+        homepage: package["homepage"].presence || registry_url(Package.new(name: package["slug"])),
+        repository_url: repo_fallback(package["homepage"], registry_url(Package.new(name: package["slug"]))),
+        keywords_array: Array.wrap(package["tags"]).map { |tag| tag.is_a?(Array) ? tag.first : tag }.compact,
+        licenses: "Unknown",
+        downloads: package["downloaded"],
+        downloads_period: "total",
+        versions: package["versions"]&.keys || [],
+        metadata: {
+          "author" => package["author"],
+          "author_profile" => package["author_profile"],
+          "requires" => package["requires"],
+          "requires_php" => package["requires_php"],
+          "tested" => package["tested"],
+          "rating" => package["rating"],
+          "active_installs" => package["active_installs"]
+        }
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      pkg_metadata[:versions]
+        .reject { |version| existing_version_numbers.include?(version) }
+        .map do |version|
+          {
+            number: version,
+            published_at: nil,
+            licenses: pkg_metadata[:licenses],
+            metadata: pkg_metadata[:metadata]
+          }
+        end
+    end
+
+    private
+
+    def query_plugins(options = {})
+      params = {
+        "action" => "query_plugins",
+        "request[page]" => options[:page] || 1,
+        "request[per_page]" => options[:per_page] || 100,
+        "request[fields][description]" => 0,
+        "request[fields][sections]" => 0,
+        "request[fields][versions]" => 0
+      }
+      params["request[browse]"] = options[:browse] if options[:browse]
+
+      response = get_json("#{API_URL}?#{URI.encode_www_form(params)}")
+      response["plugins"] || []
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,7 @@ default_registries = [
   {name: 'anaconda.org', url: 'https://anaconda.org', ecosystem: 'conda', github: 'Anaconda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'}, default: true},
   {name: 'conda-forge.org', url: 'https://conda-forge.org', ecosystem: 'conda', github: 'conda-forge', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'}, default: false},
   {name: 'hub.docker.com', url: 'https://hub.docker.com', ecosystem: 'docker', github: 'docker', metadata: {api_url: 'https://registry-1.docker.io'}, default: true},
+  {name: 'wordpress.org/plugins', url: 'https://wordpress.org/plugins', ecosystem: 'wordpress', github: 'wordpress', default: true},
   {name: 'swiftpackageindex.com', url: 'https://swiftpackageindex.com', ecosystem: 'swiftpm', github: 'SwiftPackageIndex', default: true},
   {name: 'vcpkg.io', url: 'https://vcpkg.io', ecosystem: 'vcpkg', github: 'vcpkg', default: true},
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},

--- a/test/models/ecosystem/wordpress_test.rb
+++ b/test/models/ecosystem/wordpress_test.rb
@@ -1,0 +1,123 @@
+require "test_helper"
+
+class WordpressTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'wordpress.org/plugins', url: 'https://wordpress.org/plugins', ecosystem: 'wordpress')
+    @ecosystem = Ecosystem::Wordpress.new(@registry)
+    @package = Package.new(ecosystem: @registry.ecosystem, name: 'akismet')
+    @version = @package.versions.build(number: '5.5')
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://wordpress.org/plugins/akismet/', @ecosystem.registry_url(@package)
+  end
+
+  test 'registry_url with version' do
+    assert_equal 'https://wordpress.org/plugins/akismet/', @ecosystem.registry_url(@package, @version)
+  end
+
+  test 'documentation_url' do
+    assert_equal 'https://wordpress.org/plugins/akismet/', @ecosystem.documentation_url(@package)
+  end
+
+  test 'install_command' do
+    assert_equal 'wp plugin install akismet', @ecosystem.install_command(@package)
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:wordpress/akismet', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, %r{https://api.wordpress.org/plugins/info/1.2/\?.*action=query_plugins.*})
+      .to_return({ status: 200, body: wordpress_query_response })
+
+    assert_equal ['akismet', 'classic-editor'], @ecosystem.all_package_names
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, %r{https://api.wordpress.org/plugins/info/1.2/\?.*action=query_plugins.*request%5Bbrowse%5D=updated.*})
+      .to_return({ status: 200, body: wordpress_query_response })
+
+    assert_equal ['akismet', 'classic-editor'], @ecosystem.recently_updated_package_names
+  end
+
+  test 'package_metadata' do
+    stub_wordpress_plugin_information
+
+    metadata = @ecosystem.package_metadata('akismet')
+
+    assert_equal 'akismet', metadata[:name]
+    assert_equal 'Spam protection for WordPress.', metadata[:description]
+    assert_equal 'https://akismet.com/', metadata[:homepage]
+    assert_equal 'https://akismet.com/', metadata[:repository_url]
+    assert_equal ['spam', 'security'], metadata[:keywords_array]
+    assert_equal 'Unknown', metadata[:licenses]
+    assert_equal 123456, metadata[:downloads]
+    assert_equal 'total', metadata[:downloads_period]
+    assert_equal ['5.5', '5.4'], metadata[:versions]
+    assert_equal 'Automattic', metadata[:metadata]['author']
+  end
+
+  test 'download_url' do
+    stub_wordpress_plugin_information
+
+    assert_equal 'https://downloads.wordpress.org/plugin/akismet.5.5.zip', @ecosystem.download_url(@package)
+    assert_equal 'https://downloads.wordpress.org/plugin/akismet.5.5.zip', @ecosystem.download_url(@package, '5.5')
+  end
+
+  test 'versions_metadata' do
+    stub_wordpress_plugin_information
+
+    metadata = @ecosystem.package_metadata('akismet')
+    versions = @ecosystem.versions_metadata(metadata, ['5.4'])
+
+    assert_equal 1, versions.length
+    assert_equal '5.5', versions.first[:number]
+    assert_equal 'Unknown', versions.first[:licenses]
+  end
+
+  private
+
+  def stub_wordpress_plugin_information
+    stub_request(:get, %r{https://api.wordpress.org/plugins/info/1.2/\?.*action=plugin_information.*request%5Bslug%5D=akismet.*})
+      .to_return({ status: 200, body: wordpress_plugin_information })
+  end
+
+  def wordpress_query_response
+    {
+      plugins: [
+        { slug: 'akismet' },
+        { slug: 'classic-editor' }
+      ]
+    }.to_json
+  end
+
+  def wordpress_plugin_information
+    {
+      slug: 'akismet',
+      name: 'Akismet Anti-spam',
+      short_description: 'Spam protection for WordPress.',
+      homepage: 'https://akismet.com/',
+      author: 'Automattic',
+      author_profile: 'https://profiles.wordpress.org/automattic/',
+      requires: '5.8',
+      requires_php: '7.2',
+      tested: '6.8',
+      rating: 96,
+      active_installs: 5_000_000,
+      downloaded: 123456,
+      download_link: 'https://downloads.wordpress.org/plugin/akismet.5.5.zip',
+      tags: {
+        spam: 'spam',
+        security: 'security'
+      },
+      versions: {
+        '5.5' => 'https://downloads.wordpress.org/plugin/akismet.5.5.zip',
+        '5.4' => 'https://downloads.wordpress.org/plugin/akismet.5.4.zip'
+      }
+    }.to_json
+  end
+end


### PR DESCRIPTION
## Summary
- add a WordPress plugin ecosystem adapter backed by the wordpress.org plugin API
- support registry/documentation/download URLs, WP-CLI install command, package lookup, package lists, recently updated packages, and version metadata
- seed wordpress.org/plugins as the default WordPress registry
- add model coverage for URLs, purl, package lists, metadata, downloads, and versions

Refs #660

## Validation
- `ruby -c app/models/ecosystem/wordpress.rb`
- `ruby -c test/models/ecosystem/wordpress_test.rb`
- `ruby -c db/seeds.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
