### PR TITLE
Add Drupal module ecosystem support

### DIFF
--- a/app/models/ecosystem/drupal.rb
+++ b/app/models/ecosystem/drupal.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Drupal < Base
+    API_URL = "https://www.drupal.org/api-d7/node.json".freeze
+
+    def registry_url(package, _version = nil)
+      "https://www.drupal.org/project/#{package.name}"
+    end
+
+    def download_url(package, version = nil)
+      return nil unless version.present?
+
+      "https://ftp.drupal.org/files/projects/#{package.name}-#{version}.tar.gz"
+    end
+
+    def documentation_url(package, _version = nil)
+      registry_url(package)
+    end
+
+    def install_command(package, version = nil)
+      version_part = version ? ":#{version}" : ""
+      "composer require drupal/#{package.name}#{version_part}"
+    end
+
+    def check_status(package)
+      pkg = fetch_package_metadata(package.name)
+      return nil if pkg.present? && pkg.is_a?(Hash) && pkg["field_project_machine_name"].present?
+
+      "removed"
+    end
+
+    def all_package_names
+      fetch_modules.map { |mod| module_name(mod) }.compact
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      fetch_modules(sort: "changed", direction: "DESC").map { |mod| module_name(mod) }.compact.first(100)
+    rescue
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      response = get_json("#{API_URL}?#{URI.encode_www_form(type: 'project_module', field_project_machine_name: name)}")
+      Array.wrap(response["list"]).first
+    rescue
+      nil
+    end
+
+    def map_package_metadata(package)
+      return false unless package.present?
+
+      name = module_name(package)
+      homepage = package["url"].presence || registry_url(Package.new(name: name))
+
+      {
+        name: name,
+        description: package["body"]&.dig("value") || package["title"],
+        homepage: homepage,
+        repository_url: repo_fallback(package["field_project_repository"], homepage),
+        keywords_array: Array.wrap(package["taxonomy_vocabulary_3"]).map { |term| term["name"] || term }.compact,
+        licenses: package["field_project_license"] || "GPL-2.0-or-later",
+        downloads: package["field_project_download_count"],
+        downloads_period: "total",
+        versions: Array.wrap(package["field_project_releases"]).filter_map { |release| release["version"] || release["name"] },
+        metadata: {
+          "nid" => package["nid"],
+          "title" => package["title"],
+          "project_type" => package["field_project_type"],
+          "created" => package["created"],
+          "changed" => package["changed"],
+          "maintainers" => package["field_project_maintainers"]
+        }
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      pkg_metadata[:versions]
+        .reject { |version| existing_version_numbers.include?(version) }
+        .map do |version|
+          {
+            number: version,
+            published_at: nil,
+            licenses: pkg_metadata[:licenses],
+            metadata: pkg_metadata[:metadata]
+          }
+        end
+    end
+
+    def purl_type
+      "drupal"
+    end
+
+    def self.purl_type
+      "drupal"
+    end
+
+    private
+
+    def fetch_modules(sort: nil, direction: nil)
+      params = { type: "project_module", limit: 100 }
+      params[:sort] = sort if sort
+      params[:direction] = direction if direction
+
+      response = get_json("#{API_URL}?#{URI.encode_www_form(params)}")
+      Array.wrap(response["list"])
+    end
+
+    def module_name(package)
+      package["field_project_machine_name"].presence || package["machine_name"].presence || package["title"]&.parameterize
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,7 @@ default_registries = [
   {name: 'anaconda.org', url: 'https://anaconda.org', ecosystem: 'conda', github: 'Anaconda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'}, default: true},
   {name: 'conda-forge.org', url: 'https://conda-forge.org', ecosystem: 'conda', github: 'conda-forge', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'}, default: false},
   {name: 'hub.docker.com', url: 'https://hub.docker.com', ecosystem: 'docker', github: 'docker', metadata: {api_url: 'https://registry-1.docker.io'}, default: true},
+  {name: 'drupal.org', url: 'https://www.drupal.org', ecosystem: 'drupal', github: 'drupal', default: true},
   {name: 'swiftpackageindex.com', url: 'https://swiftpackageindex.com', ecosystem: 'swiftpm', github: 'SwiftPackageIndex', default: true},
   {name: 'vcpkg.io', url: 'https://vcpkg.io', ecosystem: 'vcpkg', github: 'vcpkg', default: true},
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},

--- a/test/models/ecosystem/drupal_test.rb
+++ b/test/models/ecosystem/drupal_test.rb
@@ -1,0 +1,125 @@
+require "test_helper"
+
+class DrupalTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'drupal.org', url: 'https://www.drupal.org', ecosystem: 'drupal')
+    @ecosystem = Ecosystem::Drupal.new(@registry)
+    @package = Package.new(ecosystem: @registry.ecosystem, name: 'views')
+    @version = @package.versions.build(number: '8.x-3.0')
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://www.drupal.org/project/views', @ecosystem.registry_url(@package)
+  end
+
+  test 'registry_url with version' do
+    assert_equal 'https://www.drupal.org/project/views', @ecosystem.registry_url(@package, @version)
+  end
+
+  test 'download_url' do
+    assert_equal 'https://ftp.drupal.org/files/projects/views-8.x-3.0.tar.gz', @ecosystem.download_url(@package, @version.number)
+  end
+
+  test 'documentation_url' do
+    assert_equal 'https://www.drupal.org/project/views', @ecosystem.documentation_url(@package)
+  end
+
+  test 'install_command' do
+    assert_equal 'composer require drupal/views', @ecosystem.install_command(@package)
+  end
+
+  test 'install_command with version' do
+    assert_equal 'composer require drupal/views:8.x-3.0', @ecosystem.install_command(@package, @version.number)
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:drupal/views', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, %r{https://www.drupal.org/api-d7/node.json\?.*type=project_module.*})
+      .to_return({ status: 200, body: drupal_list_response })
+
+    assert_equal ['views', 'token'], @ecosystem.all_package_names
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, %r{https://www.drupal.org/api-d7/node.json\?.*sort=changed.*})
+      .to_return({ status: 200, body: drupal_list_response })
+
+    assert_equal ['views', 'token'], @ecosystem.recently_updated_package_names
+  end
+
+  test 'package_metadata' do
+    stub_drupal_module_lookup
+
+    metadata = @ecosystem.package_metadata('views')
+
+    assert_equal 'views', metadata[:name]
+    assert_equal 'Create customized lists and queries from your database.', metadata[:description]
+    assert_equal 'https://www.drupal.org/project/views', metadata[:homepage]
+    assert_equal 'https://git.drupalcode.org/project/views', metadata[:repository_url]
+    assert_equal ['administration', 'fields'], metadata[:keywords_array]
+    assert_equal 'GPL-2.0-or-later', metadata[:licenses]
+    assert_equal 1234567, metadata[:downloads]
+    assert_equal 'total', metadata[:downloads_period]
+    assert_equal ['8.x-3.0', '8.x-3.1'], metadata[:versions]
+    assert_equal '1234', metadata[:metadata]['nid']
+  end
+
+  test 'versions_metadata' do
+    stub_drupal_module_lookup
+
+    metadata = @ecosystem.package_metadata('views')
+    versions = @ecosystem.versions_metadata(metadata, ['8.x-3.0'])
+
+    assert_equal 1, versions.length
+    assert_equal '8.x-3.1', versions.first[:number]
+    assert_equal 'GPL-2.0-or-later', versions.first[:licenses]
+  end
+
+  private
+
+  def stub_drupal_module_lookup
+    stub_request(:get, %r{https://www.drupal.org/api-d7/node.json\?.*field_project_machine_name=views.*})
+      .to_return({ status: 200, body: { list: [drupal_module] }.to_json })
+  end
+
+  def drupal_list_response
+    {
+      list: [
+        drupal_module,
+        drupal_module.merge('field_project_machine_name' => 'token', 'title' => 'Token')
+      ]
+    }.to_json
+  end
+
+  def drupal_module
+    {
+      'nid' => '1234',
+      'title' => 'Views',
+      'field_project_machine_name' => 'views',
+      'url' => 'https://www.drupal.org/project/views',
+      'body' => { 'value' => 'Create customized lists and queries from your database.' },
+      'field_project_repository' => 'https://git.drupalcode.org/project/views',
+      'field_project_license' => 'GPL-2.0-or-later',
+      'field_project_download_count' => 1_234_567,
+      'field_project_type' => 'module',
+      'created' => '1100000000',
+      'changed' => '1700000000',
+      'taxonomy_vocabulary_3' => [
+        { 'name' => 'administration' },
+        { 'name' => 'fields' }
+      ],
+      'field_project_releases' => [
+        { 'version' => '8.x-3.0' },
+        { 'version' => '8.x-3.1' }
+      ],
+      'field_project_maintainers' => [
+        { 'name' => 'maintainer' }
+      ]
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- add a Drupal module ecosystem adapter backed by the drupal.org JSON API
- support registry/documentation/download URLs, Composer install command, module lookup, package lists, recently updated packages, and version metadata
- seed drupal.org as the default Drupal registry
- add model coverage for URLs, purl, module lists, metadata, downloads, and versions

Refs #980

## Validation
- `ruby -c app/models/ecosystem/drupal.rb`
- `ruby -c test/models/ecosystem/drupal_test.rb`
- `ruby -c db/seeds.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
