### PR TITLE
Add OpenResty OPM ecosystem support

### DIFF
--- a/app/models/ecosystem/opm.rb
+++ b/app/models/ecosystem/opm.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Opm < Base
+    def registry_url(package, version = nil)
+      url = "#{@registry_url}/package/#{package.name}/"
+      url += "?version=#{version}" if version.present?
+      url
+    end
+
+    def download_url(package, version = nil)
+      return nil unless version.present?
+
+      owner, name = package.name.split('/', 2)
+      return nil unless owner.present? && name.present?
+
+      "#{@registry_url}/download/#{owner}/#{name}-#{version}.tar.gz"
+    end
+
+    def documentation_url(package, _version = nil)
+      registry_url(package)
+    end
+
+    def install_command(package, version = nil)
+      version_part = version ? " #{version}" : ""
+      "opm get #{package.name}#{version_part}"
+    end
+
+    def check_status(package)
+      html = fetch_package_metadata(package.name)
+      return nil if html.present?
+
+      "removed"
+    end
+
+    def all_package_names
+      package_names_from_page(get_html("#{@registry_url}/packages"))
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      all_package_names.first(100)
+    end
+
+    def fetch_package_metadata_uncached(name)
+      get_html("#{@registry_url}/package/#{name}/")
+    rescue
+      nil
+    end
+
+    def map_package_metadata(html)
+      return false unless html.present?
+
+      title = html.at_css('h2')&.text&.strip
+      account = metadata_value(html, 'Account')
+      repository_url = html.at_xpath("//h3[normalize-space()='Repo']/following-sibling::a[1]")&.[]('href')
+      name = [account, title].compact.join('/')
+
+      {
+        name: name,
+        description: html.at_css('.description p')&.text&.strip,
+        homepage: registry_url(Package.new(name: name)),
+        repository_url: repo_fallback(repository_url, nil),
+        licenses: license_from_html(html) || 'Unknown',
+        versions: html.css('.package_list .package_row .version_name').map { |node| node.text.strip }.reject(&:blank?).uniq,
+        metadata: {
+          'account' => account,
+          'repo' => repository_url,
+          'dependencies' => dependencies_from_html(html)
+        }
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      pkg_metadata[:versions]
+        .reject { |version| existing_version_numbers.include?(version) }
+        .map do |version|
+          {
+            number: version,
+            published_at: nil,
+            licenses: pkg_metadata[:licenses],
+            metadata: pkg_metadata[:metadata]
+          }
+        end
+    end
+
+    def dependencies_metadata(_name, _version, package)
+      Array.wrap(package.metadata&.dig('dependencies')).map do |dependency|
+        dep_name, requirements = dependency.split(/\s+/, 2)
+        next unless dep_name&.include?('/')
+
+        {
+          package_name: dep_name,
+          requirements: requirements.presence || '*',
+          kind: 'runtime',
+          ecosystem: self.class.name.demodulize.downcase,
+        }
+      end.compact
+    end
+
+    private
+
+    def package_names_from_page(html)
+      html.css('a.title').map { |link| link.text.strip }.reject(&:blank?).uniq
+    end
+
+    def metadata_value(html, heading)
+      node = html.at_xpath("//h3[normalize-space()='#{heading}']")
+      node&.parent&.text&.sub(heading, '')&.strip
+    end
+
+    def dependencies_from_html(html)
+      dependency_heading = html.at_xpath("//h3[normalize-space()='Dependencies']")
+      dependency_heading&.next_element&.text&.split(',')&.map(&:strip)&.reject(&:blank?) || []
+    end
+
+    def license_from_html(html)
+      license_heading = html.at_xpath("//*[self::h1 or self::h2 or self::h3][contains(translate(normalize-space(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), 'license')]")
+      license_text = license_heading&.next_element&.text&.strip
+      return nil if license_text.blank?
+
+      license_text.lines.first.strip
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,7 @@ default_registries = [
   {name: 'anaconda.org', url: 'https://anaconda.org', ecosystem: 'conda', github: 'Anaconda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'}, default: true},
   {name: 'conda-forge.org', url: 'https://conda-forge.org', ecosystem: 'conda', github: 'conda-forge', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'}, default: false},
   {name: 'hub.docker.com', url: 'https://hub.docker.com', ecosystem: 'docker', github: 'docker', metadata: {api_url: 'https://registry-1.docker.io'}, default: true},
+  {name: 'opm.openresty.org', url: 'https://opm.openresty.org', ecosystem: 'opm', github: 'openresty', default: true},
   {name: 'swiftpackageindex.com', url: 'https://swiftpackageindex.com', ecosystem: 'swiftpm', github: 'SwiftPackageIndex', default: true},
   {name: 'vcpkg.io', url: 'https://vcpkg.io', ecosystem: 'vcpkg', github: 'vcpkg', default: true},
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},

--- a/test/models/ecosystem/opm_test.rb
+++ b/test/models/ecosystem/opm_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class OpmTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'opm.openresty.org', url: 'https://opm.openresty.org', ecosystem: 'opm')
+    @ecosystem = Ecosystem::Opm.new(@registry)
+    @package = Package.new(ecosystem: @registry.ecosystem, name: 'openresty/lua-resty-core', metadata: { 'dependencies' => ['openresty/lua-resty-lrucache >= 0.08'] })
+    @version = @package.versions.build(number: '0.1.15')
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://opm.openresty.org/package/openresty/lua-resty-core/', @ecosystem.registry_url(@package)
+  end
+
+  test 'registry_url with version' do
+    assert_equal 'https://opm.openresty.org/package/openresty/lua-resty-core/?version=0.1.15', @ecosystem.registry_url(@package, @version.number)
+  end
+
+  test 'download_url' do
+    assert_equal 'https://opm.openresty.org/download/openresty/lua-resty-core-0.1.15.tar.gz', @ecosystem.download_url(@package, @version.number)
+  end
+
+  test 'documentation_url' do
+    assert_equal 'https://opm.openresty.org/package/openresty/lua-resty-core/', @ecosystem.documentation_url(@package)
+  end
+
+  test 'install_command' do
+    assert_equal 'opm get openresty/lua-resty-core', @ecosystem.install_command(@package)
+  end
+
+  test 'install_command with version' do
+    assert_equal 'opm get openresty/lua-resty-core 0.1.15', @ecosystem.install_command(@package, @version.number)
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:opm/openresty/lua-resty-core', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, 'https://opm.openresty.org/packages')
+      .to_return({ status: 200, body: opm_packages_html })
+
+    assert_equal ['openresty/lua-resty-core', 'agentzh/lua-resty-cookie'], @ecosystem.all_package_names
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, 'https://opm.openresty.org/packages')
+      .to_return({ status: 200, body: opm_packages_html })
+
+    assert_equal ['openresty/lua-resty-core', 'agentzh/lua-resty-cookie'], @ecosystem.recently_updated_package_names
+  end
+
+  test 'package_metadata' do
+    stub_request(:get, 'https://opm.openresty.org/package/openresty/lua-resty-core/')
+      .to_return({ status: 200, body: opm_package_html })
+
+    metadata = @ecosystem.package_metadata('openresty/lua-resty-core')
+
+    assert_equal 'openresty/lua-resty-core', metadata[:name]
+    assert_equal 'New FFI-based Lua API for the ngx_lua module', metadata[:description]
+    assert_equal 'https://opm.openresty.org/package/openresty/lua-resty-core/', metadata[:homepage]
+    assert_equal 'https://github.com/openresty/lua-resty-core', metadata[:repository_url]
+    assert_equal 'This module is licensed under the BSD license.', metadata[:licenses]
+    assert_equal ['0.1.15', '0.1.14'], metadata[:versions]
+    assert_equal ['openresty/lua-resty-lrucache >= 0.08'], metadata[:metadata]['dependencies']
+  end
+
+  test 'versions_metadata' do
+    stub_request(:get, 'https://opm.openresty.org/package/openresty/lua-resty-core/')
+      .to_return({ status: 200, body: opm_package_html })
+
+    metadata = @ecosystem.package_metadata('openresty/lua-resty-core')
+    versions = @ecosystem.versions_metadata(metadata, ['0.1.14'])
+
+    assert_equal 1, versions.length
+    assert_equal '0.1.15', versions.first[:number]
+  end
+
+  test 'dependencies_metadata' do
+    deps = @ecosystem.dependencies_metadata(@package.name, @version.number, @package)
+
+    assert_equal [
+      { package_name: 'openresty/lua-resty-lrucache', requirements: '>= 0.08', kind: 'runtime', ecosystem: 'opm' }
+    ], deps
+  end
+
+  private
+
+  def opm_packages_html
+    <<~HTML
+      <ul class="package_list">
+        <li><a class="title" href="/package/openresty/lua-resty-core/">openresty/lua-resty-core</a></li>
+        <li><a class="title" href="/package/agentzh/lua-resty-cookie/">agentzh/lua-resty-cookie</a></li>
+      </ul>
+    HTML
+  end
+
+  def opm_package_html
+    <<~HTML
+      <div class="main_col package_page">
+        <h2>lua-resty-core</h2>
+        <div class="description"><p>New FFI-based Lua API for the ngx_lua module</p></div>
+        <div class="metadata_columns">
+          <div class="column"><h3>Account</h3>openresty</div>
+          <div class="column"><h3>Repo</h3><a href="https://github.com/openresty/lua-resty-core">repo</a></div>
+        </div>
+        <h3>Dependencies</h3>
+        <div class="description"><p>openresty/lua-resty-lrucache >= 0.08</p></div>
+        <h3>Versions</h3>
+        <ul class="package_list">
+          <li class="package_row"><span class="version_name">0.1.15</span></li>
+          <li class="package_row"><span class="version_name">0.1.14</span></li>
+        </ul>
+        <h1>Copyright and License</h1>
+        <p>This module is licensed under the BSD license.</p>
+      </div>
+    HTML
+  end
+end


### PR DESCRIPTION
## Summary
- add an OpenResty OPM ecosystem adapter using opm.openresty.org package pages
- support registry/documentation/download URLs, `opm get` install command, package lists, recently updated packages, package metadata, version metadata, and dependency metadata
- seed opm.openresty.org as the default OPM registry
- add model coverage for URLs, purl, package lists, metadata, versions, and dependencies

Refs #1227

## Validation
- `ruby -c app/models/ecosystem/opm.rb`
- `ruby -c test/models/ecosystem/opm_test.rb`
- `ruby -c db/seeds.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
