### PR TITLE
Add Hugging Face model ecosystem support

### DIFF
--- a/app/models/ecosystem/huggingface.rb
+++ b/app/models/ecosystem/huggingface.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Huggingface < Base
+    API_URL = "https://huggingface.co/api/models".freeze
+
+    def registry_url(package, version = nil)
+      url = "#{@registry_url}/#{package.name}"
+      url += "/tree/#{version}" if version.present?
+      url
+    end
+
+    def download_url(package, version = nil)
+      revision = version.presence || "main"
+      "#{@registry_url}/#{package.name}/resolve/#{revision}/config.json"
+    end
+
+    def documentation_url(package, _version = nil)
+      registry_url(package)
+    end
+
+    def install_command(package, version = nil)
+      revision_part = version ? " --revision #{version}" : ""
+      "huggingface-cli download #{package.name}#{revision_part}"
+    end
+
+    def check_status(package)
+      model = fetch_package_metadata(package.name)
+      return nil if model.present? && model.is_a?(Hash) && model["id"].present?
+
+      "removed"
+    end
+
+    def all_package_names
+      get_json("#{API_URL}?#{URI.encode_www_form(limit: 100)}").map { |model| model["id"] }.compact
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      get_json("#{API_URL}?#{URI.encode_www_form(limit: 100, sort: 'lastModified', direction: -1)}").map { |model| model["id"] }.compact
+    rescue
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      get_json("#{API_URL}/#{name}")
+    rescue
+      nil
+    end
+
+    def map_package_metadata(model)
+      return false unless model.present?
+
+      license = model.dig("cardData", "license").presence || license_from_tags(model["tags"])
+
+      {
+        name: model["id"] || model["modelId"],
+        description: model.dig("cardData", "summary") || model["pipeline_tag"],
+        homepage: registry_url(Package.new(name: model["id"] || model["modelId"])),
+        repository_url: registry_url(Package.new(name: model["id"] || model["modelId"])),
+        keywords_array: Array.wrap(model["tags"]),
+        licenses: license || "Unknown",
+        downloads: model["downloads"],
+        downloads_period: "total",
+        versions: [model["sha"]].compact,
+        metadata: {
+          "author" => model["author"],
+          "sha" => model["sha"],
+          "pipeline_tag" => model["pipeline_tag"],
+          "library_name" => model["library_name"],
+          "last_modified" => model["lastModified"],
+          "siblings" => Array.wrap(model["siblings"]).map { |sibling| sibling["rfilename"] }.compact
+        }
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      pkg_metadata[:versions]
+        .reject { |version| existing_version_numbers.include?(version) }
+        .map do |version|
+          {
+            number: version,
+            published_at: pkg_metadata.dig(:metadata, "last_modified"),
+            licenses: pkg_metadata[:licenses],
+            metadata: pkg_metadata[:metadata]
+          }
+        end
+    end
+
+    def purl_params(package, version = nil)
+      namespace, name = package.name.split('/', 2)
+      {
+        type: purl_type,
+        namespace: namespace,
+        name: (name || namespace).encode('iso-8859-1'),
+        version: version.try(:number).try(:encode, 'iso-8859-1')
+      }
+    end
+
+    def self.purl_type
+      "huggingface"
+    end
+
+    private
+
+    def license_from_tags(tags)
+      Array.wrap(tags).find { |tag| tag.start_with?("license:") }&.delete_prefix("license:")
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,7 @@ default_registries = [
   {name: 'anaconda.org', url: 'https://anaconda.org', ecosystem: 'conda', github: 'Anaconda', metadata: {'kind' => 'anaconda', 'key' => 'Main', 'api' => 'https://repo.ananconda.com'}, default: true},
   {name: 'conda-forge.org', url: 'https://conda-forge.org', ecosystem: 'conda', github: 'conda-forge', metadata: {'kind' => 'conda-forge', 'key' => 'CondaForge', 'api' => 'https://conda.anaconda.org'}, default: false},
   {name: 'hub.docker.com', url: 'https://hub.docker.com', ecosystem: 'docker', github: 'docker', metadata: {api_url: 'https://registry-1.docker.io'}, default: true},
+  {name: 'huggingface.co', url: 'https://huggingface.co', ecosystem: 'huggingface', github: 'huggingface', default: true},
   {name: 'swiftpackageindex.com', url: 'https://swiftpackageindex.com', ecosystem: 'swiftpm', github: 'SwiftPackageIndex', default: true},
   {name: 'vcpkg.io', url: 'https://vcpkg.io', ecosystem: 'vcpkg', github: 'vcpkg', default: true},
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},

--- a/test/models/ecosystem/huggingface_test.rb
+++ b/test/models/ecosystem/huggingface_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+class HuggingfaceTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'huggingface.co', url: 'https://huggingface.co', ecosystem: 'huggingface')
+    @ecosystem = Ecosystem::Huggingface.new(@registry)
+    @package = Package.new(ecosystem: @registry.ecosystem, name: 'google-bert/bert-base-uncased')
+    @version = @package.versions.build(number: '86b5e0934494bd15c9632b12f734a8a67f723594')
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased', @ecosystem.registry_url(@package)
+  end
+
+  test 'registry_url with version' do
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased/tree/86b5e0934494bd15c9632b12f734a8a67f723594', @ecosystem.registry_url(@package, @version.number)
+  end
+
+  test 'download_url' do
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased/resolve/main/config.json', @ecosystem.download_url(@package)
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased/resolve/86b5e0934494bd15c9632b12f734a8a67f723594/config.json', @ecosystem.download_url(@package, @version.number)
+  end
+
+  test 'documentation_url' do
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased', @ecosystem.documentation_url(@package)
+  end
+
+  test 'install_command' do
+    assert_equal 'huggingface-cli download google-bert/bert-base-uncased', @ecosystem.install_command(@package)
+  end
+
+  test 'install_command with version' do
+    assert_equal 'huggingface-cli download google-bert/bert-base-uncased --revision 86b5e0934494bd15c9632b12f734a8a67f723594', @ecosystem.install_command(@package, @version.number)
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package, @version)
+    assert_equal 'pkg:huggingface/google-bert/bert-base-uncased@86b5e0934494bd15c9632b12f734a8a67f723594', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, 'https://huggingface.co/api/models?limit=100')
+      .to_return({ status: 200, body: huggingface_list_response })
+
+    assert_equal ['google-bert/bert-base-uncased', 'openai/privacy-filter'], @ecosystem.all_package_names
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, 'https://huggingface.co/api/models?direction=-1&limit=100&sort=lastModified')
+      .to_return({ status: 200, body: huggingface_list_response })
+
+    assert_equal ['google-bert/bert-base-uncased', 'openai/privacy-filter'], @ecosystem.recently_updated_package_names
+  end
+
+  test 'package_metadata' do
+    stub_huggingface_model_lookup
+
+    metadata = @ecosystem.package_metadata('google-bert/bert-base-uncased')
+
+    assert_equal 'google-bert/bert-base-uncased', metadata[:name]
+    assert_equal 'fill-mask', metadata[:description]
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased', metadata[:homepage]
+    assert_equal 'https://huggingface.co/google-bert/bert-base-uncased', metadata[:repository_url]
+    assert_equal ['transformers', 'license:apache-2.0', 'fill-mask'], metadata[:keywords_array]
+    assert_equal 'apache-2.0', metadata[:licenses]
+    assert_equal 58_054_642, metadata[:downloads]
+    assert_equal 'total', metadata[:downloads_period]
+    assert_equal ['86b5e0934494bd15c9632b12f734a8a67f723594'], metadata[:versions]
+    assert_equal ['config.json', 'model.safetensors'], metadata[:metadata]['siblings']
+  end
+
+  test 'versions_metadata' do
+    stub_huggingface_model_lookup
+
+    metadata = @ecosystem.package_metadata('google-bert/bert-base-uncased')
+    versions = @ecosystem.versions_metadata(metadata)
+
+    assert_equal 1, versions.length
+    assert_equal '86b5e0934494bd15c9632b12f734a8a67f723594', versions.first[:number]
+    assert_equal 'apache-2.0', versions.first[:licenses]
+    assert_equal '2024-02-19T11:06:12.000Z', versions.first[:published_at]
+  end
+
+  private
+
+  def stub_huggingface_model_lookup
+    stub_request(:get, 'https://huggingface.co/api/models/google-bert/bert-base-uncased')
+      .to_return({ status: 200, body: huggingface_model_response })
+  end
+
+  def huggingface_list_response
+    [
+      { id: 'google-bert/bert-base-uncased' },
+      { id: 'openai/privacy-filter' }
+    ].to_json
+  end
+
+  def huggingface_model_response
+    {
+      id: 'google-bert/bert-base-uncased',
+      modelId: 'google-bert/bert-base-uncased',
+      author: 'google-bert',
+      sha: '86b5e0934494bd15c9632b12f734a8a67f723594',
+      pipeline_tag: 'fill-mask',
+      library_name: 'transformers',
+      tags: ['transformers', 'license:apache-2.0', 'fill-mask'],
+      downloads: 58_054_642,
+      lastModified: '2024-02-19T11:06:12.000Z',
+      siblings: [
+        { rfilename: 'config.json' },
+        { rfilename: 'model.safetensors' }
+      ]
+    }.to_json
+  end
+end


### PR DESCRIPTION
## Summary
- add a Hugging Face model ecosystem adapter backed by the Hugging Face models API
- support model URLs, revision URLs, config download URLs, `huggingface-cli download` install commands, model lists, recently updated models, package metadata, SHA-based versions, and namespaced purls
- seed huggingface.co as the default Hugging Face registry
- add model coverage for URLs, purl, model lists, metadata, downloads, licenses, siblings, and versions

Refs #1232

## Validation
- `ruby -c app/models/ecosystem/huggingface.rb`
- `ruby -c test/models/ecosystem/huggingface_test.rb`
- `ruby -c db/seeds.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
