### PR TITLE
Add SWHID support for versions

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:package_id])
     scope = @package.versions#.includes(:dependencies)
+    scope = scope.with_swhid(params[:swhid]) if params[:swhid].present?
 
     scope = scope.created_after(params[:created_after]) if params[:created_after].present?
     scope = scope.published_after(params[:published_after]) if params[:published_after].present?

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,8 @@ class Version < ApplicationRecord
   validates_presence_of :package_id, :number
   validates_uniqueness_of :number, scope: :package_id, case_sensitive: false
 
+  before_validation :generate_swhid
+
   belongs_to :package
   belongs_to :registry, optional: true
   counter_culture :package
@@ -16,6 +18,7 @@ class Version < ApplicationRecord
       'created_at' => 'created_at',
       'updated_at' => 'updated_at',
       'number' => 'number',
+      'swhid' => 'swhid',
     }
   end
 
@@ -25,6 +28,7 @@ class Version < ApplicationRecord
   scope :updated_after, ->(updated_at) { where('updated_at > ?', updated_at) }
   scope :created_before, ->(created_at) { where('created_at < ?', created_at) }
   scope :updated_before, ->(updated_at) { where('updated_at < ?', updated_at) }
+  scope :with_swhid, ->(swhid) { where(swhid: swhid) }
 
   scope :active, -> { where(status: nil) }
 
@@ -212,6 +216,19 @@ class Version < ApplicationRecord
         false
       end
     end
+  end
+
+  def generate_swhid
+    return if swhid.present?
+
+    sha1 = metadata_sha1
+    self.swhid = "swh:1:rev:#{sha1}" if sha1.present?
+  end
+
+  def metadata_sha1
+    candidate = metadata&.dig('sha') || metadata&.dig(:sha) || metadata&.dig('commit') || metadata&.dig(:commit)
+    candidate = candidate.to_s
+    candidate.match?(/\A[0-9a-f]{40}\z/i) ? candidate.downcase : nil
   end
 
   def transitive_dependencies(max_depth: TransitiveDependencyResolver::DEFAULT_MAX_DEPTH, max_dependencies: TransitiveDependencyResolver::DEFAULT_MAX_DEPENDENCIES, include_optional: false, kind: nil)

--- a/app/views/api/v1/versions/_version.json.jbuilder
+++ b/app/views/api/v1/versions/_version.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+json.extract! version, :id, :number, :published_at, :licenses, :integrity, :swhid, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(version.package.registry, version.package, version)
 json.codemeta_url codemeta_api_v1_registry_package_version_url(version.package.registry, version.package, version)
 json.dependencies version.dependencies do |dependency|

--- a/app/views/api/v1/versions/_version_with_package.json.jbuilder
+++ b/app/views/api/v1/versions/_version_with_package.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+json.extract! version, :id, :number, :published_at, :licenses, :integrity, :swhid, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(@registry, version.package, version)
 json.package_url api_v1_registry_package_url(@registry, version.package)

--- a/app/views/api/v1/versions/index.json.jbuilder
+++ b/app/views/api/v1/versions/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @versions do |version|
-  json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+  json.extract! version, :id, :number, :published_at, :licenses, :integrity, :swhid, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
   json.version_url api_v1_registry_package_version_url(@registry, @package, version)
   # json.dependencies version.dependencies do |dependency|
   #   json.extract! dependency, :ecosystem, :package_name, :requirements, :kind, :optional

--- a/db/migrate/20260429050500_add_swhid_to_versions.rb
+++ b/db/migrate/20260429050500_add_swhid_to_versions.rb
@@ -1,0 +1,6 @@
+class AddSwhidToVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :swhid, :string
+    add_index :versions, :swhid, unique: true, where: "swhid IS NOT NULL"
+  end
+end

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -5,6 +5,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     @registry = Registry.create(name: 'crates.io', url: 'https://crates.io', ecosystem: 'cargo')
     @package = @registry.packages.create(ecosystem: 'cargo', name: 'rand')
     @version = @package.versions.create(number: '1.0.0', metadata: {foo: 'bar'}, registry_id: @registry.id)
+    @swhid_version = @package.versions.create(number: '2.0.0', metadata: { sha: '86b5e0934494bd15c9632b12f734a8a67f723594' }, registry_id: @registry.id)
 
     @pypi_registry = Registry.create(name: 'pypi.org', url: 'https://pypi.org', ecosystem: 'pypi')
     @pypi_package = @pypi_registry.packages.create(
@@ -22,7 +23,18 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     
     actual_response = Oj.load(@response.body)
 
-    assert_equal actual_response.length, 1
+    assert_equal actual_response.length, 2
+  end
+
+  test 'filter versions by SWHID' do
+    get api_v1_registry_package_versions_path(registry_id: @registry.name, package_id: @package.name, swhid: 'swh:1:rev:86b5e0934494bd15c9632b12f734a8a67f723594')
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '2.0.0', actual_response.first['number']
+    assert_equal 'swh:1:rev:86b5e0934494bd15c9632b12f734a8a67f723594', actual_response.first['swhid']
   end
 
   test 'get version of a package' do
@@ -179,7 +191,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     actual_response = Oj.load(@response.body)
-    assert_equal actual_response.length, 1
+    assert_equal actual_response.length, 2
     assert_equal actual_response.first['number'], '1.0.0'
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -57,6 +57,21 @@ class VersionTest < ActiveSupport::TestCase
     assert Purl.parse(@version.purl)
   end
 
+
+
+  test 'generate_swhid from sha metadata' do
+    sha = '86b5e0934494bd15c9632b12f734a8a67f723594'
+    version = @package.versions.create(number: '3.0.0', metadata: { sha: sha })
+
+    assert_equal "swh:1:rev:#{sha}", version.swhid
+  end
+
+  test 'generate_swhid ignores non sha metadata' do
+    version = @package.versions.create(number: '4.0.0', metadata: { sha: 'not-a-sha' })
+
+    assert_nil version.swhid
+  end
+
   test "transitive_dependencies delegates to resolver" do
     TransitiveDependencyResolver.any_instance.expects(:resolve).returns([])
     


### PR DESCRIPTION
## Summary
- add a `swhid` field for package versions, indexed for lookup
- generate Software Heritage revision SWHIDs from version SHA/commit metadata when available
- expose `swhid` in version API responses
- allow filtering package versions by `swhid`
- add model and API coverage for SWHID generation and lookup

Refs #1206

## Validation
- `ruby -c app/models/version.rb`
- `ruby -c app/controllers/api/v1/versions_controller.rb`
- `ruby -c db/migrate/20260429050500_add_swhid_to_versions.rb`
- `ruby -c test/models/version_test.rb`
- `ruby -c test/controllers/api/v1/versions_controller_test.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
