### PR TITLE
Add OmniBOR artifact ID support for versions

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:package_id])
     scope = @package.versions#.includes(:dependencies)
+    scope = scope.with_omnibor_artifact_id(params[:omnibor_artifact_id]) if params[:omnibor_artifact_id].present?
 
     scope = scope.created_after(params[:created_after]) if params[:created_after].present?
     scope = scope.published_after(params[:published_after]) if params[:published_after].present?

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,8 @@ class Version < ApplicationRecord
   validates_presence_of :package_id, :number
   validates_uniqueness_of :number, scope: :package_id, case_sensitive: false
 
+  before_validation :generate_omnibor_artifact_id
+
   belongs_to :package
   belongs_to :registry, optional: true
   counter_culture :package
@@ -16,6 +18,7 @@ class Version < ApplicationRecord
       'created_at' => 'created_at',
       'updated_at' => 'updated_at',
       'number' => 'number',
+      'omnibor_artifact_id' => 'omnibor_artifact_id',
     }
   end
 
@@ -25,6 +28,7 @@ class Version < ApplicationRecord
   scope :updated_after, ->(updated_at) { where('updated_at > ?', updated_at) }
   scope :created_before, ->(created_at) { where('created_at < ?', created_at) }
   scope :updated_before, ->(updated_at) { where('updated_at < ?', updated_at) }
+  scope :with_omnibor_artifact_id, ->(artifact_id) { where(omnibor_artifact_id: artifact_id) }
 
   scope :active, -> { where(status: nil) }
 
@@ -211,6 +215,34 @@ class Version < ApplicationRecord
       else
         false
       end
+    end
+  end
+
+  def generate_omnibor_artifact_id
+    return if omnibor_artifact_id.present?
+
+    self.omnibor_artifact_id = calculated_omnibor_artifact_id
+  end
+
+  def calculated_omnibor_artifact_id
+    length = metadata_artifact_length
+    sha256 = integrity_sha256
+    return if length.blank? || sha256.blank?
+
+    digest = Digest::SHA256.hexdigest("blob #{length}\0" + [sha256].pack('H*'))
+    "gitoid:blob:sha256:#{digest}"
+  end
+
+  def metadata_artifact_length
+    value = metadata&.dig('length') || metadata&.dig(:length) || metadata&.dig('size') || metadata&.dig(:size) || metadata&.dig('archive_length') || metadata&.dig(:archive_length)
+    value.to_i if value.present? && value.to_i.positive?
+  end
+
+  def integrity_sha256
+    return unless integrity.present?
+
+    integrity.to_s.delete_prefix('sha256-').then do |value|
+      value.match?(/\A[0-9a-f]{64}\z/i) ? value.downcase : nil
     end
   end
 

--- a/app/views/api/v1/versions/_version.json.jbuilder
+++ b/app/views/api/v1/versions/_version.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+json.extract! version, :id, :number, :published_at, :licenses, :integrity, :omnibor_artifact_id, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(version.package.registry, version.package, version)
 json.codemeta_url codemeta_api_v1_registry_package_version_url(version.package.registry, version.package, version)
 json.dependencies version.dependencies do |dependency|

--- a/app/views/api/v1/versions/_version_with_package.json.jbuilder
+++ b/app/views/api/v1/versions/_version_with_package.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+json.extract! version, :id, :number, :published_at, :licenses, :integrity, :omnibor_artifact_id, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(@registry, version.package, version)
 json.package_url api_v1_registry_package_url(@registry, version.package)

--- a/app/views/api/v1/versions/index.json.jbuilder
+++ b/app/views/api/v1/versions/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @versions do |version|
-  json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+  json.extract! version, :id, :number, :published_at, :licenses, :integrity, :omnibor_artifact_id, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
   json.version_url api_v1_registry_package_version_url(@registry, @package, version)
   # json.dependencies version.dependencies do |dependency|
   #   json.extract! dependency, :ecosystem, :package_name, :requirements, :kind, :optional

--- a/db/migrate/20260429051000_add_omnibor_artifact_id_to_versions.rb
+++ b/db/migrate/20260429051000_add_omnibor_artifact_id_to_versions.rb
@@ -1,0 +1,6 @@
+class AddOmniborArtifactIdToVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :omnibor_artifact_id, :string
+    add_index :versions, :omnibor_artifact_id, unique: true, where: "omnibor_artifact_id IS NOT NULL"
+  end
+end

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -5,6 +5,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     @registry = Registry.create(name: 'crates.io', url: 'https://crates.io', ecosystem: 'cargo')
     @package = @registry.packages.create(ecosystem: 'cargo', name: 'rand')
     @version = @package.versions.create(number: '1.0.0', metadata: {foo: 'bar'}, registry_id: @registry.id)
+    @omnibor_version = @package.versions.create(number: '2.0.0', integrity: 'sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824', metadata: { length: 5 }, registry_id: @registry.id)
 
     @pypi_registry = Registry.create(name: 'pypi.org', url: 'https://pypi.org', ecosystem: 'pypi')
     @pypi_package = @pypi_registry.packages.create(
@@ -22,7 +23,19 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     
     actual_response = Oj.load(@response.body)
 
-    assert_equal actual_response.length, 1
+    assert_equal actual_response.length, 2
+  end
+
+  test 'filter versions by OmniBOR artifact ID' do
+    artifact_id = 'gitoid:blob:sha256:2c0eb59d2f7fb34d4326d83952c8425731a200dde6b6f93c465c6e315a4cbd33'
+    get api_v1_registry_package_versions_path(registry_id: @registry.name, package_id: @package.name, omnibor_artifact_id: artifact_id)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '2.0.0', actual_response.first['number']
+    assert_equal artifact_id, actual_response.first['omnibor_artifact_id']
   end
 
   test 'get version of a package' do
@@ -179,7 +192,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     actual_response = Oj.load(@response.body)
-    assert_equal actual_response.length, 1
+    assert_equal actual_response.length, 2
     assert_equal actual_response.first['number'], '1.0.0'
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -57,6 +57,27 @@ class VersionTest < ActiveSupport::TestCase
     assert Purl.parse(@version.purl)
   end
 
+
+
+  test 'generate_omnibor_artifact_id from sha256 integrity and length metadata' do
+    version = @package.versions.create(
+      number: '3.0.0',
+      integrity: 'sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+      metadata: { length: 5 }
+    )
+
+    assert_equal 'gitoid:blob:sha256:2c0eb59d2f7fb34d4326d83952c8425731a200dde6b6f93c465c6e315a4cbd33', version.omnibor_artifact_id
+  end
+
+  test 'generate_omnibor_artifact_id ignores missing length metadata' do
+    version = @package.versions.create(
+      number: '4.0.0',
+      integrity: 'sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+    )
+
+    assert_nil version.omnibor_artifact_id
+  end
+
   test "transitive_dependencies delegates to resolver" do
     TransitiveDependencyResolver.any_instance.expects(:resolve).returns([])
     


### PR DESCRIPTION
## Summary
- add an `omnibor_artifact_id` field for package versions, indexed for lookup
- generate OmniBOR Artifact IDs using the SHA-256 GitOID blob construction when version integrity and artifact length metadata are available
- expose `omnibor_artifact_id` in version API responses
- allow filtering package versions by OmniBOR Artifact ID
- add model and API coverage for ID generation and lookup

Refs #1205

## Validation
- `ruby -c app/models/version.rb`
- `ruby -c app/controllers/api/v1/versions_controller.rb`
- `ruby -c db/migrate/20260429051000_add_omnibor_artifact_id_to_versions.rb`
- `ruby -c test/models/version_test.rb`
- `ruby -c test/controllers/api/v1/versions_controller_test.rb`
- `git diff --check`

Full Rails test execution is blocked locally because this repo lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it.
