### PR TITLE
Sanitize invalid repository owner website URLs

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -398,7 +398,7 @@ class Package < ApplicationRecord
     repo_metadata = fetch_repo_metadata
     if repo_metadata.present?
       tags = fetch_tags
-      owner = fetch_owner
+      owner = sanitize_owner_record(fetch_owner)
       repo_metadata.merge!({'owner_record' => owner}) if owner
       repo_metadata.merge!({'tags' => tags}) if tags
       update(repo_metadata: repo_metadata)
@@ -986,5 +986,22 @@ class Package < ApplicationRecord
   def scorecard_url
     return unless scorecard_slug.present?
     "https://scorecard.dev/viewer/?uri=#{scorecard_slug}"
+  end
+
+  def sanitize_owner_record(owner)
+    return owner unless owner.is_a?(Hash)
+
+    owner = owner.deep_dup
+    owner['website'] = sanitized_http_url(owner['website']) if owner.key?('website')
+    owner
+  end
+
+  def sanitized_http_url(url)
+    return nil if url.blank?
+
+    uri = URI.parse(url.to_s)
+    return url if uri.is_a?(URI::HTTP) && uri.host.present?
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -266,4 +266,52 @@ class PackageTest < ActiveSupport::TestCase
     refute_includes results, package_without_advisories
     refute_includes results, @package
   end
+
+  test 'update_repo_metadata drops invalid owner website urls' do
+    @package.update(repository_url: 'https://github.com/snyk/parlay')
+    repo = {
+      'host' => { 'name' => 'GitHub' },
+      'full_name' => 'snyk/parlay',
+      'owner' => 'snyk'
+    }
+    owner = {
+      'login' => 'snyk',
+      'website' => 'JavaScript Testing utilities for React'
+    }
+
+    @package.expects(:fetch_repo_metadata).returns(repo)
+    @package.expects(:fetch_tags).returns([])
+    @package.expects(:fetch_owner).returns(owner)
+    @package.expects(:ping_issues)
+    @package.expects(:ping_commits)
+    @package.expects(:update_issue_metadata)
+
+    @package.update_repo_metadata
+
+    assert_nil @package.reload.repo_metadata['owner_record']['website']
+  end
+
+  test 'update_repo_metadata keeps valid owner website urls' do
+    @package.update(repository_url: 'https://github.com/snyk/parlay')
+    repo = {
+      'host' => { 'name' => 'GitHub' },
+      'full_name' => 'snyk/parlay',
+      'owner' => 'snyk'
+    }
+    owner = {
+      'login' => 'snyk',
+      'website' => 'https://snyk.io'
+    }
+
+    @package.expects(:fetch_repo_metadata).returns(repo)
+    @package.expects(:fetch_tags).returns([])
+    @package.expects(:fetch_owner).returns(owner)
+    @package.expects(:ping_issues)
+    @package.expects(:ping_commits)
+    @package.expects(:update_issue_metadata)
+
+    @package.update_repo_metadata
+
+    assert_equal 'https://snyk.io', @package.reload.repo_metadata['owner_record']['website']
+  end
 end


### PR DESCRIPTION
Refs #1061

## Summary

- Sanitizes repository owner website values before caching repos.ecosyste.ms owner metadata on packages.
- Drops non-HTTP/HTTPS or unparseable owner website strings instead of returning plain descriptions through the package API.
- Adds model coverage for invalid and valid owner website values.

## Validation

- `ruby -c app/models/package.rb`
- `ruby -c test/models/package_test.rb`
- `git diff --check`

`bundle exec ruby -Itest test/models/package_test.rb -n '/owner website/'` is blocked locally because this checkout requires Bundler 4.0.10 from `Gemfile.lock`, which is not available in the system Ruby environment.