### PR TITLE
Fix reported license normalization bugs

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -270,8 +270,6 @@ class Package < ApplicationRecord
     self.normalized_licenses =
       if licenses.blank?
         []
-      elsif licenses.length > 150
-        ["Other"]
       else
         spdx = spdx_license
         if spdx.empty?
@@ -287,9 +285,13 @@ class Package < ApplicationRecord
   end
 
   NON_SPDX_LICENSE_VALUES = %w[other unknown none noassertion proprietary custom see\ license].freeze
+  SPDX_EXACT_LICENSE_IDS = {
+    'edl-1.0' => 'EDL-1.0'
+  }.freeze
 
   def spdx_license
     return Spdx.parse_spdx(licenses).licenses if Spdx.valid_spdx?(licenses)
+    return ["MIT"] if licenses.match?(/mit license.*permission is hereby granted/im)
 
     licenses
       .downcase
@@ -301,9 +303,15 @@ class Package < ApplicationRecord
       .flat_map { |l| l.split(/[,\/]/) }
       .map(&:strip)
       .reject { |l| l.blank? || l.match?(/\A(version\s+)?[\d.]+\z/) }
-      .map { |l| NON_SPDX_LICENSE_VALUES.include?(l) ? nil : Spdx.find(l) }
+      .map { |l| license_id_for(l) }
       .compact
-      .map(&:id)
+  end
+
+  def license_id_for(license)
+    return nil if NON_SPDX_LICENSE_VALUES.include?(license)
+    return SPDX_EXACT_LICENSE_IDS[license] if SPDX_EXACT_LICENSE_IDS.key?(license)
+
+    Spdx.find(license)&.id
   end
 
   def manual_license_format(license)

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -91,6 +91,23 @@ class PackageTest < ActiveSupport::TestCase
     assert_equal ["Apache-2.0"], package.normalized_licenses
   end
 
+  test 'normalize_licenses preserves EDL in compound SPDX expression' do
+    package = @registry.packages.create(name: 'test_edl', ecosystem: @registry.ecosystem, licenses: '(EDL-1.0 OR EPL-1.0)')
+    package.normalize_licenses
+    assert_equal ["EDL-1.0", "EPL-1.0"], package.normalized_licenses
+  end
+
+  test 'normalize_licenses recognizes long MIT license text' do
+    license_text = <<~LICENSE
+      MIT License Copyright (c) 2023 Thomas Montaigu Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including
+      without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software.
+    LICENSE
+    package = @registry.packages.create(name: 'test_mit_text', ecosystem: @registry.ecosystem, licenses: license_text)
+    package.normalize_licenses
+    assert_equal ["MIT"], package.normalized_licenses
+  end
+
   test 'set_latest_release_published_at' do
     @package.set_latest_release_published_at
     assert_equal @package.latest_release_published_at, @version2.published_at


### PR DESCRIPTION
Refs #1059

## Summary

- Removes the 150-character early fallback so long license texts can still be recognized.
- Recognizes standard MIT license text using the canonical permission grant phrase.
- Preserves EDL-1.0 in compound license expressions instead of letting the fuzzy SPDX lookup misclassify it.
- Adds regression coverage for both examples from the issue.

## Validation

- `ruby -c app/models/package.rb`
- `ruby -c test/models/package_test.rb`
- `git diff --check`

`bundle exec ruby -Itest test/models/package_test.rb -n '/normalize_licenses (preserves EDL|recognizes long MIT)/'` is blocked locally because this checkout requires Bundler 4.0.10 from `Gemfile.lock`, which is not available in the system Ruby environment.