### PR TITLE
Add Buildkite plugin ecosystem support

### DIFF
--- a/app/models/ecosystem/buildkite.rb
+++ b/app/models/ecosystem/buildkite.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Buildkite < Base
+
+    def self.purl_type
+      'buildkite'
+    end
+
+    def self.namespace_separator
+      '/'
+    end
+
+    def purl_params(package, version = nil)
+      {
+        type: purl_type,
+        namespace: package.name.split('/').first,
+        name: package.name.split('/').last,
+        version: version.try(:number).try(:encode, 'iso-8859-1', invalid: :replace, undef: :replace, replace: '')
+      }
+    end
+
+    def registry_url(package, _version = nil)
+      "https://buildkite.com/resources/plugins/#{plugin_slug(package.name)}"
+    end
+
+    def documentation_url(package, version = nil)
+      version.present? ? "#{repository_url(package.name)}/tree/#{version.number}" : repository_url(package.name)
+    end
+
+    def download_url(package, version = nil)
+      ref = version.try(:number).presence || 'HEAD'
+      "https://codeload.github.com/#{repository_full_name(package.name)}/tar.gz/#{ref}"
+    end
+
+    def install_command(package, version = nil)
+      version_number = version.try(:number).presence || version
+      plugin = version_number.present? ? "#{package.name}##{version_number}" : package.name
+      "plugins:\n  - #{plugin}: ~"
+    end
+
+    def check_status_url(package)
+      repository_url(package.name)
+    end
+
+    def all_package_names
+      scrape_plugin_names
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      all_package_names.first(20)
+    end
+
+    def fetch_package_metadata_uncached(name)
+      repo = get_json("https://repos.ecosyste.ms/api/v1/repositories/lookup?url=#{CGI.escape(repository_url(name))}")
+      return nil if repo.blank? || repo['error'].present?
+
+      repo.merge('name' => name, 'repository_url' => repository_url(name))
+    rescue
+      nil
+    end
+
+    def map_package_metadata(package)
+      return nil unless package
+
+      {
+        name: package['name'],
+        description: package['description'],
+        repository_url: package['repository_url'],
+        licenses: package['license'],
+        keywords_array: package['topics'],
+        homepage: package['homepage'],
+        tags_url: package['tags_url'],
+        namespace: package['owner'],
+        metadata: {
+          default_branch: package['default_branch'],
+          full_name: package['full_name']
+        }
+      }
+    end
+
+    def versions_metadata(pkg_metadata, _existing_version_numbers = [])
+      return [] unless pkg_metadata[:tags_url]
+      tags_json = get_json("#{pkg_metadata[:tags_url]}?per_page=1000")
+      return [] if tags_json.blank?
+
+      tags_json.map do |tag|
+        {
+          number: tag['name'],
+          published_at: tag['published_at'],
+          metadata: {
+            sha: tag['sha'],
+            download_url: tag['download_url']
+          }
+        }
+      end
+    end
+
+    def package_find_names(package_name)
+      [package_name, repository_full_name(package_name)].uniq
+    end
+
+    private
+
+    def repository_full_name(name)
+      owner, plugin = name.split('/', 2)
+      return name unless owner.present? && plugin.present?
+
+      "#{owner}/#{plugin}-buildkite-plugin"
+    end
+
+    def repository_url(name)
+      "https://github.com/#{repository_full_name(name)}"
+    end
+
+    def plugin_slug(name)
+      name.tr('/', '-')
+    end
+
+    def scrape_plugin_names
+      html = get_raw('https://buildkite.com/resources/plugins')
+      html.scan(%r{github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)-buildkite-plugin}).map do |owner, plugin|
+        "#{owner}/#{plugin}"
+      end.uniq
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,6 +125,14 @@ nixpkgs_registries.each do |data|
   r.save
 end
 
+r = Registry.find_or_initialize_by(url: 'https://buildkite.com/resources/plugins')
+r.assign_attributes(
+  name: 'Buildkite Plugins',
+  ecosystem: 'buildkite',
+  default: true
+)
+r.save
+
 r = Registry.find_or_initialize_by(url: 'https://guix.gnu.org')
 r.assign_attributes(
   name: 'guix',

--- a/test/models/ecosystem/buildkite_test.rb
+++ b/test/models/ecosystem/buildkite_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class BuildkiteTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'Buildkite Plugins', url: 'https://buildkite.com/resources/plugins', ecosystem: 'Buildkite')
+    @ecosystem = Ecosystem::Buildkite.new(@registry)
+    @package = Package.new(ecosystem: 'Buildkite', name: 'chronotc/monorepo-diff')
+    @version = @package.versions.build(number: 'v2.4.0', metadata: { 'download_url' => 'https://codeload.github.com/chronotc/monorepo-diff-buildkite-plugin/tar.gz/v2.4.0' })
+  end
+
+  test 'purl_params use buildkite type and namespace' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:buildkite/chronotc/monorepo-diff', purl
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://buildkite.com/resources/plugins/chronotc-monorepo-diff', @ecosystem.registry_url(@package)
+  end
+
+  test 'repository based urls' do
+    assert_equal 'https://github.com/chronotc/monorepo-diff-buildkite-plugin', @ecosystem.documentation_url(@package)
+    assert_equal 'https://codeload.github.com/chronotc/monorepo-diff-buildkite-plugin/tar.gz/v2.4.0', @ecosystem.download_url(@package, @version)
+    assert_equal 'https://github.com/chronotc/monorepo-diff-buildkite-plugin', @ecosystem.check_status_url(@package)
+  end
+
+  test 'install_command' do
+    assert_equal "plugins:\n  - chronotc/monorepo-diff#v2.4.0: ~", @ecosystem.install_command(@package, @version)
+  end
+
+  test 'package_find_names includes repository form' do
+    assert_equal ['chronotc/monorepo-diff', 'chronotc/monorepo-diff-buildkite-plugin'], @ecosystem.package_find_names('chronotc/monorepo-diff')
+  end
+
+  test 'fetch_package_metadata looks up canonical github repository' do
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https%3A%2F%2Fgithub.com%2Fchronotc%2Fmonorepo-diff-buildkite-plugin')
+      .to_return(status: 200, body: {
+        full_name: 'chronotc/monorepo-diff-buildkite-plugin',
+        owner: 'chronotc',
+        description: 'Detect changed paths in a monorepo',
+        license: 'MIT',
+        topics: ['buildkite-plugin'],
+        homepage: 'https://github.com/chronotc/monorepo-diff-buildkite-plugin',
+        tags_url: 'https://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/chronotc%2Fmonorepo-diff-buildkite-plugin/tags',
+        default_branch: 'main'
+      }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    metadata = @ecosystem.package_metadata('chronotc/monorepo-diff')
+
+    assert_equal 'chronotc/monorepo-diff', metadata[:name]
+    assert_equal 'https://github.com/chronotc/monorepo-diff-buildkite-plugin', metadata[:repository_url]
+    assert_equal 'MIT', metadata[:licenses]
+    assert_equal 'chronotc', metadata[:namespace]
+  end
+end


### PR DESCRIPTION
Refs #816

## Summary

- Adds a Buildkite ecosystem for plugin package lookups such as `chronotc/monorepo-diff`.
- Maps Buildkite plugin names to their canonical GitHub repositories (`owner/plugin-buildkite-plugin`) for metadata, status, docs, downloads, and versions.
- Adds Buildkite PURL generation (`pkg:buildkite/owner/plugin`), install commands, plugin listing scraping, default registry seed, and model coverage.

## Validation

- `ruby -c app/models/ecosystem/buildkite.rb`
- `ruby -c test/models/ecosystem/buildkite_test.rb`
- `ruby -c db/seeds.rb`
- `git diff --check`

`bundle exec ruby -Itest test/models/ecosystem/buildkite_test.rb` is blocked locally because this checkout requires Bundler 4.0.10 from `Gemfile.lock`, which is not available in the system Ruby environment.