### PR TITLE
Preserve PyPI versions without files

### DIFF
--- a/app/models/ecosystem/pypi.rb
+++ b/app/models/ecosystem/pypi.rb
@@ -156,31 +156,38 @@ module Ecosystem
       pkg_metadata[:releases].filter_map do |k, v|
         next if existing_version_numbers.include?(k)
 
-        if v == []
+        release_file = v.first
+        version_info = fetch_version(name, k)["info"] || {}
+
+        if release_file.nil?
           {
             number: k,
             published_at: nil,
             integrity: nil,
-            licenses: nil,
+            licenses: version_licenses(name, k),
             metadata: {
-              download_url: nil
+              download_url: nil,
+              requires_python: version_info["requires_python"],
+              yanked: version_info["yanked"],
+              yanked_reason: version_info["yanked_reason"],
+              no_release_files: true
             }
           }
         else
           {
             number: k,
-            published_at: v[0]["upload_time"],
-            integrity: 'sha256-' + v[0]['digests']['sha256'],
+            published_at: release_file["upload_time"],
+            integrity: 'sha256-' + release_file['digests']['sha256'],
             licenses: version_licenses(name, k),
             metadata: {
-              download_url: v[0]['url'],
-              requires_python: v[0]['requires_python'],
-              yanked: v[0]['yanked'],
-              yanked_reason: v[0]['yanked_reason'],
-              packagetype: v[0]['packagetype'],
-              python_version: v[0]['python_version'],
-              size: v[0]['size'],
-              has_sig: v[0]['has_sig']
+              download_url: release_file['url'],
+              requires_python: release_file['requires_python'],
+              yanked: release_file['yanked'],
+              yanked_reason: release_file['yanked_reason'],
+              packagetype: release_file['packagetype'],
+              python_version: release_file['python_version'],
+              size: release_file['size'],
+              has_sig: release_file['has_sig']
             }
           }
         end


### PR DESCRIPTION
Refs #301

Preserves PyPI versions even when PyPI reports a release with no downloadable files.

The `web` package currently exposes release numbers in PyPI JSON, but each release has an empty file list. Previously that branch created a very sparse placeholder. This change keeps the version entry while enriching it from the per-version PyPI JSON endpoint.

Changes:
- Handles empty PyPI release file arrays via `release_file = v.first`
- Fetches per-version `info` metadata for no-file releases
- Preserves licenses, `requires_python`, `yanked`, and `yanked_reason` where available
- Marks those entries with `metadata[:no_release_files] = true`
- Keeps normal file-backed release behavior unchanged, just replacing `v[0]` with `release_file`

Validation:
- `ruby -c app/models/ecosystem/pypi.rb`
- `git diff --check`

Notes:
- Full Rails tests remain locally blocked by the repo lockfile requiring Bundler 4.0.10 under system Ruby.