### PR TITLE
Populate maintainer email for alpine, adelie, postmarketos and deb

### DIFF
--- a/app/models/ecosystem/adelie.rb
+++ b/app/models/ecosystem/adelie.rb
@@ -135,7 +135,8 @@ module Ecosystem
       email = d[1].gsub('>','').strip
       [{
         uuid: email,
-        name: name
+        name: name,
+        email: email
       }]
     end
 

--- a/app/models/ecosystem/alpine.rb
+++ b/app/models/ecosystem/alpine.rb
@@ -166,6 +166,7 @@ module Ecosystem
       [{
         uuid: email,
         name: name,
+        email: email,
         url: "https://pkgs.alpinelinux.org/packages?maintainer=#{name}",
       }]
     end

--- a/app/models/ecosystem/deb.rb
+++ b/app/models/ecosystem/deb.rb
@@ -233,7 +233,8 @@ module Ecosystem
         email = $2.strip
         [{
           uuid: email,
-          name: name
+          name: name,
+          email: email
         }]
       else
         []

--- a/app/models/ecosystem/postmarketos.rb
+++ b/app/models/ecosystem/postmarketos.rb
@@ -133,6 +133,7 @@ module Ecosystem
       [{
         uuid: email,
         name: name,
+        email: email,
         url: "https://pkgs.postmarketoslinux.org/packages?maintainer=#{name}",
       }]
     end

--- a/test/models/ecosystem/adelie_test.rb
+++ b/test/models/ecosystem/adelie_test.rb
@@ -50,6 +50,7 @@ class AdelieTest < ActiveSupport::TestCase
     assert_equal 1, maintainers.length
     assert_equal 'awilfox@adelielinux.org', maintainers.first[:uuid]
     assert_equal 'A. Wilcox', maintainers.first[:name]
+    assert_equal 'awilfox@adelielinux.org', maintainers.first[:email]
   end
 
   test 'dependencies_metadata returns empty array when package not found' do

--- a/test/models/ecosystem/ubuntu_test.rb
+++ b/test/models/ecosystem/ubuntu_test.rb
@@ -108,6 +108,7 @@ class UbuntuTest < ActiveSupport::TestCase
     assert_equal 1, maintainers.length
     assert_equal 'Jonathan Carter', maintainers[0][:name]
     assert_equal 'jcc@debian.org', maintainers[0][:uuid]
+    assert_equal 'jcc@debian.org', maintainers[0][:email]
   end
 
   test 'map_package_metadata returns expected format' do


### PR DESCRIPTION
These ecosystems were already parsing the maintainer email from the `Name <email>` string and using it as the `uuid`, but weren't setting the `email` key on the maintainer hash. This brings them in line with the other 10 ecosystems that populate `email` (npm, hex, cran, etc).

Covers `debian` and `ubuntu` via the `deb` base class.