### PR TITLE
Add latest_version API endpoint for packages

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -273,6 +273,14 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     render json: { message: 'pong' }
   end
 
+  def latest_version
+    @registry = Registry.find_by_name!(params[:registry_id])
+    @package = find_package_with_normalization!(@registry, params[:id])
+    @version = @package.latest_version
+    raise ActiveRecord::RecordNotFound, "No versions found" unless @version
+    fresh_when @version, public: true
+  end
+
   def codemeta
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:id])

--- a/app/views/api/v1/packages/_package.json.jbuilder
+++ b/app/views/api/v1/packages/_package.json.jbuilder
@@ -2,6 +2,7 @@ json.extract! package, :id, :name, :ecosystem, :description, :homepage, :license
 
 json.versions_url api_v1_registry_package_versions_url(registry_id: package.registry.name, package_id: package.name)
 json.version_numbers_url version_numbers_api_v1_registry_package_url(registry_id: package.registry.name, id: package.name)
+json.latest_version_url latest_version_api_v1_registry_package_url(registry_id: package.registry.name, id: package.name)
 json.dependent_packages_url dependent_packages_api_v1_registry_package_url(registry_id: package.registry.name, id: package.name)
 json.related_packages_url related_packages_api_v1_registry_package_url(registry_id: package.registry.name, id: package.name)
 json.codemeta_url codemeta_api_v1_registry_package_url(registry_id: package.registry.name, id: package.name)

--- a/app/views/api/v1/packages/latest_version.json.jbuilder
+++ b/app/views/api/v1/packages/latest_version.json.jbuilder
@@ -1,0 +1,2 @@
+json.partial! 'api/v1/versions/version', version: @version
+json.package_url api_v1_registry_package_url(@registry, @package)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
             get :ping, to: 'packages#ping'
             get :version_numbers, to: 'versions#version_numbers'
             get :codemeta, to: 'packages#codemeta'
+            get :latest_version, to: 'packages#latest_version'
           end
         end
 

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -1392,6 +1392,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Package'
+  /registries/{registryName}/packages/{packageName}/latest_version:
+    get:
+      summary: get the latest version of a package
+      operationId: getRegistryPackageLatestVersion
+      tags:
+        - packages
+      parameters:
+        - in: path
+          name: registryName
+          schema:
+            type: string
+          required: true
+          description: name of registry
+        - in: path
+          name: packageName
+          schema:
+            type: string
+          required: true
+          description: name of package
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionWithDependencies'
+        404:
+          description: package not found or no versions available
   /registries/{registryName}/packages/{packageName}/version_numbers:
     get:
       summary: get a list of version numbers for a package from a registry
@@ -1774,6 +1802,7 @@ components:
         - purl
         - advisories
         - versions_url
+        - latest_version_url
         - dependent_packages_url
         - related_packages_url
         - codemeta_url
@@ -1878,6 +1907,8 @@ components:
           items:
             $ref: '#/components/schemas/Advisory'
         versions_url:
+          type: string
+        latest_version_url:
           type: string
         version_numbers_url:
           type: string

--- a/test/controllers/api/v1/packages_controller_test.rb
+++ b/test/controllers/api/v1/packages_controller_test.rb
@@ -670,6 +670,63 @@ class ApiV1PackagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'removed', actual_response['status']
   end
 
+  test 'get latest version for a package' do
+    version = @package.versions.create(number: '1.0.0', published_at: 1.day.ago)
+    get latest_version_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+    assert_equal '1.0.0', actual_response['number']
+    assert_equal version.id, actual_response['id']
+  end
+
+  test 'get latest version returns latest stable version when pre-releases exist' do
+    stable = @package.versions.create(number: '1.0.0', published_at: 2.days.ago, status: nil)
+    prerelease = @package.versions.create(number: '2.0.0-beta.1', published_at: 1.day.ago, status: nil)
+    get latest_version_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+    assert_equal '1.0.0', actual_response['number']
+  end
+
+  test 'get latest version returns 404 when package has no versions' do
+    get latest_version_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :not_found
+  end
+
+  test 'get latest version for nonexistent package' do
+    get latest_version_api_v1_registry_package_path(registry_id: @registry.name, id: 'nonexistent')
+    assert_response :not_found
+  end
+
+  test 'get latest version includes dependencies' do
+    version = @package.versions.create(number: '1.0.0', published_at: 1.day.ago)
+    version.dependencies.create(ecosystem: 'cargo', package_name: 'serde', requirements: '^1.0', kind: 'runtime')
+    get latest_version_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+    assert_equal 1, actual_response['dependencies'].length
+    assert_equal 'serde', actual_response['dependencies'].first['package_name']
+  end
+
+  test 'get latest version for pypi package with underscore in name' do
+    pypi_registry = Registry.create(name: 'pypi.org', url: 'https://pypi.org', ecosystem: 'pypi')
+    pypi_package = pypi_registry.packages.create(
+      ecosystem: 'pypi',
+      name: 'tomli-w',
+      metadata: { 'normalized_name' => 'tomli-w' }
+    )
+    pypi_package.versions.create(number: '1.0.0', published_at: 1.day.ago)
+
+    get latest_version_api_v1_registry_package_path(registry_id: pypi_registry.name, id: 'tomli_w')
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+    assert_equal '1.0.0', actual_response['number']
+  end
+
   test 'get codemeta for a package' do
     get codemeta_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name)
     assert_response :success


### PR DESCRIPTION
Adds `GET /api/v1/registries/:registry/packages/:package/latest_version` which returns the latest stable version of a package (falling back to the latest pre-release if no stable version exists). Returns 404 if the package has no versions.

- Adds `latest_version` action to `Api::V1::PackagesController`
- Adds `latest_version_url` to the package JSON response
- Documented in the OpenAPI spec
- Six tests covering: basic lookup, stable vs pre-release preference, no versions (404), nonexistent package (404), dependencies included, and pypi name normalization