### PR TITLE
Add Flathub ecosystem support

### DIFF
--- a/app/models/ecosystem/flathub.rb
+++ b/app/models/ecosystem/flathub.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Flathub < Base
+
+    def has_dependent_repos?
+      false
+    end
+
+    def self.purl_type
+      'flatpak'
+    end
+
+    def registry_url(package, version = nil)
+      "#{@registry_url}/apps/#{package.name}"
+    end
+
+    def install_command(package, version = nil)
+      "flatpak install flathub #{package.name}"
+    end
+
+    def documentation_url(package, version = nil)
+      package.metadata&.dig('urls', 'help')
+    end
+
+    def check_status_url(package)
+      "#{@registry_url}/api/v2/appstream/#{package.name}"
+    end
+
+    def all_package_names
+      get_json("#{@registry_url}/api/v2/appstream")
+    rescue
+      []
+    end
+
+    def recently_updated_package_names
+      updated = get_json("#{@registry_url}/api/v2/collection/recently-updated?page=1&per_page=100")['hits'] rescue []
+      added = get_json("#{@registry_url}/api/v2/collection/recently-added?page=1&per_page=100")['hits'] rescue []
+      (updated + added).map { |h| h['app_id'] }.compact.uniq
+    end
+
+    def fetch_package_metadata_uncached(name)
+      app = get_json("#{@registry_url}/api/v2/appstream/#{name}")
+      return nil if app.nil? || app['id'].blank?
+      app['stats'] = get_json("#{@registry_url}/api/v2/stats/#{name}") rescue {}
+      app
+    rescue
+      nil
+    end
+
+    def map_package_metadata(app)
+      return false if app.blank? || app['id'].blank?
+
+      urls = app['urls'] || {}
+      flathub_metadata = app['metadata'] || {}
+      bundle = app['bundle'] || {}
+
+      {
+        name: app['id'],
+        description: app['summary'].presence || strip_html(app['description'])&.truncate(500),
+        homepage: urls['homepage'],
+        licenses: app['project_license'],
+        repository_url: repo_fallback(urls['vcs_browser'], urls['homepage']),
+        keywords_array: Array(app['categories']) + Array(app['keywords']),
+        namespace: app['developer_name'],
+        downloads: app.dig('stats', 'installs_total'),
+        downloads_period: 'total',
+        releases: app['releases'],
+        metadata: {
+          display_name: app['name'],
+          type: app['type'],
+          icon: app['icon'],
+          runtime: bundle['runtime'],
+          sdk: bundle['sdk'],
+          urls: urls.compact,
+          verified: flathub_metadata['flathub::verification::verified'],
+          verification_method: flathub_metadata['flathub::verification::method'],
+          is_eol: app['is_eol'],
+          installs_last_month: app.dig('stats', 'installs_last_month'),
+        }.compact
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      Array(pkg_metadata[:releases]).map do |release|
+        next if release['version'].blank?
+        {
+          number: release['version'],
+          published_at: release['timestamp'].present? ? Time.at(release['timestamp'].to_i) : nil,
+          metadata: {
+            release_type: release['type'],
+            url: release['url'],
+            urgency: release['urgency'],
+          }.compact
+        }
+      end.compact
+    end
+
+    def dependencies_metadata(_name, version, mapped_package)
+      return [] unless version == mapped_package[:releases]&.first&.dig('version')
+
+      runtime = mapped_package.dig(:metadata, :runtime)
+      sdk = mapped_package.dig(:metadata, :sdk)
+
+      deps = []
+      deps << runtime_dependency(runtime, 'runtime') if runtime.present?
+      deps << runtime_dependency(sdk, 'build') if sdk.present?
+      deps
+    end
+
+    def runtime_dependency(ref, kind)
+      name, _arch, branch = ref.split('/')
+      {
+        package_name: name,
+        requirements: branch.presence || '*',
+        kind: kind,
+        ecosystem: 'flathub',
+      }
+    end
+
+    def strip_html(str)
+      return nil if str.blank?
+      Nokogiri::HTML(str).text.squish
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ default_registries = [
   {name: 'hackage.haskell.org', url: 'https://hackage.haskell.org', ecosystem: 'hackage', github: 'haskell-infra', default: true},
   {name: 'cran.r-project.org', url: 'https://cran.r-project.org', ecosystem: 'cran', github: 'r-project-org', metadata: {'icon_url' => 'https://cran.r-project.org/CRANlogo.png'}, default: true},
   {name: 'f-droid.org', url: 'https://f-droid.org', ecosystem: 'fdroid', github: 'f-droid', default: true},
+  {name: 'flathub.org', url: 'https://flathub.org', ecosystem: 'flathub', github: 'flathub', default: true},
   {name: 'formulae.brew.sh', url: 'https://formulae.brew.sh', ecosystem: 'homebrew', github: 'homebrew', default: true},
   {name: 'forge.puppet.com', url: 'https://forge.puppet.com', ecosystem: 'puppet', github: 'puppet', default: true},
   {name: 'juliahub.com', url: 'https://juliahub.com', ecosystem: 'julia', github: 'JuliaRegistries', default: true},

--- a/test/fixtures/files/flathub/appstream
+++ b/test/fixtures/files/flathub/appstream
@@ -1,0 +1,1 @@
+["ai.jan.Jan","app.authpass.AuthPass","org.gimp.GIMP","org.gnome.Calculator","org.kde.kdenlive"]

--- a/test/fixtures/files/flathub/org.gimp.GIMP
+++ b/test/fixtures/files/flathub/org.gimp.GIMP
@@ -1,0 +1,79 @@
+{
+  "is_free_license": true,
+  "isMobileFriendly": false,
+  "branding": null,
+  "is_eol": false,
+  "kudos": null,
+  "keywords": [
+    "GIMP",
+    "Photoshop"
+  ],
+  "mimetypes": null,
+  "project_license": "GPL-3.0+ AND LGPL-3.0+",
+  "name": "GNU Image Manipulation Program",
+  "type": "desktop-application",
+  "developer_name": "The GIMP team",
+  "translation": null,
+  "bundle": {
+    "value": "app/org.gimp.GIMP/x86_64/stable",
+    "type": "flatpak",
+    "sdk": "org.gnome.Sdk/x86_64/50",
+    "runtime": "org.gnome.Platform/x86_64/50"
+  },
+  "launchable": {
+    "value": "org.gimp.GIMP.desktop",
+    "type": "desktop-id"
+  },
+  "summary": "High-end image creation and manipulation",
+  "categories": [
+    "Graphics",
+    "2DGraphics",
+    "RasterGraphics"
+  ],
+  "description": "<p>\n      GIMP is an acronym for GNU Image Manipulation Program. It is\n      Community-driven Free Software for high-end image creation and manipulation.\n    </p>\n      <p>\n      It has many capabilities. It can be used as a paint program,\n      an expert quality photo retouching program, image composition,\n      an online batch processing system, a mass production image\n      renderer, an image format converter, etc.\n    </p>\n      <p>\n      GIMP is expandable and extensible. It is designed to be\n      augmented with plug-ins and extensions to do just about\n      anything. The advanced scripting interface allows everything\n      from the simplest task to the most complex image manipulation\n      procedures to be easily scripted. GIMP is available for Linux,\n      Microsoft Windows and macOS.\n    </p>\n    ",
+  "icon": "https://dl.flathub.org/media/org/gimp/GIMP/ab48223ba11e3bad9493fcda45e9ac04/icons/128x128/org.gimp.GIMP.png",
+  "releases": [
+    {
+      "url": "https://www.gimp.org/release/3.2.4/",
+      "version": "3.2.4",
+      "date_eol": null,
+      "description": "<p>\n        The second bugfix release of the GIMP 3.2 series brings it to quite a stable state again as bugs reports are slowing down.\n        </p>\n          <ul>\n            <li>Bug fixed where GIMP would fail to open some XCF</li>\n            <li>When moving a floating layer or selection with a selection tool, marching ants are now disabled</li>\n            <li>Improved Text tool, especially regarding prioritizing global actions</li>\n            <li>Better temporary folder handling</li>\n            <li>Fill actions now behave accordingly to the target item type</li>\n            <li>Various file formats support improved</li>\n            <li>A new function and a deprecation in the libgimp API for plug-ins</li>\n          </ul>\n        ",
+      "timestamp": "1776384000",
+      "type": "stable",
+      "date": null,
+      "urgency": null
+    },
+    {
+      "url": "https://www.gimp.org/release/3.2.2/",
+      "version": "3.2.2",
+      "date_eol": null,
+      "description": "<p>\n        Here we go! The first bugfix release for the GIMP 3.2 series is here.\n        </p>\n          <ul>\n            <li>A bug when group layers became invisible in some conditions when children had effects got fixed</li>\n            <li>More fixes, especially for the new vector and link layer types, as well as non-destructive effects</li>\n            <li>Various file formats support improved</li>\n            <li>Themes fixes and improvements</li>\n            <li>Support for x86 (32-bit) architecture on Windows was dropped</li>\n          </ul>\n        ",
+      "timestamp": "1774656000",
+      "type": "stable",
+      "date": null,
+      "urgency": null
+    }
+  ],
+  "metadata": {
+    "flathub::verification::verified": true,
+    "flathub::verification::method": "website",
+    "flathub::verification::login_is_organization": false,
+    "flathub::verification::login_name": null,
+    "flathub::verification::login_provider": null,
+    "flathub::manifest": null,
+    "flathub::verification::website": "gimp.org",
+    "flathub::verification::timestamp": "1682352604"
+  },
+  "urls": {
+    "help": "https://www.gimp.org/docs/",
+    "donation": "https://www.gimp.org/donating/",
+    "translate": null,
+    "faq": null,
+    "contact": null,
+    "vcs_browser": "https://gitlab.gnome.org/GNOME/gimp/",
+    "contribute": "https://www.gimp.org/develop/",
+    "bugtracker": "https://gitlab.gnome.org/GNOME/gimp/issues/new",
+    "homepage": "https://www.gimp.org/"
+  },
+  "id": "org.gimp.GIMP"
+}

--- a/test/fixtures/files/flathub/recently-updated
+++ b/test/fixtures/files/flathub/recently-updated
@@ -1,0 +1,1 @@
+{"hits":[{"app_id":"dev.nicx.mimick","name":"Mimick","updated_at":1778162033},{"app_id":"org.kde.drawy","name":"Drawy","updated_at":1778160000},{"app_id":"org.gimp.GIMP","name":"GNU Image Manipulation Program","updated_at":1777907892}],"page":1,"per_page":100,"total_hits":3}

--- a/test/fixtures/files/flathub/stats_org.gimp.GIMP
+++ b/test/fixtures/files/flathub/stats_org.gimp.GIMP
@@ -1,0 +1,6 @@
+{
+  "id": "org.gimp.GIMP",
+  "installs_total": 3534790,
+  "installs_last_month": 72565,
+  "installs_last_7_days": 15537
+}

--- a/test/models/ecosystem/flathub_test.rb
+++ b/test/models/ecosystem/flathub_test.rb
@@ -1,0 +1,130 @@
+require "test_helper"
+
+class FlathubTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'flathub.org', url: 'https://flathub.org', ecosystem: 'flathub')
+    @ecosystem = Ecosystem::Flathub.new(@registry)
+    @package = Package.new(ecosystem: 'flathub', name: 'org.gimp.GIMP', metadata: { 'urls' => { 'help' => 'https://www.gimp.org/docs/' } })
+    @version = @package.versions.build(number: '3.2.4')
+  end
+
+  test 'registry_url' do
+    assert_equal 'https://flathub.org/apps/org.gimp.GIMP', @ecosystem.registry_url(@package)
+  end
+
+  test 'install_command' do
+    assert_equal 'flatpak install flathub org.gimp.GIMP', @ecosystem.install_command(@package)
+  end
+
+  test 'documentation_url' do
+    assert_equal 'https://www.gimp.org/docs/', @ecosystem.documentation_url(@package)
+  end
+
+  test 'check_status_url' do
+    assert_equal 'https://flathub.org/api/v2/appstream/org.gimp.GIMP', @ecosystem.check_status_url(@package)
+  end
+
+  test 'purl' do
+    purl = @ecosystem.purl(@package)
+    assert_equal 'pkg:flatpak/org.gimp.GIMP', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'purl with version' do
+    purl = @ecosystem.purl(@package, @version)
+    assert_equal 'pkg:flatpak/org.gimp.GIMP@3.2.4', purl
+    assert Purl.parse(purl)
+  end
+
+  test 'all_package_names' do
+    stub_request(:get, "https://flathub.org/api/v2/appstream")
+      .to_return({ status: 200, body: file_fixture('flathub/appstream') })
+    all_package_names = @ecosystem.all_package_names
+    assert_equal 5, all_package_names.length
+    assert_includes all_package_names, 'org.gimp.GIMP'
+  end
+
+  test 'recently_updated_package_names' do
+    stub_request(:get, "https://flathub.org/api/v2/collection/recently-updated?page=1&per_page=100")
+      .to_return({ status: 200, body: file_fixture('flathub/recently-updated') })
+    stub_request(:get, "https://flathub.org/api/v2/collection/recently-added?page=1&per_page=100")
+      .to_return({ status: 200, body: file_fixture('flathub/recently-updated') })
+    names = @ecosystem.recently_updated_package_names
+    assert_equal 3, names.length
+    assert_equal 'dev.nicx.mimick', names.first
+  end
+
+  test 'package_metadata' do
+    stub_request(:get, "https://flathub.org/api/v2/appstream/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/org.gimp.GIMP') })
+    stub_request(:get, "https://flathub.org/api/v2/stats/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/stats_org.gimp.GIMP') })
+    package_metadata = @ecosystem.package_metadata('org.gimp.GIMP')
+
+    assert_equal 'org.gimp.GIMP', package_metadata[:name]
+    assert_equal 'High-end image creation and manipulation', package_metadata[:description]
+    assert_equal 'https://www.gimp.org/', package_metadata[:homepage]
+    assert_equal 'GPL-3.0+ AND LGPL-3.0+', package_metadata[:licenses]
+    assert_equal 'https://gitlab.gnome.org/GNOME/gimp/', package_metadata[:repository_url]
+    assert_equal 'The GIMP team', package_metadata[:namespace]
+    assert_includes package_metadata[:keywords_array], 'Graphics'
+    assert_includes package_metadata[:keywords_array], 'Photoshop'
+    assert_equal 3534790, package_metadata[:downloads]
+    assert_equal 'total', package_metadata[:downloads_period]
+    assert_equal 'GNU Image Manipulation Program', package_metadata[:metadata][:display_name]
+    assert_equal 'org.gnome.Platform/x86_64/50', package_metadata[:metadata][:runtime]
+    assert package_metadata[:metadata][:verified]
+    assert_equal 72565, package_metadata[:metadata][:installs_last_month]
+  end
+
+  test 'package_metadata for missing package returns false' do
+    stub_request(:get, "https://flathub.org/api/v2/appstream/does.not.exist")
+      .to_return({ status: 404, body: '{"detail":"Not Found"}' })
+    assert_equal false, @ecosystem.package_metadata('does.not.exist')
+  end
+
+  test 'versions_metadata' do
+    stub_request(:get, "https://flathub.org/api/v2/appstream/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/org.gimp.GIMP') })
+    stub_request(:get, "https://flathub.org/api/v2/stats/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/stats_org.gimp.GIMP') })
+    package_metadata = @ecosystem.package_metadata('org.gimp.GIMP')
+    versions_metadata = @ecosystem.versions_metadata(package_metadata)
+
+    assert_equal 2, versions_metadata.length
+    assert_equal '3.2.4', versions_metadata.first[:number]
+    assert_equal Time.at(1776384000), versions_metadata.first[:published_at]
+    assert_equal 'stable', versions_metadata.first[:metadata][:release_type]
+    assert_equal 'https://www.gimp.org/release/3.2.4/', versions_metadata.first[:metadata][:url]
+  end
+
+  test 'dependencies_metadata for latest version' do
+    stub_request(:get, "https://flathub.org/api/v2/appstream/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/org.gimp.GIMP') })
+    stub_request(:get, "https://flathub.org/api/v2/stats/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/stats_org.gimp.GIMP') })
+    package_metadata = @ecosystem.package_metadata('org.gimp.GIMP')
+    deps = @ecosystem.dependencies_metadata('org.gimp.GIMP', '3.2.4', package_metadata)
+
+    assert_equal 2, deps.length
+    runtime = deps.find { |d| d[:kind] == 'runtime' }
+    assert_equal 'org.gnome.Platform', runtime[:package_name]
+    assert_equal '50', runtime[:requirements]
+    assert_equal 'flathub', runtime[:ecosystem]
+    sdk = deps.find { |d| d[:kind] == 'build' }
+    assert_equal 'org.gnome.Sdk', sdk[:package_name]
+  end
+
+  test 'dependencies_metadata for older version is empty' do
+    stub_request(:get, "https://flathub.org/api/v2/appstream/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/org.gimp.GIMP') })
+    stub_request(:get, "https://flathub.org/api/v2/stats/org.gimp.GIMP")
+      .to_return({ status: 200, body: file_fixture('flathub/stats_org.gimp.GIMP') })
+    package_metadata = @ecosystem.package_metadata('org.gimp.GIMP')
+    assert_equal [], @ecosystem.dependencies_metadata('org.gimp.GIMP', '3.2.2', package_metadata)
+  end
+
+  test 'has_dependent_repos' do
+    refute @ecosystem.has_dependent_repos?
+  end
+end


### PR DESCRIPTION
Adds support for indexing Flatpak apps from Flathub.

Uses the v2 REST API:
- `/api/v2/appstream` for the full package list (~3250 apps)
- `/api/v2/appstream/{id}` for per-app metadata (license, summary, vcs_browser, releases, categories, verification status)
- `/api/v2/stats/{id}` for total install counts
- `/api/v2/collection/recently-updated` and `recently-added` for incremental syncs

The flatpak runtime and sdk are recorded as dependencies on the latest version so reverse lookups like "what runs on org.gnome.Platform" work. purl type is `flatpak`.

To enable in production:

```ruby
Registry.find_or_create_by(name: 'flathub.org', url: 'https://flathub.org', ecosystem: 'flathub', github: 'flathub', default: true).sync_all_packages_async
```

Closes #1614