### PR TITLE
Propagate removed package status to versions

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -77,6 +77,7 @@ class Package < ApplicationRecord
   scope :with_advisories, -> { where("json_array_length(advisories) > 0") }
 
   after_create :update_rankings_async
+  after_update :mark_versions_removed, if: :saved_change_to_removed_status?
 
   def self.find_by_normalized_name(name)
     normalized_name = name.downcase.gsub('_', '-').gsub('.', '-')
@@ -366,6 +367,14 @@ class Package < ApplicationRecord
   def status
     val = read_attribute(:status)
     val == 'active' ? nil : val
+  end
+
+  def saved_change_to_removed_status?
+    saved_change_to_attribute?(:status) && read_attribute(:status) == 'removed'
+  end
+
+  def mark_versions_removed
+    versions.update_all(status: 'removed', updated_at: Time.current)
   end
 
   def check_status

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -201,6 +201,20 @@ class PackageTest < ActiveSupport::TestCase
     assert_equal 'removed', @package.reload.status
   end
 
+  test 'updating package status to removed marks versions removed' do
+    @package.update!(status: 'removed')
+
+    assert_equal ['removed'], @package.versions.reload.pluck(:status).uniq
+  end
+
+  test 'updating package status to another inactive status does not mark versions removed' do
+    @version.update!(status: 'yanked')
+
+    @package.update!(status: 'unpublished')
+
+    assert_equal ['yanked', nil], @package.versions.order(:number).pluck(:status)
+  end
+
   test 'check_status sets active when ecosystem returns nil' do
     @package.registry.ecosystem_instance.expects(:check_status).with(@package).returns(nil)
     @package.check_status


### PR DESCRIPTION
Fixes #509.

## Summary
- add a Package callback that marks all versions as removed when the package status changes to removed
- add model coverage for removed propagation and for preserving version statuses on other inactive package statuses

## Tests
- `docker run --rm -v "$PWD":/app -w /app ruby:4.0.3-alpine sh -lc 'ruby -v && ruby -c app/models/package.rb && ruby -c test/models/package_test.rb'`\n\nFull Rails tests were not run because this environment does not have local `ruby`/`bundle` installed; later Docker client runs hung before creating a container.