### PR TITLE
Poll PyPI RSS feeds every 2 minutes

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,10 @@
       "schedule": "*/5 * * * *"
     },
     {
+      "command": "bundle exec rake packages:sync_recent_pypi",
+      "schedule": "*/2 * * * *"
+    },
+    {
       "command": "bundle exec rake packages:sync_recent",
       "schedule": "*/15 * * * *"
     },

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -28,6 +28,14 @@ namespace :packages do
     end
   end
 
+  desc 'sync recently updated pypi packages'
+  task sync_recent_pypi: :environment do
+    with_rake_lock('packages:sync_recent_pypi') do
+      r = Registry.find_by(ecosystem: 'pypi')
+      r.sync_recently_updated_packages_async
+    end
+  end
+
   desc 'sync_worst_one_percent'
   task sync_worst_one_percent: :environment do
     with_rake_lock('packages:sync_worst_one_percent') do


### PR DESCRIPTION
Adds a dedicated `packages:sync_recent_pypi` rake task and schedules it every 2 minutes in `app.json`.

The PyPI `/rss/updates.xml` feed holds 100 items and PyPI sees roughly 8-10 releases per minute, so items roll off after ~10-12 minutes. The all-registries `packages:sync_recent` runs every 15 minutes, which means we were likely missing a few releases between polls. `recently_updated_package_names_excluding_recently_synced` already filters out anything synced in the last 10 minutes so the tighter interval won't enqueue duplicate jobs.

Same approach as https://github.com/miketheman/listen-to-pypi which polls these feeds every 30s.