### PR TITLE
fix: refresh existing version metadata on force sync

### DIFF
--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -227,8 +227,10 @@ module Ecosystem
       package
     end
 
-    def versions_metadata(pkg_metadata, existing_version_numbers = [])
-      pkg_metadata[:versions].reject{|v| existing_version_numbers.include?(v)}.sort_by { |v| Gem::Version.new(v) rescue Gem::Version.new('0') }.reverse
+    def versions_metadata(pkg_metadata, existing_version_numbers = [], force: false)
+      versions = pkg_metadata[:versions]
+      versions = versions.reject { |v| existing_version_numbers.include?(v) } unless force
+      versions.sort_by { |v| Gem::Version.new(v) rescue Gem::Version.new('0') }.reverse
         .map do |version|
           pom = get_pom(*pkg_metadata[:name].split(':', 2), version)
           next if pom.nil?

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -215,13 +215,10 @@ class Registry < ApplicationRecord
     end
 
     if force && versions_to_refresh.any?
-      versions_to_refresh.uniq! { |v| v.with_indifferent_access[:number].to_s }
-
-      versions_to_refresh.each_slice(100) do |s|
-        Version.upsert_all(
-          s,
-          unique_by: [:package_id, :number],
-          update_only: [:published_at, :licenses, :metadata, :status, :integrity, :registry_id, :updated_at]
+      by_number = package.versions.where(number: versions_to_refresh.map { |v| v[:number].to_s }).index_by(&:number)
+      versions_to_refresh.each do |v|
+        by_number[v[:number].to_s]&.update_columns(
+          v.slice(:published_at, :licenses, :metadata, :status, :integrity).compact.merge(updated_at: Time.zone.now)
         )
       end
     end
@@ -287,9 +284,7 @@ class Registry < ApplicationRecord
   end
 
   def versions_metadata_for_sync(package_metadata, existing_version_numbers, force:)
-    ecosystem_instance.versions_metadata(package_metadata, existing_version_numbers, force: force)
-  rescue ArgumentError
-    ecosystem_instance.versions_metadata(package_metadata, existing_version_numbers)
+    versions_metadata = ecosystem_instance.versions_metadata(package_metadata, force ? [] : existing_version_numbers)
   end
 
   def ecosystem_instance

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -197,12 +197,33 @@ class Registry < ApplicationRecord
     package.update_repo_metadata_async if update_repo_metadata_after_save
 
     new_versions = []
+    versions_to_refresh = []
     existing_version_numbers = package.versions.pluck('number')
 
-    versions_metadata = ecosystem_instance.versions_metadata(package_metadata, existing_version_numbers)
+    versions_metadata = versions_metadata_for_sync(package_metadata, existing_version_numbers, force: force)
 
     versions_metadata.each do |version|
-      new_versions << version.merge(package_id: package.id, registry_id: id, created_at: Time.now, updated_at: Time.now) unless existing_version_numbers.find { |v| v == version.with_indifferent_access[:number].to_s && version.with_indifferent_access[:status].nil? }
+      version_attrs = version.with_indifferent_access
+      number = version_attrs[:number].to_s
+      base_attrs = { package_id: package.id, registry_id: id, updated_at: Time.zone.now }
+
+      if existing_version_numbers.include?(number) && version_attrs[:status].nil?
+        versions_to_refresh << version.merge(base_attrs)
+      else
+        new_versions << version.merge(base_attrs.merge(created_at: Time.zone.now))
+      end
+    end
+
+    if force && versions_to_refresh.any?
+      versions_to_refresh.uniq! { |v| v.with_indifferent_access[:number].to_s }
+
+      versions_to_refresh.each_slice(100) do |s|
+        Version.upsert_all(
+          s,
+          unique_by: [:package_id, :number],
+          update_only: [:published_at, :licenses, :metadata, :status, :integrity, :registry_id, :updated_at]
+        )
+      end
     end
 
     if new_versions.any?
@@ -263,6 +284,12 @@ class Registry < ApplicationRecord
 
   def sync_package_async(name)
     SyncPackageWorker.perform_async(id, name)
+  end
+
+  def versions_metadata_for_sync(package_metadata, existing_version_numbers, force:)
+    ecosystem_instance.versions_metadata(package_metadata, existing_version_numbers, force: force)
+  rescue ArgumentError
+    ecosystem_instance.versions_metadata(package_metadata, existing_version_numbers)
   end
 
   def ecosystem_instance

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -166,6 +166,30 @@ class RegistryTest < ActiveSupport::TestCase
     Registry.sync_all_packages_async
   end
 
+  test 'sync_package refreshes published_at for existing version on force sync' do
+    package = @registry.packages.create!(name: 'test-package', ecosystem: @registry.ecosystem)
+    bad_date = Time.at(1_700_000)
+    version = package.versions.create!(
+      number: '1.0.0',
+      published_at: bad_date,
+      registry_id: @registry.id
+    )
+
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.stubs(:package_metadata).returns({ name: 'test-package', description: 'Test' })
+
+    corrected_date = Time.parse('2023-09-09T00:00:00Z')
+    ecosystem.stubs(:versions_metadata).returns([
+      { number: '1.0.0', published_at: corrected_date }
+    ])
+    ecosystem.stubs(:dependencies_metadata).returns([])
+
+    @registry.sync_package('test-package', force: true)
+
+    version.reload
+    assert_in_delta corrected_date.to_f, version.read_attribute(:published_at).to_f, 1.0
+  end
+
   test 'sync_package does not trigger N+1 when checking for existing dependencies' do
     # Create package with existing versions that have dependencies
     package = @registry.packages.create!(name: 'test-package', ecosystem: @registry.ecosystem)


### PR DESCRIPTION
## Summary\n- refresh existing version rows during  instead of only inserting new versions\n- let the Maven ecosystem include existing versions on forced syncs so corrected  dates can be re-fetched\n- add a regression test proving a forced sync repairs an existing version's stale  value\n\n## Why\nIssue #657 still has Maven versions stuck with 1970-era  values even after bulk resyncs. The current  path only upserts new versions, so forced resyncs never update existing rows with corrected metadata.\n\n## Validation\n- \n\n## Local test blocker\nI could not run the Rails test suite in this environment because the repo currently targets Ruby  / Bundler , which are not installed on this host. The added regression test is included for CI / a proper Ruby toolchain to exercise.\n\nCloses #657