### PR TITLE
Partial covering index on versions for latest dependent_packages join

### DIFF
--- a/db/migrate/20260527145308_add_latest_covering_index_to_versions.rb
+++ b/db/migrate/20260527145308_add_latest_covering_index_to_versions.rb
@@ -1,0 +1,13 @@
+class AddLatestCoveringIndexToVersions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    ActiveRecord::Base.connection.execute('SET statement_timeout TO 0')
+    add_index :versions, :id,
+              include: [:package_id],
+              where: "latest = true",
+              name: "index_versions_on_id_where_latest_covering",
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_11_180158) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_145308) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -228,6 +228,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_180158) do
     t.integer "registry_id"
     t.string "status"
     t.datetime "updated_at", null: false
+    t.index ["id"], name: "index_versions_on_id_where_latest_covering", where: "(latest = true)", include: ["package_id"]
     t.index ["package_id", "number"], name: "index_versions_on_package_id_and_number", unique: true
     t.index ["published_at"], name: "index_versions_on_published_at"
     t.index ["registry_id", "created_at"], name: "index_versions_on_registry_id_and_created_at"


### PR DESCRIPTION
Adds `index_versions_on_id_where_latest_covering` on `versions (id) INCLUDE (package_id) WHERE latest = true`, built concurrently with `statement_timeout` cleared.

The `latest_dependent_packages` / `latest_dependent_package_kinds` queries currently nested-loop probe `versions_pkey` and heap-fetch each row to read `package_id` and filter `latest`. With ~14M latest versions out of 163M total this index lets that probe become an index-only scan against a ~500MB partial index, and rows surviving into the HashAggregate/Sort drop from one-per-dependency-row to one-per-dependent-package.

Follows on from the API default flips so the default `dependent_packages` and `dependent_package_kinds` paths hit the `latest = true` branch and can use this.

Doesn't help the `?latest=false` opt-out, `update_dependent_packages_count`, or the dependencies-side scan for npm-scale targets.