### PR TITLE
feat: Add API endpoint to look up versions by integrity hash

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -76,33 +76,7 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
   end
 
   def lookup
-    integrity = params[:integrity]
-
-    if integrity.blank?
-      if params[:sha256].present?
-        integrity = "sha256-#{params[:sha256].to_s.downcase}"
-      elsif params[:sha1].present?
-        integrity = "sha1-#{params[:sha1].to_s.downcase}"
-      elsif params[:sha512].present?
-        integrity = "sha512-#{params[:sha512].to_s.downcase}"
-      end
-    end
-
-    if integrity.present? && integrity.match?(/\A[a-fA-F0-9]+\z/)
-      integrity = integrity.downcase
-
-      if integrity.length == 64
-        integrity = "sha256-#{integrity}"
-      elsif integrity.length == 40
-        integrity = "sha1-#{integrity}"
-      elsif integrity.length == 128
-        integrity = "sha512-#{integrity}"
-      end
-    elsif integrity.present?
-      integrity = integrity.sub(/\A(sha256|sha1|sha512)-([a-fA-F0-9]+)\z/i) do
-        "#{Regexp.last_match(1).downcase}-#{Regexp.last_match(2).downcase}"
-      end
-    end
+    integrity = Version.normalize_integrity(params)
 
     if integrity.blank?
       return render json: { error: 'Missing integrity parameter' }, status: :bad_request

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -74,4 +74,36 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
     @version = @package.versions.find_by_number!(params[:id])
     fresh_when @version, public: true
   end
+
+  def lookup
+    integrity = params[:integrity]
+
+    if integrity.blank?
+      if params[:sha256].present?
+        integrity = "sha256-#{params[:sha256]}"
+      elsif params[:sha1].present?
+        integrity = "sha1-#{params[:sha1]}"
+      elsif params[:sha512].present?
+        integrity = "sha512-#{params[:sha512]}"
+      end
+    end
+
+    if integrity.present? && integrity.match?(/\A[a-fA-F0-9]+\z/)
+      if integrity.length == 64
+        integrity = "sha256-#{integrity}"
+      elsif integrity.length == 40
+        integrity = "sha1-#{integrity}"
+      elsif integrity.length == 128
+        integrity = "sha512-#{integrity}"
+      end
+    end
+
+    if integrity.blank?
+      return render json: { error: 'Missing integrity parameter' }, status: :bad_request
+    end
+
+    scope = Version.where(integrity: integrity).includes(package: :registry)
+
+    @pagy, @versions = pagy_countless(scope)
+  end
 end

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -82,7 +82,9 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
       return render json: { error: 'Missing integrity parameter' }, status: :bad_request
     end
 
-    scope = Version.where(integrity: integrity).includes(:dependencies, package: :registry)
+    scope = Version.where(integrity: integrity)
+                   .includes(:dependencies, package: :registry)
+                   .order('published_at DESC nulls last, created_at DESC, id DESC')
 
     @pagy, @versions = pagy_countless(scope)
   end

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -80,15 +80,17 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
 
     if integrity.blank?
       if params[:sha256].present?
-        integrity = "sha256-#{params[:sha256]}"
+        integrity = "sha256-#{params[:sha256].to_s.downcase}"
       elsif params[:sha1].present?
-        integrity = "sha1-#{params[:sha1]}"
+        integrity = "sha1-#{params[:sha1].to_s.downcase}"
       elsif params[:sha512].present?
-        integrity = "sha512-#{params[:sha512]}"
+        integrity = "sha512-#{params[:sha512].to_s.downcase}"
       end
     end
 
     if integrity.present? && integrity.match?(/\A[a-fA-F0-9]+\z/)
+      integrity = integrity.downcase
+
       if integrity.length == 64
         integrity = "sha256-#{integrity}"
       elsif integrity.length == 40
@@ -96,13 +98,17 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
       elsif integrity.length == 128
         integrity = "sha512-#{integrity}"
       end
+    elsif integrity.present?
+      integrity = integrity.sub(/\A(sha256|sha1|sha512)-([a-fA-F0-9]+)\z/i) do
+        "#{Regexp.last_match(1).downcase}-#{Regexp.last_match(2).downcase}"
+      end
     end
 
     if integrity.blank?
       return render json: { error: 'Missing integrity parameter' }, status: :bad_request
     end
 
-    scope = Version.where(integrity: integrity).includes(package: :registry)
+    scope = Version.where(integrity: integrity).includes(:dependencies, package: :registry)
 
     @pagy, @versions = pagy_countless(scope)
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -28,6 +28,42 @@ class Version < ApplicationRecord
 
   scope :active, -> { where(status: nil) }
 
+  def self.normalize_integrity(params)
+    integrity = params[:integrity]
+
+    if integrity.blank?
+      if params[:sha256].present?
+        integrity = "sha256-#{params[:sha256].to_s.downcase}"
+      elsif params[:sha1].present?
+        integrity = "sha1-#{params[:sha1].to_s.downcase}"
+      elsif params[:sha512].present?
+        integrity = "sha512-#{params[:sha512].to_s.downcase}"
+      end
+    end
+
+    return if integrity.blank?
+
+    integrity = integrity.to_s
+
+    if integrity.match?(/\A[a-fA-F0-9]+\z/)
+      integrity = integrity.downcase
+
+      if integrity.length == 64
+        "sha256-#{integrity}"
+      elsif integrity.length == 40
+        "sha1-#{integrity}"
+      elsif integrity.length == 128
+        "sha512-#{integrity}"
+      else
+        integrity
+      end
+    else
+      integrity.sub(/\A(sha256|sha1|sha512)-([a-fA-F0-9]+)\z/i) do
+        "#{Regexp.last_match(1).downcase}-#{Regexp.last_match(2).downcase}"
+      end
+    end
+  end
+
   def to_param
     number.gsub(/(\r\n|\n)/, "%0A")
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -58,8 +58,11 @@ class Version < ApplicationRecord
         integrity
       end
     else
-      integrity.sub(/\A(sha256|sha1|sha512)-([a-fA-F0-9]+)\z/i) do
-        "#{Regexp.last_match(1).downcase}-#{Regexp.last_match(2).downcase}"
+      integrity.sub(/\A(sha256|sha1|sha512)-(.+)\z/i) do
+        digest = Regexp.last_match(2)
+        digest = digest.downcase if digest.match?(/\A[a-fA-F0-9]+\z/)
+
+        "#{Regexp.last_match(1).downcase}-#{digest}"
       end
     end
   end

--- a/app/views/api/v1/versions/lookup.json.jbuilder
+++ b/app/views/api/v1/versions/lookup.json.jbuilder
@@ -1,0 +1,16 @@
+json.array! @versions do |version|
+  package = version.package
+
+  json.partial! 'api/v1/versions/version', version: version
+
+  json.package do
+    json.partial! 'api/v1/packages/package', package: package
+
+    json.registry do
+      json.extract! package.registry, :name, :url, :ecosystem, :default, :packages_count, :maintainers_count, :namespaces_count, :keywords_count, :github, :metadata, :icon_url, :created_at, :updated_at
+      json.packages_url api_v1_registry_packages_url(registry_id: package.registry.name)
+      json.maintainers_url api_v1_registry_maintainers_url(registry_id: package.registry.name)
+      json.namespaces_url api_v1_registry_namespaces_url(registry_id: package.registry.name)
+    end
+  end
+end

--- a/app/views/api/v1/versions/lookup.json.jbuilder
+++ b/app/views/api/v1/versions/lookup.json.jbuilder
@@ -7,10 +7,7 @@ json.array! @versions do |version|
     json.partial! 'api/v1/packages/package', package: package
 
     json.registry do
-      json.extract! package.registry, :name, :url, :ecosystem, :default, :packages_count, :maintainers_count, :namespaces_count, :keywords_count, :github, :metadata, :icon_url, :created_at, :updated_at
-      json.packages_url api_v1_registry_packages_url(registry_id: package.registry.name)
-      json.maintainers_url api_v1_registry_maintainers_url(registry_id: package.registry.name)
-      json.namespaces_url api_v1_registry_namespaces_url(registry_id: package.registry.name)
+      json.partial! 'api/v1/registries/registry', registry: package.registry
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,12 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :dependencies, only: [:index]
 
+      resources :versions, only: [] do
+        collection do
+          get :lookup
+        end
+      end
+
       resources :keywords, only: [:index, :show], constraints: { id: /.*/ }, defaults: { format: :json }
 
       resources :critical, only: [:index] do

--- a/db/migrate/20260529182000_add_integrity_index_to_versions.rb
+++ b/db/migrate/20260529182000_add_integrity_index_to_versions.rb
@@ -1,4 +1,4 @@
-class AddIntegrityIndexToVersions < ActiveRecord::Migration[7.2]
+class AddIntegrityIndexToVersions < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20260529182000_add_integrity_index_to_versions.rb
+++ b/db/migrate/20260529182000_add_integrity_index_to_versions.rb
@@ -1,0 +1,7 @@
+class AddIntegrityIndexToVersions < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :versions, :integrity, algorithm: :concurrently, where: "integrity IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -237,6 +237,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_204256) do
     t.string "status"
     t.datetime "updated_at", null: false
     t.index ["id"], name: "index_versions_on_id_where_latest_covering", where: "(latest = true)", include: ["package_id"]
+    t.index ["integrity"], name: "index_versions_on_integrity", where: "(integrity IS NOT NULL)"
     t.index ["package_id", "number"], name: "index_versions_on_package_id_and_number", unique: true
     t.index ["published_at"], name: "index_versions_on_published_at"
     t.index ["registry_id", "created_at"], name: "index_versions_on_registry_id_and_created_at"

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -199,6 +199,55 @@ paths:
                       type: array
                       items:
                         $ref: '#/components/schemas/PackageWithRegistry'
+  /versions/lookup:
+    get:
+      summary: lookup versions by integrity hash
+      operationId: lookupVersions
+      tags:
+        - versions
+      parameters:
+        - name: integrity
+          in: query
+          description: integrity hash (SRI format)
+          required: false
+          schema:
+            type: string
+        - name: sha256
+          in: query
+          description: sha256 hash (hex)
+          required: false
+          schema:
+            type: string
+        - name: sha1
+          in: query
+          description: sha1 hash (hex)
+          required: false
+          schema:
+            type: string
+        - name: sha512
+          in: query
+          description: sha512 hash (hex)
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: page number
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Version'
+        '400':
+          description: missing integrity parameter
+
   /packages/lookup:
     get:
       summary: lookup a package by repository URL, purl or ecosystem+name

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -236,6 +236,12 @@ paths:
           required: false
           schema:
             type: integer
+        - name: per_page
+          in: query
+          description: Number of records to return
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: successful operation
@@ -244,7 +250,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Version'
+                  $ref: '#/components/schemas/VersionLookup'
         '400':
           description: missing integrity parameter
 
@@ -2143,6 +2149,15 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Dependency'
+    VersionLookup:
+      allOf:
+        - $ref: '#/components/schemas/VersionWithDependencies'
+        - type: object
+          required:
+            - package
+          properties:
+            package:
+              $ref: '#/components/schemas/PackageWithRegistry'
     VersionWithPackage:
       required:
         - id

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    Package.any_instance.stubs(:update_rankings_async)
-
     @registry = Registry.create(name: 'crates.io', url: 'https://crates.io', ecosystem: 'cargo')
     @package = @registry.packages.create(ecosystem: 'cargo', name: 'rand')
     @version = @package.versions.create(number: '1.0.0', metadata: {foo: 'bar'}, registry_id: @registry.id)
@@ -67,7 +65,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'lookup version by full integrity' do
-    @version.update!(integrity: "sha256-#{'a' * 64}")
+    @version.update_column(:integrity, "sha256-#{'a' * 64}")
 
     get lookup_api_v1_versions_path(integrity: "sha256-#{'a' * 64}")
     assert_response :success
@@ -82,7 +80,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'lookup version by sha256 hex parameter' do
     hex = 'b' * 64
-    @version.update!(integrity: "sha256-#{hex}")
+    @version.update_column(:integrity, "sha256-#{hex}")
 
     get lookup_api_v1_versions_path(sha256: hex.upcase)
     assert_response :success
@@ -95,7 +93,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'lookup version by sha1 hex parameter' do
     hex = 'c' * 40
-    @version.update!(integrity: "sha1-#{hex}")
+    @version.update_column(:integrity, "sha1-#{hex}")
 
     get lookup_api_v1_versions_path(sha1: hex.upcase)
     assert_response :success
@@ -108,7 +106,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'lookup version by sha512 hex parameter' do
     hex = 'd' * 128
-    @version.update!(integrity: "sha512-#{hex}")
+    @version.update_column(:integrity, "sha512-#{hex}")
 
     get lookup_api_v1_versions_path(sha512: hex.upcase)
     assert_response :success
@@ -121,7 +119,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'lookup version by bare integrity hex' do
     hex = 'e' * 64
-    @version.update!(integrity: "sha256-#{hex}")
+    @version.update_column(:integrity, "sha256-#{hex}")
 
     get lookup_api_v1_versions_path(integrity: hex.upcase)
     assert_response :success
@@ -142,7 +140,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'lookup version returns empty array without match' do
-    @version.update!(integrity: "sha256-#{'f' * 64}")
+    @version.update_column(:integrity, "sha256-#{'f' * 64}")
 
     get lookup_api_v1_versions_path(sha256: '0' * 64)
     assert_response :success

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -76,6 +76,34 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, actual_response.length
     assert_equal '1.0.0', actual_response.first['number']
     assert_equal @package.name, actual_response.first['package']['name']
+    assert actual_response.first['package']['registry'].key?('versions_count')
+    assert actual_response.first['package']['registry'].key?('downloads')
+    assert actual_response.first['package']['registry'].key?('purl_type')
+  end
+
+  test 'lookup version by full integrity with uppercase algorithm prefix' do
+    @version.update_column(:integrity, "sha256-#{'a' * 64}")
+
+    get lookup_api_v1_versions_path(integrity: "SHA256-#{'A' * 64}")
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
+  end
+
+  test 'lookup version by full integrity with base64 digest' do
+    digest = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+    @version.update_column(:integrity, "sha256-#{digest}")
+
+    get lookup_api_v1_versions_path(integrity: "SHA256-#{digest}")
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
   end
 
   test 'lookup version by sha256 hex parameter' do

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    Package.any_instance.stubs(:update_rankings_async)
+
     @registry = Registry.create(name: 'crates.io', url: 'https://crates.io', ecosystem: 'cargo')
     @package = @registry.packages.create(ecosystem: 'cargo', name: 'rand')
     @version = @package.versions.create(number: '1.0.0', metadata: {foo: 'bar'}, registry_id: @registry.id)
@@ -62,6 +64,92 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     first_version = actual_response.first
     assert_equal first_version['number'], '1.0.0'
     assert_equal first_version['metadata'], { 'foo' => 'bar' }
+  end
+
+  test 'lookup version by full integrity' do
+    @version.update!(integrity: "sha256-#{'a' * 64}")
+
+    get lookup_api_v1_versions_path(integrity: "sha256-#{'a' * 64}")
+    assert_response :success
+    assert_template 'versions/lookup', file: 'versions/lookup.json.jbuilder'
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
+    assert_equal @package.name, actual_response.first['package']['name']
+  end
+
+  test 'lookup version by sha256 hex parameter' do
+    hex = 'b' * 64
+    @version.update!(integrity: "sha256-#{hex}")
+
+    get lookup_api_v1_versions_path(sha256: hex.upcase)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
+  end
+
+  test 'lookup version by sha1 hex parameter' do
+    hex = 'c' * 40
+    @version.update!(integrity: "sha1-#{hex}")
+
+    get lookup_api_v1_versions_path(sha1: hex.upcase)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
+  end
+
+  test 'lookup version by sha512 hex parameter' do
+    hex = 'd' * 128
+    @version.update!(integrity: "sha512-#{hex}")
+
+    get lookup_api_v1_versions_path(sha512: hex.upcase)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
+  end
+
+  test 'lookup version by bare integrity hex' do
+    hex = 'e' * 64
+    @version.update!(integrity: "sha256-#{hex}")
+
+    get lookup_api_v1_versions_path(integrity: hex.upcase)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 1, actual_response.length
+    assert_equal '1.0.0', actual_response.first['number']
+  end
+
+  test 'lookup version returns bad request without integrity parameter' do
+    get lookup_api_v1_versions_path
+    assert_response :bad_request
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal 'Missing integrity parameter', actual_response['error']
+  end
+
+  test 'lookup version returns empty array without match' do
+    @version.update!(integrity: "sha256-#{'f' * 64}")
+
+    get lookup_api_v1_versions_path(sha256: '0' * 64)
+    assert_response :success
+
+    actual_response = Oj.load(@response.body)
+
+    assert_equal [], actual_response
   end
 
   test 'get version numbers' do


### PR DESCRIPTION
fixes #1631
depends on #1630...

### Description
this PR introduces a new endpoint to find versions by their artifact hash (`integrity`). this is particularly useful for identifying a package from a tarball hash or cross-referencing the same artifact published across multiple registries...

### Changes Made
* **Database:** Added a concurrent, partial B-tree index on `versions.integrity` (`WHERE integrity IS NOT NULL`) to support performant lookups across the large table without locking it during migration...
* **API Controller:** Implemented `GET /api/v1/versions/lookup` in the `VersionsController`. It handles exact `integrity` (SRI format) matches and normalizes bare hex digests provided via `sha256`, `sha1`, and `sha512` query parameters.
* **Jbuilder View:** Added `lookup.json.jbuilder` to structure the JSON response cleanly, ensuring the parent package and registry details are nested so the response is usable standalone.
* **OpenAPI Specs:** Updated `openapi/api/v1/openapi.yaml` to document the new `/versions/lookup` endpoint and its schema parameters.
