### PR TITLE
fix: ignore generic 'open source' string for SPDX license matching

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -287,7 +287,7 @@ class Package < ApplicationRecord
     read_attribute(:licenses).presence || repo_metadata && repo_metadata['license']
   end
 
-  NON_SPDX_LICENSE_VALUES = %w[other unknown none noassertion proprietary custom see\ license].freeze
+  NON_SPDX_LICENSE_VALUES = ["other", "unknown", "none", "noassertion", "proprietary", "custom", "see license", "open source"].freeze
 
   def spdx_license
     return Spdx.parse_spdx(licenses).licenses if Spdx.valid_spdx?(licenses)


### PR DESCRIPTION
fixes #1611

### Description
This PR fixes a bug where the generic `"Open Source"` string was being incorrectly fuzzy-matched to the `"TMate Open Source License"` (SPDX: `TMate`) by the `spdx` gem..

When an upstream registry (like NPM) has an empty license, `ecosyste.ms` falls back to GitHub API metadata, which sometimes returns `"Open Source"` for unclassified licenses. This led to packages like `innosetup-compiler` erroneously displaying `TMate` as their normalized license instead of remaining unclassified or "Other".

### Changes Made
- Added `"open source"` to the `NON_SPDX_LICENSE_VALUES` array in the `Package` model. This ensures that the generic string is properly ignored during SPDX parsing and correctly normalizes to `["Other"]`.