### PR TITLE
fix: add index for dependent_repos_count DESC NULLS LAST to fix API timeouts

### DIFF
--- a/db/migrate/20260530093800_add_desc_nulls_last_index_to_packages_dependent_repos_count.rb
+++ b/db/migrate/20260530093800_add_desc_nulls_last_index_to_packages_dependent_repos_count.rb
@@ -1,0 +1,10 @@
+class AddDescNullsLastIndexToPackagesDependentReposCount < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :packages, [:registry_id, :dependent_repos_count],
+              order: { dependent_repos_count: 'DESC NULLS LAST' },
+              algorithm: :concurrently,
+              name: 'index_packages_registry_id_dep_repos_desc'
+  end
+end


### PR DESCRIPTION
fixess #1632

### Description
This PR resolves the `HTTP 500` internal server errors that occur on the `/registries/{registry}/packages` endpoint when sorting by `dependent_repos_count` in descending order..

The endpoint was timing out because a previous refactoring applied `.nulls_last` to all API `ORDER BY` sorts. Since the existing database index for `dependent_repos_count` is ascending (where NULLs are placed last by default), Postgres cannot efficiently scan it backward when the query explicitly requests `DESC NULLS LAST`. This mismatch forced Postgres to perform a sequential scan and an expensive in-memory sort, leading to statement timeouts on large registries like NPM...

### Changes Made
- Added a new migration to create a concurrent index on `packages (registry_id, dependent_repos_count DESC NULLS LAST)`. This perfectly matches the query planner's requested sort order and allows the index to be scanned directly, restoring the endpoint's speed and preventing the timeout...