### PR TITLE
Fix PyPI license field returning full license body

### DIFF
--- a/app/models/ecosystem/pypi.rb
+++ b/app/models/ecosystem/pypi.rb
@@ -208,8 +208,7 @@ module Ecosystem
     end
 
     def version_licenses(name, version)
-      info = fetch_version(name, version)["info"] || {}
-      info["license_expression"].presence || info["license"].presence
+      licenses(fetch_version(name, version))
     end
 
     def dependencies_metadata(name, version, _package)
@@ -235,12 +234,24 @@ module Ecosystem
       nil
     end
 
-    def licenses(package)
-      return package["info"]["license_expression"] if package["info"]["license_expression"].present?
-      return package["info"]["license"] if package["info"]["license"].present?
+    LICENSE_IDENTIFIER_MAX_LENGTH = 100
 
-      license_classifiers = package["info"]["classifiers"].select { |c| c.start_with?("License :: ") }
-      license_classifiers.map { |l| l.split(":: ").last }.join(",")
+    def licenses(package)
+      info = package["info"] || {}
+      return info["license_expression"] if info["license_expression"].present?
+
+      license = info["license"]
+      return license if license_identifier?(license)
+
+      license_classifiers = (info["classifiers"] || []).select { |c| c.start_with?("License :: ") }
+      return license_classifiers.map { |l| l.split(":: ").last }.join(",") if license_classifiers.any?
+
+      license.presence
+    end
+
+    def license_identifier?(license)
+      return false if license.blank?
+      license.length <= LICENSE_IDENTIFIER_MAX_LENGTH && !license.include?("\n")
     end
 
     def package_find_names(package_name)

--- a/test/models/ecosystem/pypi_test.rb
+++ b/test/models/ecosystem/pypi_test.rb
@@ -476,6 +476,40 @@ class PypiTest < ActiveSupport::TestCase
     assert_equal "MIT License,BSD License", @ecosystem.licenses(package)
   end
 
+  test 'licenses falls back to classifiers when license contains a full license body' do
+    package = {
+      "info" => {
+        "license_expression" => nil,
+        "license" => "Copyright (c) 2001-2002 Enthought, Inc.\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met...",
+        "classifiers" => ["License :: OSI Approved :: BSD License"]
+      }
+    }
+    assert_equal "BSD License", @ecosystem.licenses(package)
+  end
+
+  test 'licenses falls back to classifiers when license is a long single-line string' do
+    package = {
+      "info" => {
+        "license_expression" => nil,
+        "license" => "BSD 3-Clause License Copyright (c) 2008-2011, AQR Capital Management, LLC, Lambda Foundry, Inc. and PyData Development Team. All rights reserved.",
+        "classifiers" => ["License :: OSI Approved :: BSD License"]
+      }
+    }
+    assert_equal "BSD License", @ecosystem.licenses(package)
+  end
+
+  test 'licenses returns license body when no classifiers available' do
+    body = "Copyright body\nwith newlines"
+    package = {
+      "info" => {
+        "license_expression" => nil,
+        "license" => body,
+        "classifiers" => []
+      }
+    }
+    assert_equal body, @ecosystem.licenses(package)
+  end
+
   test 'pypi package_metadata funding_url flask' do
     stub_request(:get, "https://pypi.org/pypi/flask/json")
       .to_return({ status: 200, body: file_fixture('pypi/flask/flask.json') })


### PR DESCRIPTION
Fixes #1662.

PyPI's `info.license` is free-form and some projects (scipy, pandas) upload the full license body there rather than an SPDX identifier. The lookup API surfaced that raw text in `licenses`, which in turn pushed `normalized_licenses` to `["Other"]` (the `Package#normalize_licenses` bail-out at >150 chars).

`Pypi#licenses` now treats `info.license` as an identifier only when it's short (<=100 chars) and single-line. Anything longer or multi-line is assumed to be a body and falls back to the `License ::` classifiers. If both are unusable it returns the raw string, matching prior behaviour. `version_licenses` now delegates to `licenses` so version-level lookups get the same fallback.

For scipy 1.17.0 and pandas this means `licenses` returns `"BSD License"` (from the `License :: OSI Approved :: BSD License` classifier) instead of the raw BSD body.