### PR TITLE
Populate Version#integrity for cargo, conan, pub, packagist

### DIFF
--- a/app/models/ecosystem/cargo.rb
+++ b/app/models/ecosystem/cargo.rb
@@ -90,6 +90,7 @@ module Ecosystem
           number: version["num"],
           published_at: version["created_at"],
           status: (version['yanked'] ? 'yanked' : nil),
+          integrity: version["checksum"].present? ? "sha256-" + version["checksum"] : nil,
           metadata: {
             uuid: version["id"],
             downloads: version["downloads"],

--- a/app/models/ecosystem/conan.rb
+++ b/app/models/ecosystem/conan.rb
@@ -125,6 +125,7 @@ module Ecosystem
 
         {
           number: version,
+	  integrity: sha256.present? ? "sha256-#{sha256}" : nil,
           metadata: {
             url: url,
             sha256: sha256

--- a/app/models/ecosystem/packagist.rb
+++ b/app/models/ecosystem/packagist.rb
@@ -123,6 +123,7 @@ module Ecosystem
         {
           number: version["version"],
           published_at: version["time"],
+          integrity: (version['dist'] && version['dist']['shasum'].present?) ? "sha1-#{version['dist']['shasum']}" : nil,
           metadata: metadata
         }
       end

--- a/app/models/ecosystem/pub.rb
+++ b/app/models/ecosystem/pub.rb
@@ -64,7 +64,8 @@ module Ecosystem
       pkg_metadata[:versions].map do |v|
         {
           number: v["version"],
-          published_at: v['published']
+          published_at: v['published'],
+          integrity: v["archive_sha256"].present? ? "sha256-#{v['archive_sha256']}" : nil
         }
       end
     end

--- a/test/models/ecosystem/cargo_test.rb
+++ b/test/models/ecosystem/cargo_test.rb
@@ -104,6 +104,7 @@ class CargoTest < ActiveSupport::TestCase
     assert_equal versions_metadata, [{:number=>"0.2.2",
     :published_at=>"2022-03-29T13:35:06.927472+00:00",
     :status=>nil,
+    :integrity=>"sha256-bced3bcb3f52104ec2c5d32d23b0b76fb4079a3567025f64ef500082bc29f2c3",
     :metadata=>
      {:uuid=>523961,
       :downloads=>473,
@@ -130,6 +131,7 @@ class CargoTest < ActiveSupport::TestCase
    {:number=>"0.1.0",
     :published_at=>"2022-03-24T16:19:57.595451+00:00",
     :status=>nil,
+    :integrity=>"sha256-3c73ba40f4d2fc31375a39ce83d08695993f14c411f6907fe032535843811806",
     :metadata=>
      {:uuid=>521540,
       :downloads=>120,
@@ -156,6 +158,7 @@ class CargoTest < ActiveSupport::TestCase
    {:number=>"0.1.0-dev.2",
     :published_at=>"2022-03-24T16:08:54.337646+00:00",
     :status=>nil,
+    :integrity=>"sha256-5f9bef8f40cfbd69b1cb8e9de369940adb6fc676dddcb878afcd5683f883e5de",
     :metadata=>
      {:uuid=>521537,
       :downloads=>100,
@@ -182,6 +185,7 @@ class CargoTest < ActiveSupport::TestCase
    {:number=>"0.1.0-dev.1",
     :published_at=>"2022-03-24T15:58:36.858899+00:00",
     :status=>nil,
+    :integrity=>"sha256-dcd44068a1f7ff7a8069aab2b41c6c5f378806bf22119e399ca04e4da1633ab6",
     :metadata=>
      {:uuid=>521532,
       :downloads=>102,

--- a/test/models/ecosystem/conan_test.rb
+++ b/test/models/ecosystem/conan_test.rb
@@ -86,6 +86,7 @@ class ConanTest < ActiveSupport::TestCase
     assert_equal versions_metadata.length, 1
     assert_equal versions_metadata.first[:number], '1.3.1'
     assert_equal versions_metadata.first[:metadata][:url], 'https://zlib.net/fossils/zlib-1.3.1.tar.gz'
+    assert_equal versions_metadata.first[:integrity], "sha256-9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
   end
 
   test 'dependencies_metadata from api' do

--- a/test/models/ecosystem/packagist_test.rb
+++ b/test/models/ecosystem/packagist_test.rb
@@ -103,6 +103,7 @@ class PackagistTest < ActiveSupport::TestCase
 
     first_version = versions_metadata.first
     assert_equal first_version[:number], "3.0.0"
+    assert_nil first_version[:integrity]
     assert_equal first_version[:published_at], "2021-07-14T16:46:02+00:00"
     assert_equal first_version[:metadata][:php_version], ">=8.0.0"
     assert_equal first_version[:metadata][:autoload], {"psr-4"=>{"Psr\\Log\\"=>"src"}}

--- a/test/models/ecosystem/pub_test.rb
+++ b/test/models/ecosystem/pub_test.rb
@@ -95,8 +95,8 @@ class PubTest < ActiveSupport::TestCase
     package_metadata = @ecosystem.package_metadata('bloc')
     versions_metadata = @ecosystem.versions_metadata(package_metadata)
 
-    assert_equal versions_metadata.first, {:number=>"0.1.0", :published_at=>"2018-10-08T02:30:26.298213Z"}
-    assert_equal versions_metadata.last, {:number=>"8.0.3", :published_at=>"2022-02-28T16:43:11.890583Z"}
+    assert_equal versions_metadata.first, {:number=>"0.1.0", :published_at=>"2018-10-08T02:30:26.298213Z", :integrity=>nil}
+    assert_equal versions_metadata.last, {:number=>"8.0.3", :published_at=>"2022-02-28T16:43:11.890583Z", :integrity=>nil}
   end
 
   test 'dependencies_metadata' do


### PR DESCRIPTION
Map the per-version hash already present in each registry response into the integrity column, using the existing "<algo>-<digest>" convention (cf. npm, rubygems, pypi). Refs ecosyste-ms/packages#1630.

- cargo:     checksum (sha256), already in metadata
- conan:     sha256, already in metadata
- pub:       archive_sha256 (sha256)
- packagist: dist.shasum (sha1) when present

Verified locally: stored integrity matches an independently computed sha256 of the downloaded artifact for cargo (anyhow), conan (zlib), and pub (http)