### PR TITLE
Populate Version#integrity for nuget via catalog leaf

### DIFF
--- a/app/models/ecosystem/nuget.rb
+++ b/app/models/ecosystem/nuget.rb
@@ -319,7 +319,7 @@ module Ecosystem
       return nil unless leaf.is_a?(Hash) && leaf["packageHash"].present?
       algo = (leaf["packageHashAlgorithm"] || "SHA512").to_s.downcase
       "#{algo}-#{leaf['packageHash']}"
-    rescue StandardError
+    rescue Faraday::Error, Oj::ParseError
       nil
     end
 

--- a/app/models/ecosystem/nuget.rb
+++ b/app/models/ecosystem/nuget.rb
@@ -305,9 +305,22 @@ module Ecosystem
           number: version,
           published_at: catalog_entry["published"],
           status: status,
+          integrity: version_integrity(item, skip: existing_set.include?(version.to_s)),
           metadata: build_version_nuspec_metadata(pkg_metadata[:name], version, pkg_metadata, item, skip_nuspec: existing_set.include?(version.to_s))
         }
       end
+    end
+
+    def version_integrity(item, skip: false)
+      return nil if skip
+      catalog_entry = item["catalogEntry"]
+      return nil unless catalog_entry && catalog_entry["@id"].present?
+      leaf = get_json(catalog_entry["@id"])
+      return nil unless leaf.is_a?(Hash) && leaf["packageHash"].present?
+      algo = (leaf["packageHashAlgorithm"] || "SHA512").to_s.downcase
+      "#{algo}-#{leaf['packageHash']}"
+    rescue StandardError
+      nil
     end
 
     def version_status(catalog_entry)

--- a/test/models/ecosystem/nuget_test.rb
+++ b/test/models/ecosystem/nuget_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class NugetTest < ActiveSupport::TestCase
   setup do
+    stub_request(:get, %r{\Ahttps://api\.nuget\.org/v3/catalog0/}).to_return(status: 200, body: '{}')
     @registry = Registry.new(default: true, name: 'NuGet.org', url: 'https://www.nuget.org', ecosystem: 'nuget')
     @ecosystem = Ecosystem::Nuget.new(@registry)
     @package = Package.new(ecosystem: 'nuget', name: 'ogcapi.net.sqlserver')
@@ -117,6 +118,10 @@ class NugetTest < ActiveSupport::TestCase
       .to_return({ status: 404, body: "" })
     stub_request(:get, "https://api.nuget.org/v3-flatcontainer/ogcapi.net.sqlserver/0.3.1/ogcapi.net.sqlserver.nuspec")
       .to_return({ status: 404, body: "" })
+    stub_request(:get, "https://api.nuget.org/v3/catalog0/data/2022.03.25.05.13.54/ogcapi.net.sqlserver.0.3.0.json")
+      .to_return({ status: 200, body: '{"packageHash":"AAAA000abc==","packageHashAlgorithm":"SHA512"}' })
+    stub_request(:get, "https://api.nuget.org/v3/catalog0/data/2022.03.25.10.27.50/ogcapi.net.sqlserver.0.3.1.json")
+      .to_return({ status: 200, body: '{"packageHash":"BBBB111def==","packageHashAlgorithm":"SHA512"}' })
     package_metadata = @ecosystem.package_metadata('ogcapi.net.sqlserver')
     versions_metadata = @ecosystem.versions_metadata(package_metadata)
 
@@ -128,7 +133,9 @@ class NugetTest < ActiveSupport::TestCase
     assert_equal "2022-03-25T05:11:36.793+00:00", versions_metadata[0][:published_at]
     assert_equal "0.3.1", versions_metadata[1][:number]
     assert_equal "2022-03-25T10:25:47.79+00:00", versions_metadata[1][:published_at]
-    
+    assert_equal "sha512-AAAA000abc==", versions_metadata[0][:integrity]
+    assert_equal "sha512-BBBB111def==", versions_metadata[1][:integrity]    
+
     # Check that metadata now includes enhanced information
     metadata_0 = versions_metadata[0][:metadata]
     assert_not_nil metadata_0


### PR DESCRIPTION
NuGet's registration catalogEntry doesn't carry the package hash, so fetch
the catalog leaf (catalogEntry["@id"]) which exposes packageHash +
packageHashAlgorithm (SHA512), and map it to integrity as sha512-<base64>. Refs ecosyste-ms/packages#1630.

Verified: stored integrity for Newtonsoft.Json 13.0.3 matches an
independent sha512 of the downloaded .nupkg.
