### PR TITLE
Populate Version#integrity for maven via .jar.sha1 sidecar

### DIFF
--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -244,6 +244,7 @@ module Ecosystem
             number: version,
             published_at: published_at_node ? Time.parse(published_at_node.text) : nil,
             licenses: license_list,
+            integrity: version_integrity(pkg_metadata[:name], version),
             metadata: {
               properties: properties,
               java_version: extract_java_version(pom),
@@ -258,6 +259,17 @@ module Ecosystem
         next
         end
         .compact
+    end
+
+    def version_integrity(name, version)
+      group_id, artifact_id = *name.split(':', 2)
+      url = "#{@registry_url}/#{group_id.gsub('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.jar.sha1"
+      resp = request(url)
+      return nil unless resp.respond_to?(:success?) && resp.success?
+      sha1 = resp.body.to_s.strip[/\A[0-9a-fA-F]{40}/]
+      sha1 ? "sha1-#{sha1.downcase}" : nil
+    rescue StandardError
+      nil
     end
 
     def dependencies_metadata(name, version, mapped_package)

--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -268,7 +268,7 @@ module Ecosystem
       return nil unless resp.respond_to?(:success?) && resp.success?
       sha1 = resp.body.to_s.strip[/\A[0-9a-fA-F]{40}/]
       sha1 ? "sha1-#{sha1.downcase}" : nil
-    rescue StandardError
+    rescue Faraday::Error
       nil
     end
 

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -5,6 +5,7 @@ class MavenTest < ActiveSupport::TestCase
   setup do
     @registry = Registry.new(default: true, name: 'repo1.maven.org', url: 'https://repo1.maven.org/maven2', ecosystem: 'maven')
     @ecosystem = Ecosystem::Maven.new(@registry)
+    stub_request(:get, /\.jar\.sha1$/).to_return(status: 404, body: '')
     @package = Package.new(ecosystem: 'maven', name: 'dev.zio:zio-aws-autoscaling_3')
     @version = @package.versions.build(number: '5.17.224.2')
   end
@@ -590,5 +591,19 @@ class MavenTest < ActiveSupport::TestCase
     assert_not_nil result2
     # Should only have made one HTTP request
     assert_requested(pom_stub, times: 1)
+  end
+
+  test 'version_integrity maps the .jar.sha1 sidecar to sha1 integrity' do
+    stub_request(:get, "https://repo1.maven.org/maven2/dev/zio/zio-aws-autoscaling_3/5.17.225.2/zio-aws-autoscaling_3-5.17.225.2.jar.sha1")
+      .to_return(status: 200, body: "16d2a89f307bc09e96af26d938ade5812550606a")
+    integrity = @ecosystem.send(:version_integrity, 'dev.zio:zio-aws-autoscaling_3', '5.17.225.2')
+    assert_equal "sha1-16d2a89f307bc09e96af26d938ade5812550606a", integrity
+  end
+
+  test 'version_integrity returns nil when no .jar.sha1 exists (pom-only / 404)' do
+    stub_request(:get, "https://repo1.maven.org/maven2/com/example/pom-only/1.0.0/pom-only-1.0.0.jar.sha1")
+      .to_return(status: 404, body: "")
+    integrity = @ecosystem.send(:version_integrity, 'com.example:pom-only', '1.0.0')
+    assert_nil integrity
   end
 end


### PR DESCRIPTION
Maven Central publishes a .sha1 sidecar next to each artifact; fetch
<artifact>-<version>.jar.sha1 and map it to integrity as sha1-<hex>.
Returns nil for pom-only artifacts (no jar). Refs ecosyste-ms/packages#1630.

Verified: stored integrity for dev.zio:zio-aws-autoscaling_3 5.17.225.2
matches an independent sha1 of the downloaded .jar (16d2a89f...); a full
sync populated 507/507 versions of that package.
