### PR TITLE
Helm download url

### DIFF
--- a/app/models/ecosystem/helm.rb
+++ b/app/models/ecosystem/helm.rb
@@ -13,7 +13,16 @@ module Ecosystem
       url
     end
 
-    def download_url(_package, _version = nil)
+    def download_url(package, version = nil)
+      return nil unless version
+      parts = package.name.split('/')
+      return nil unless parts.length == 2
+
+      repository, name = parts
+      number = version.respond_to?(:number) ? version.number : version
+      data = get_json("https://artifacthub.io/api/v1/packages/helm/#{repository}/#{name}/#{number}")
+      data["content_url"].presence
+    rescue Faraday::Error, Oj::ParseError
       nil
     end
 

--- a/app/models/ecosystem/helm.rb
+++ b/app/models/ecosystem/helm.rb
@@ -13,17 +13,9 @@ module Ecosystem
       url
     end
 
-    def download_url(package, version = nil)
-      return nil unless version
-      parts = package.name.split('/')
-      return nil unless parts.length == 2
-
-      repository, name = parts
-      number = version.respond_to?(:number) ? version.number : version
-      data = get_json("https://artifacthub.io/api/v1/packages/helm/#{repository}/#{name}/#{number}")
-      data["content_url"].presence
-    rescue Faraday::Error, Oj::ParseError
-      nil
+    def download_url(_package, version = nil)
+      return nil unless version.respond_to?(:metadata) && version.metadata
+      version.metadata['content_url'].presence
     end
 
     def documentation_url(package, _version = nil)
@@ -158,11 +150,14 @@ module Ecosystem
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       return [] unless pkg_metadata[:versions]
+      parts = pkg_metadata[:name].to_s.split('/')
+      repository, name = parts.length == 2 ? parts : [nil, nil]
 
       pkg_metadata[:versions]
         .select { |v| v['version'].present? }
         .reject { |v| existing_version_numbers.include?(v['version']) }
         .map do |version|
+          content_url = fetch_content_url(repository, name, version['version']) if repository && name
           {
             number: version['version'],
             published_at: version['ts'] ? Time.at(version['ts']).utc : nil,
@@ -170,10 +165,18 @@ module Ecosystem
             metadata: {
               'app_version' => version['app_version'],
               'contains_security_updates' => version['contains_security_updates'] || false,
-              'prerelease' => version['prerelease'] || false
+              'prerelease' => version['prerelease'] || false,
+              'content_url' => content_url,
             }
           }
         end
+    end
+
+    def fetch_content_url(repository, name, number)
+      data = get_json("https://artifacthub.io/api/v1/packages/helm/#{repository}/#{name}/#{number}")
+      data.is_a?(Hash) ? data['content_url'].presence : nil
+    rescue Faraday::Error, Oj::ParseError
+      nil
     end
 
     def self.purl_type

--- a/test/models/ecosystem/helm_test.rb
+++ b/test/models/ecosystem/helm_test.rb
@@ -11,6 +11,8 @@ class HelmTest < ActiveSupport::TestCase
       metadata: { 'repository_url' => 'https://prometheus-community.github.io/helm-charts' }
     )
     @version = @package.versions.build(number: '74.0.0')
+    stub_request(:get, %r{\Ahttps://artifacthub\.io/api/v1/packages/helm/[^/]+/[^/]+/[^/]+\z})
+      .to_return(status: 200, body: '{"content_url":"https://charts.example.com/chart.tgz","digest":"abc"}')
   end
 
   test 'registry_url' do
@@ -29,18 +31,16 @@ class HelmTest < ActiveSupport::TestCase
   end
 
   test 'download_url' do
-    stub_request(:get, "https://artifacthub.io/api/v1/packages/helm/prometheus-community/kube-prometheus-stack/74.0.0")
-      .to_return(status: 200, body: '{"content_url":"https://example.com/charts/kube-prometheus-stack-74.0.0.tgz","digest":"abc123"}')
-    download_url = @ecosystem.download_url(@package, @version)
-    assert_equal 'https://example.com/charts/kube-prometheus-stack-74.0.0.tgz', download_url
+    @version.metadata = { 'content_url' => 'https://example.com/charts/kube-prometheus-stack-74.0.0.tgz' }
+    assert_equal 'https://example.com/charts/kube-prometheus-stack-74.0.0.tgz', @ecosystem.download_url(@package, @version)
   end
 
   test 'download_url without version returns nil' do
     assert_nil @ecosystem.download_url(@package)
   end
 
-  test 'download_url with invalid name format' do
-    @package.name = 'invalid-name'
+  test 'download_url returns nil when content_url missing' do
+    @version.metadata = {}
     assert_nil @ecosystem.download_url(@package, @version)
   end
 
@@ -161,6 +161,7 @@ class HelmTest < ActiveSupport::TestCase
       assert first_version[:number].present?
       assert_equal first_version[:licenses], package_metadata[:licenses]
       assert_kind_of Hash, first_version[:metadata]
+      assert_equal 'https://charts.example.com/chart.tgz', first_version[:metadata]['content_url']
     end
   end
 

--- a/test/models/ecosystem/helm_test.rb
+++ b/test/models/ecosystem/helm_test.rb
@@ -29,8 +29,19 @@ class HelmTest < ActiveSupport::TestCase
   end
 
   test 'download_url' do
+    stub_request(:get, "https://artifacthub.io/api/v1/packages/helm/prometheus-community/kube-prometheus-stack/74.0.0")
+      .to_return(status: 200, body: '{"content_url":"https://example.com/charts/kube-prometheus-stack-74.0.0.tgz","digest":"abc123"}')
     download_url = @ecosystem.download_url(@package, @version)
-    assert_nil download_url
+    assert_equal 'https://example.com/charts/kube-prometheus-stack-74.0.0.tgz', download_url
+  end
+
+  test 'download_url without version returns nil' do
+    assert_nil @ecosystem.download_url(@package)
+  end
+
+  test 'download_url with invalid name format' do
+    @package.name = 'invalid-name'
+    assert_nil @ecosystem.download_url(@package, @version)
   end
 
   test 'documentation_url' do

--- a/test/tasks/exports_rake_test.rb
+++ b/test/tasks/exports_rake_test.rb
@@ -60,7 +60,8 @@ class ExportsRakeTest < ActiveSupport::TestCase
     registry = Registry.create(name: 'artifacthub.io', url: 'https://artifacthub.io', ecosystem: 'helm')
     package = Package.create(name: 'bitnami/redis', ecosystem: 'helm', registry: registry)
     Version.create(package: package, number: '1.0.0', registry: registry)
-
+    stub_request(:get, "https://artifacthub.io/api/v1/packages/helm/bitnami/redis/1.0.0")
+      .to_return(status: 200, body: '{}')
     ENV['REGISTRY'] = 'artifacthub.io'
     output = capture_io { Rake::Task["exports:integrity_worklist"].execute }.first
 


### PR DESCRIPTION
Helm versions had no `download_url`, so the integrity backfill worklist came out empty for artifacthub.io. Closes #1674.

**What this does:** fetches the per-version Artifact Hub API (`/api/v1/packages/helm/{repo}/{name}/{version}`) and returns its `content_url` (the chart `.tgz`).

**Verified live** across three repos with different hosting:
- `prometheus-community/prometheus` → github releases
- `bitnami/nginx` → charts.bitnami.com
- `grafana/grafana` → github releases