### PR TITLE
Deno download (closes #1673)

### DIFF
--- a/app/models/ecosystem/deno.rb
+++ b/app/models/ecosystem/deno.rb
@@ -3,16 +3,12 @@ module Ecosystem
     def registry_url(package, version = nil)
       "https://deno.land/x/#{package.name}"  + (version ? "@#{version}" : "")
     end
-    def download_url(package, version = nil)
-      return nil unless version
-      number = version.respond_to?(:number) ? version.number : version
-      meta = get_json("https://cdn.deno.land/#{package.name}/versions/#{CGI.escape(number)}/meta/meta.json")
-      opts = meta && meta["upload_options"]
-      return nil unless opts && opts["type"] == "github" && opts["repository"].present? && opts["ref"].present?
-
-      "https://codeload.github.com/#{opts['repository']}/tar.gz/refs/tags/#{opts['ref']}"
-    rescue Faraday::Error, Oj::ParseError
-      nil
+    def download_url(_package, version = nil)
+      return nil unless version.respond_to?(:metadata) && version.metadata
+      return nil unless version.metadata['source_type'] == 'github'
+      repo = version.metadata['source_repository'].presence or return nil
+      ref  = version.metadata['source_ref'].presence or return nil
+      "https://codeload.github.com/#{repo}/tar.gz/refs/tags/#{ref}"
     end
     def documentation_url(package, version = nil)
       if version
@@ -91,6 +87,11 @@ module Ecosystem
           {
             number: version,
             published_at: ver['uploaded_at'],
+            metadata: {
+              'source_type'       => (ver['upload_options'] || {})['type'],
+              'source_repository' => (ver['upload_options'] || {})['repository'],
+              'source_ref'        => (ver['upload_options'] || {})['ref'],
+            },
           }
         rescue
           nil

--- a/app/models/ecosystem/deno.rb
+++ b/app/models/ecosystem/deno.rb
@@ -3,7 +3,17 @@ module Ecosystem
     def registry_url(package, version = nil)
       "https://deno.land/x/#{package.name}"  + (version ? "@#{version}" : "")
     end
+    def download_url(package, version = nil)
+      return nil unless version
+      number = version.respond_to?(:number) ? version.number : version
+      meta = get_json("https://cdn.deno.land/#{package.name}/versions/#{CGI.escape(number)}/meta/meta.json")
+      opts = meta && meta["upload_options"]
+      return nil unless opts && opts["type"] == "github" && opts["repository"].present? && opts["ref"].present?
 
+      "https://codeload.github.com/#{opts['repository']}/tar.gz/refs/tags/#{opts['ref']}"
+    rescue Faraday::Error, Oj::ParseError
+      nil
+    end
     def documentation_url(package, version = nil)
       if version
         "https://doc.deno.land/https://deno.land/x/#{package.name}@#{version}/mod.ts"

--- a/test/models/ecosystem/deno_test.rb
+++ b/test/models/ecosystem/deno_test.rb
@@ -19,8 +19,20 @@ class DenoTest < ActiveSupport::TestCase
   end
 
   test 'download_url' do
+    stub_request(:get, "https://cdn.deno.land/deno_es/versions/v0.4.2/meta/meta.json")
+      .to_return(status: 200, body: '{"upload_options":{"type":"github","repository":"denosaurs/deno_es","ref":"v0.4.2"}}')
     download_url = @ecosystem.download_url(@package, @version)
-    assert_nil download_url
+    assert_equal 'https://codeload.github.com/denosaurs/deno_es/tar.gz/refs/tags/v0.4.2', download_url
+  end
+
+  test 'download_url without version returns nil' do
+    assert_nil @ecosystem.download_url(@package)
+  end
+
+  test 'download_url returns nil for non-github source' do
+    stub_request(:get, "https://cdn.deno.land/deno_es/versions/v0.4.2/meta/meta.json")
+      .to_return(status: 200, body: '{"upload_options":{"type":"other","repository":"x/y","ref":"v0.4.2"}}')
+    assert_nil @ecosystem.download_url(@package, @version)
   end
 
   test 'documentation_url' do

--- a/test/models/ecosystem/deno_test.rb
+++ b/test/models/ecosystem/deno_test.rb
@@ -19,10 +19,12 @@ class DenoTest < ActiveSupport::TestCase
   end
 
   test 'download_url' do
-    stub_request(:get, "https://cdn.deno.land/deno_es/versions/v0.4.2/meta/meta.json")
-      .to_return(status: 200, body: '{"upload_options":{"type":"github","repository":"denosaurs/deno_es","ref":"v0.4.2"}}')
-    download_url = @ecosystem.download_url(@package, @version)
-    assert_equal 'https://codeload.github.com/denosaurs/deno_es/tar.gz/refs/tags/v0.4.2', download_url
+    version = @package.versions.build(number: 'v0.4.2', metadata: {
+      'source_type' => 'github',
+      'source_repository' => 'denosaurs/deno_es',
+      'source_ref' => 'v0.4.2'
+    })
+    assert_equal 'https://codeload.github.com/denosaurs/deno_es/tar.gz/refs/tags/v0.4.2', @ecosystem.download_url(@package, version)
   end
 
   test 'download_url without version returns nil' do
@@ -30,9 +32,20 @@ class DenoTest < ActiveSupport::TestCase
   end
 
   test 'download_url returns nil for non-github source' do
+    version = @package.versions.build(number: 'v0.4.2', metadata: { 'source_type' => 'other' })
+    assert_nil @ecosystem.download_url(@package, version)
+  end
+  test 'versions_metadata captures github source for download_url' do
     stub_request(:get, "https://cdn.deno.land/deno_es/versions/v0.4.2/meta/meta.json")
-      .to_return(status: 200, body: '{"upload_options":{"type":"other","repository":"x/y","ref":"v0.4.2"}}')
-    assert_nil @ecosystem.download_url(@package, @version)
+      .to_return(status: 200, body: '{"uploaded_at":"2021-01-01T00:00:00Z","upload_options":{"type":"github","repository":"denosaurs/deno_es","ref":"v0.4.2"}}')
+    vm = @ecosystem.versions_metadata({ name: 'deno_es', versions: ['v0.4.2'] })
+    assert_equal 'github', vm.first[:metadata]['source_type']
+    assert_equal 'denosaurs/deno_es', vm.first[:metadata]['source_repository']
+    assert_equal 'v0.4.2', vm.first[:metadata]['source_ref']
+  end
+  test 'download_url returns nil when metadata missing' do
+    version = @package.versions.build(number: 'v0.4.2', metadata: {})
+    assert_nil @ecosystem.download_url(@package, version)
   end
 
   test 'documentation_url' do
@@ -122,9 +135,9 @@ class DenoTest < ActiveSupport::TestCase
     versions_metadata = @ecosystem.versions_metadata(package_metadata)
 
     assert_equal versions_metadata, [
-      {:number=>"v0.4.3", :published_at=>"2022-05-07T07:05:25.556Z"},
-      {:number=>"v0.4.2", :published_at=>"2022-03-25T06:16:54.883Z"},
-      {:number=>"v0.4.1", :published_at=>"2022-01-18T05:37:36.728Z"}
+      {:number=>"v0.4.3", :published_at=>"2022-05-07T07:05:25.556Z", :metadata=>{"source_type"=>"github", "source_repository"=>"jiawei397/deno_es", "source_ref"=>"v0.4.3"}},
+      {:number=>"v0.4.2", :published_at=>"2022-03-25T06:16:54.883Z", :metadata=>{"source_type"=>"github", "source_repository"=>"jiawei397/deno_es", "source_ref"=>"v0.4.2"}},
+      {:number=>"v0.4.1", :published_at=>"2022-01-18T05:37:36.728Z", :metadata=>{"source_type"=>"github", "source_repository"=>"jiawei397/deno_es", "source_ref"=>"v0.4.1"}}
     ]
   end
 


### PR DESCRIPTION
Deno versions inherited the nil `download_url` from `Ecosystem::Base`, so the integrity backfill worklist came out empty for deno.land. Closes #1673.

deno.land/x serves no single per-version archive, but each version's `meta.json` (`cdn.deno.land/{name}/versions/{version}/meta/meta.json`) records the exact GitHub source under `upload_options` - `repository` and `ref` (the published git tag). `download_url` reads that and returns the codeload tarball:
`https://codeload.github.com/{repository}/tar.gz/refs/tags/{ref}`

Using the recorded `ref` sidesteps the version->tag mapping problem (the `v`-prefix question): deno tells us the real tag per version rather than guessing.

**Verified live**:
- `oak` `v17.1.5` → `codeload.github.com/oakserver/oak/tar.gz/refs/tags/v17.1.5`
- `std` `0.224.0` → `codeload.github.com/denoland/deno_std/tar.gz/refs/tags/0.224.0`