### PR TITLE
Fix GitHub funding username parsing

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -614,7 +614,7 @@ class Package < ApplicationRecord
       next if v.blank?
       case key
       when "github"
-        Array(v).map{|username| "https://github.com/sponsors/#{username}" }
+        github_funding_usernames(v).map{|username| "https://github.com/sponsors/#{username}" }
       when "tidelift"
         "https://tidelift.com/funding/github/#{v}"
       when "community_bridge"
@@ -643,6 +643,10 @@ class Package < ApplicationRecord
         v
       end
     end.flatten.compact
+  end
+
+  def github_funding_usernames(value)
+    Array(value).flat_map { |username| username.to_s.split(",") }.map(&:strip).reject(&:blank?).first(4)
   end
 
   def stars

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -15,7 +15,6 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   setup do
-    UpdateRankingsWorker.stubs(:perform_async)
     @registry = Registry.create(default: true, name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
     @package = @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem, licenses: 'mit')
     @version = @package.versions.create(number: '1.0.0', published_at: 1.month.ago)
@@ -121,6 +120,23 @@ class PackageTest < ActiveSupport::TestCase
       'https://github.com/sponsors/foo',
       'https://github.com/sponsors/bar',
       'https://github.com/sponsors/baz'
+    ], @package.repo_funding_links
+  end
+
+  test 'repo_funding_links handles github username arrays' do
+    @package.update(
+      repo_metadata: {
+        'metadata' => {
+          'funding' => {
+            'github' => ['foo', 'bar']
+          }
+        }
+      }
+    )
+
+    assert_equal [
+      'https://github.com/sponsors/foo',
+      'https://github.com/sponsors/bar'
     ], @package.repo_funding_links
   end
 

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -15,6 +15,7 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   setup do
+    UpdateRankingsWorker.stubs(:perform_async)
     @registry = Registry.create(default: true, name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
     @package = @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem, licenses: 'mit')
     @version = @package.versions.create(number: '1.0.0', published_at: 1.month.ago)
@@ -103,6 +104,43 @@ class PackageTest < ActiveSupport::TestCase
 
   test 'install_command' do
     assert_equal @package.install_command, 'gem install foo -s https://rubygems.org'
+  end
+
+  test 'repo_funding_links splits comma separated github usernames' do
+    @package.update(
+      repo_metadata: {
+        'metadata' => {
+          'funding' => {
+            'github' => 'foo, bar, baz'
+          }
+        }
+      }
+    )
+
+    assert_equal [
+      'https://github.com/sponsors/foo',
+      'https://github.com/sponsors/bar',
+      'https://github.com/sponsors/baz'
+    ], @package.repo_funding_links
+  end
+
+  test 'repo_funding_links limits github usernames to four' do
+    @package.update(
+      repo_metadata: {
+        'metadata' => {
+          'funding' => {
+            'github' => 'foo, bar, baz, qux, quux'
+          }
+        }
+      }
+    )
+
+    assert_equal [
+      'https://github.com/sponsors/foo',
+      'https://github.com/sponsors/bar',
+      'https://github.com/sponsors/baz',
+      'https://github.com/sponsors/qux'
+    ], @package.repo_funding_links
   end
 
   test 'registry_url' do


### PR DESCRIPTION
## Summary

Fixes #752.

GitHub funding metadata can contain a comma-separated string of sponsor usernames. Previously this was treated as one username, which produced an invalid sponsor URL.

This change normalizes GitHub funding values by:

- splitting comma-separated usernames
- trimming whitespace
- ignoring blank entries
- limiting the result to four GitHub sponsor links

## Tests

```bash
rbenv exec ruby bin/rails test test/models/package_test.rb
```