### PR TITLE
Emit live webhook events for new packages and versions

### DIFF
--- a/app/lib/live_event.rb
+++ b/app/lib/live_event.rb
@@ -17,7 +17,7 @@ module LiveEvent
       req.body = { events: events }.to_json
     end
     nil
-  rescue Faraday::Error
+  rescue Faraday::Error, URI::InvalidURIError
     nil
   end
 end

--- a/app/lib/live_event.rb
+++ b/app/lib/live_event.rb
@@ -1,0 +1,23 @@
+module LiveEvent
+  def self.enabled?
+    ENV['LIVE_WEBHOOK_URL'].present?
+  end
+
+  def self.emit(events)
+    return unless enabled?
+    events = Array.wrap(events)
+    return if events.empty?
+
+    Faraday.post(ENV['LIVE_WEBHOOK_URL']) do |req|
+      req.options.timeout = 2
+      req.options.open_timeout = 2
+      req.headers['Content-Type'] = 'application/json'
+      req.headers['User-Agent'] = 'packages.ecosyste.ms'
+      req.headers['Authorization'] = "Bearer #{ENV['LIVE_WEBHOOK_TOKEN']}" if ENV['LIVE_WEBHOOK_TOKEN'].present?
+      req.body = { events: events }.to_json
+    end
+    nil
+  rescue Faraday::Error
+    nil
+  end
+end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -214,6 +214,53 @@ class Package < ApplicationRecord
     registry.purl(self)
   end
 
+  LIVE_EVENT_ATTRS = [:id, :name, :ecosystem, :description, :homepage, :licenses, :normalized_licenses,
+                      :repository_url, :keywords_array, :namespace, :versions_count, :first_release_published_at,
+                      :latest_release_published_at, :latest_release_number, :last_synced_at, :created_at,
+                      :updated_at, :dependent_packages_count, :downloads, :downloads_period,
+                      :dependent_repos_count, :rankings, :docker_dependents_count, :docker_downloads_count,
+                      :status, :critical].freeze
+  LIVE_EVENT_METHODS = [:registry_url, :install_command, :documentation_url, :purl, :docker_usage_url,
+                        :usage_url, :dependent_repositories_url, :funding_links].freeze
+
+  def as_live_event_json
+    as_json(only: LIVE_EVENT_ATTRS, methods: LIVE_EVENT_METHODS)
+  end
+
+  def packages_api_url
+    "https://packages.ecosyste.ms/api/v1/registries/#{registry.name}/packages/#{ERB::Util.url_encode(name)}"
+  end
+
+  def live_event_payload(event:, version: nil)
+    payload = {
+      event: event,
+      registry: registry.name,
+      registry_url: "https://packages.ecosyste.ms/api/v1/registries/#{registry.name}",
+      package_url: packages_api_url,
+      package: as_live_event_json
+    }
+    if version
+      payload[:version_url] = "#{packages_api_url}/versions/#{ERB::Util.url_encode(version.number)}"
+      payload[:version] = version.as_live_event_json
+    end
+    payload
+  end
+
+  def emit_new_package_event
+    return unless LiveEvent.enabled?
+    LiveEvent.emit(live_event_payload(event: 'package.created'))
+  end
+
+  def emit_new_version_events(version_records)
+    return unless LiveEvent.enabled?
+    return if version_records.blank?
+    events = version_records.map do |v|
+      v.package = self
+      live_event_payload(event: 'version.created', version: v)
+    end
+    LiveEvent.emit(events)
+  end
+
   def update_details
     set_latest_on_latest_version
     normalize_licenses
@@ -334,6 +381,7 @@ class Package < ApplicationRecord
     return false unless package_metadata
     versions_metadata = registry.ecosystem_instance.versions_metadata(package_metadata)
 
+    created_versions = []
     versions_metadata.each do |version|
       if version[:integrity].present?
         v = versions.find{|ver| ver.integrity == version[:integrity] }
@@ -343,16 +391,17 @@ class Package < ApplicationRecord
       begin
         if v
           v.registry_id = registry_id
-          v.assign_attributes(version) 
+          v.assign_attributes(version)
           v.save(validate: false)
-        else        
-          versions.create(version)
+        else
+          created_versions << versions.create(version)
         end
       rescue ActiveRecord::RecordNotUnique
         Rails.logger.warn("Version not unique: #{version[:number]}")
       end
     end
     update_columns(versions_count: versions.count, versions_updated_at: Time.now)
+    emit_new_version_events(created_versions)
   end
 
   def update_versions_async

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -394,7 +394,8 @@ class Package < ApplicationRecord
           v.assign_attributes(version)
           v.save(validate: false)
         else
-          created_versions << versions.create(version)
+          created = versions.create(version)
+          created_versions << created if created.persisted?
         end
       rescue ActiveRecord::RecordNotUnique
         Rails.logger.warn("Version not unique: #{version[:number]}")

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -215,8 +215,8 @@ class Registry < ApplicationRecord
       end
 
       if LiveEvent.enabled?
-        new_numbers = new_versions.map { |v| v.with_indifferent_access[:number].to_s }
-        package.emit_new_version_events(package.versions.where(number: new_numbers).to_a)
+        new_numbers = new_versions.map { |v| v.with_indifferent_access[:number].to_s } - existing_version_numbers
+        package.emit_new_version_events(package.versions.where(number: new_numbers).to_a) if new_numbers.any?
       end
 
       all_deps = []

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -191,9 +191,11 @@ class Registry < ApplicationRecord
     package.assign_attributes(package_metadata.except(:name, :releases, :versions, :version, :dependencies, :properties, :page, :time, :download_stats, :tags_url))
 
     update_repo_metadata_after_save = package.changed?
+    new_package = package.new_record?
 
     package.save!
 
+    package.emit_new_package_event if new_package
     package.update_repo_metadata_async if update_repo_metadata_after_save
 
     new_versions = []
@@ -211,7 +213,12 @@ class Registry < ApplicationRecord
       new_versions.each_slice(100) do |s|
         Version.upsert_all(s, unique_by: [:package_id, :number])
       end
-      
+
+      if LiveEvent.enabled?
+        new_numbers = new_versions.map { |v| v.with_indifferent_access[:number].to_s }
+        package.emit_new_version_events(package.versions.where(number: new_numbers).to_a)
+      end
+
       all_deps = []
       all_versions = package.versions
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -164,6 +164,15 @@ class Version < ApplicationRecord
     package.registry.ecosystem_instance.purl(package, self)
   end
 
+  LIVE_EVENT_ATTRS = [:id, :number, :published_at, :licenses, :integrity, :status, :metadata,
+                      :created_at, :updated_at, :latest].freeze
+  LIVE_EVENT_METHODS = [:download_url, :registry_url, :documentation_url, :install_command,
+                        :purl, :related_tag].freeze
+
+  def as_live_event_json
+    as_json(only: LIVE_EVENT_ATTRS, methods: LIVE_EVENT_METHODS)
+  end
+
   def digest_url
     "https://digest.ecosyste.ms/digest?url=#{CGI.escape(download_url)}&encoding=hex&algorithm=sha256" # TODO encoding and algorithm should come from ecosystem_instance
   end

--- a/docs/live-events.md
+++ b/docs/live-events.md
@@ -1,0 +1,72 @@
+# Live events
+
+packages.ecosyste.ms can post a webhook each time it records a new package or a new version. The receiver is expected to be an internal service (live.ecosyste.ms) that fans the events out to public SSE/WebSocket clients. This app does no fanout itself; it makes one HTTP POST per sync and moves on.
+
+The feature is off unless `LIVE_WEBHOOK_URL` is set. With it unset the emit methods return immediately, no payloads are built, and no extra queries run.
+
+## Configuration
+
+| Variable | Purpose |
+|---|---|
+| `LIVE_WEBHOOK_URL` | Full URL of the ingest endpoint. Presence of this enables the feature. |
+| `LIVE_WEBHOOK_TOKEN` | Optional. Sent as `Authorization: Bearer <token>` so the receiver can reject unauthenticated posts. |
+
+## When events fire
+
+Events are emitted inline from the sync path, which already runs inside Sidekiq, so there is no extra job.
+
+- [`Registry#sync_package`](../app/models/registry.rb#L198) emits `package.created` after saving a package that did not previously exist.
+- [`Registry#sync_package`](../app/models/registry.rb#L219) emits `version.created` for every row inserted via `Version.upsert_all`. The just-inserted versions are reloaded with one query and one POST carries all of them.
+- [`Package#update_versions`](../app/models/package.rb#L403) emits `version.created` for any versions it creates.
+
+[`LiveEvent.emit`](../app/lib/live_event.rb#L6) makes the request with a 2-second connect and read timeout and rescues `Faraday::Error`. A slow or dead receiver adds at most two seconds to a sync and never causes it to fail. Delivery is fire-and-forget with no retries; this is a live ticker, not a durable log, so a dropped event is acceptable.
+
+## Request
+
+```
+POST $LIVE_WEBHOOK_URL
+Content-Type: application/json
+User-Agent: packages.ecosyste.ms
+Authorization: Bearer $LIVE_WEBHOOK_TOKEN
+```
+
+```json
+{
+  "events": [
+    {
+      "event": "version.created",
+      "registry": "rubygems.org",
+      "registry_url": "https://packages.ecosyste.ms/api/v1/registries/rubygems.org",
+      "package_url": "https://packages.ecosyste.ms/api/v1/registries/rubygems.org/packages/rails",
+      "version_url": "https://packages.ecosyste.ms/api/v1/registries/rubygems.org/packages/rails/versions/8.1.1",
+      "package": {
+        "id": 123,
+        "name": "rails",
+        "ecosystem": "rubygems",
+        "purl": "pkg:gem/rails",
+        "registry_url": "https://rubygems.org/gems/rails",
+        "...": "..."
+      },
+      "version": {
+        "id": 456,
+        "number": "8.1.1",
+        "published_at": "2026-06-15T14:03:11Z",
+        "purl": "pkg:gem/rails@8.1.1",
+        "download_url": "https://rubygems.org/downloads/rails-8.1.1.gem",
+        "registry_url": "https://rubygems.org/gems/rails/versions/8.1.1",
+        "...": "..."
+      }
+    }
+  ]
+}
+```
+
+`events` is always an array. A `package.created` event has `registry_url`, `package_url` and `package` but no `version_url` or `version`.
+
+The `package` and `version` objects use the same field names as the [`Package`](../openapi/api/v1/openapi.yaml) and `Version` schemas in the public API, minus the parts that would cost extra queries to produce: `maintainers`, `dependencies`, the large `repo_metadata`/`metadata`/`advisories`/`issue_metadata` blobs on the package, and the route-helper `*_url` fields. See [`Package::LIVE_EVENT_ATTRS`](../app/models/package.rb#L217) and [`Version::LIVE_EVENT_ATTRS`](../app/models/version.rb#L167) for the exact lists.
+
+A consumer that wants any of the omitted data follows `registry_url`, `package_url` or `version_url`, which return the full API representation including dependencies, maintainers, and repo metadata. The inline objects carry enough (name, ecosystem, purl, description, download URL, published timestamp) to filter and display without round-tripping for every event.
+
+## Receiver expectations
+
+The receiver should respond quickly with any 2xx status; the body is ignored. It should validate the bearer token, assign each incoming event a monotonic id, keep a short ring buffer for `Last-Event-ID` replay, and broadcast to connected SSE clients with a heartbeat comment roughly every 25 seconds to keep Cloudflare from closing idle streams.

--- a/test/lib/live_event_test.rb
+++ b/test/lib/live_event_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class LiveEventTest < ActiveSupport::TestCase
+  teardown do
+    ENV.delete('LIVE_WEBHOOK_URL')
+    ENV.delete('LIVE_WEBHOOK_TOKEN')
+  end
+
+  test 'enabled? is false without env' do
+    refute LiveEvent.enabled?
+  end
+
+  test 'enabled? is true with env' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://live.test/ingest'
+    assert LiveEvent.enabled?
+  end
+
+  test 'emit does nothing without env' do
+    assert_nil LiveEvent.emit([{ event: 'version.created' }])
+  end
+
+  test 'emit does nothing with empty events' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://live.test/ingest'
+    assert_nil LiveEvent.emit([])
+    assert_nil LiveEvent.emit(nil)
+  end
+
+  test 'emit posts events with bearer token' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://live.test/ingest'
+    ENV['LIVE_WEBHOOK_TOKEN'] = 'secret'
+
+    stub = stub_request(:post, 'http://live.test/ingest')
+      .with(
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => 'Bearer secret',
+          'User-Agent' => 'packages.ecosyste.ms'
+        },
+        body: { events: [{ event: 'version.created', name: 'foo' }] }.to_json
+      )
+      .to_return(status: 200)
+
+    LiveEvent.emit({ event: 'version.created', name: 'foo' })
+    assert_requested stub
+  end
+
+  test 'emit posts without auth header when token unset' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://live.test/ingest'
+
+    stub_request(:post, 'http://live.test/ingest')
+      .with { |req| !req.headers.key?('Authorization') }
+      .to_return(status: 200)
+
+    LiveEvent.emit({ event: 'package.created' })
+    assert_requested :post, 'http://live.test/ingest'
+  end
+
+  test 'emit swallows connection errors' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://live.test/ingest'
+    stub_request(:post, 'http://live.test/ingest').to_raise(Faraday::ConnectionFailed)
+
+    assert_nothing_raised do
+      assert_nil LiveEvent.emit({ event: 'version.created' })
+    end
+  end
+
+  test 'emit swallows timeout errors' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://live.test/ingest'
+    stub_request(:post, 'http://live.test/ingest').to_timeout
+
+    assert_nothing_raised do
+      assert_nil LiveEvent.emit({ event: 'version.created' })
+    end
+  end
+end

--- a/test/lib/live_event_test.rb
+++ b/test/lib/live_event_test.rb
@@ -72,4 +72,12 @@ class LiveEventTest < ActiveSupport::TestCase
       assert_nil LiveEvent.emit({ event: 'version.created' })
     end
   end
+
+  test 'emit swallows invalid URI errors' do
+    ENV['LIVE_WEBHOOK_URL'] = 'http://[invalid'
+
+    assert_nothing_raised do
+      assert_nil LiveEvent.emit({ event: 'version.created' })
+    end
+  end
 end

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -334,4 +334,87 @@ class PackageTest < ActiveSupport::TestCase
     refute_includes results, package_without_advisories
     refute_includes results, @package
   end
+
+  test 'as_live_event_json includes API fields' do
+    json = @package.as_live_event_json
+
+    assert_equal 'foo', json['name']
+    assert_equal 'rubygems', json['ecosystem']
+    assert_equal 'pkg:gem/foo', json['purl']
+    assert_equal 'https://rubygems.org/gems/foo', json['registry_url']
+    assert_equal 'gem install foo -s https://rubygems.org', json['install_command']
+    assert json.key?('description')
+    assert json.key?('repository_url')
+    assert json.key?('latest_release_number')
+    assert json.key?('status')
+    refute json.key?('maintainers')
+    refute json.key?('repo_metadata')
+  end
+
+  test 'live_event_payload for package.created' do
+    payload = @package.live_event_payload(event: 'package.created')
+
+    assert_equal 'package.created', payload[:event]
+    assert_equal 'rubygems.org', payload[:registry]
+    assert_equal 'https://packages.ecosyste.ms/api/v1/registries/rubygems.org', payload[:registry_url]
+    assert_equal 'https://packages.ecosyste.ms/api/v1/registries/rubygems.org/packages/foo', payload[:package_url]
+    assert_equal 'foo', payload[:package]['name']
+    assert_equal 'pkg:gem/foo', payload[:package]['purl']
+    refute payload.key?(:version)
+  end
+
+  test 'live_event_payload for version.created' do
+    payload = @package.live_event_payload(event: 'version.created', version: @version)
+
+    assert_equal 'version.created', payload[:event]
+    assert_equal 'https://packages.ecosyste.ms/api/v1/registries/rubygems.org/packages/foo', payload[:package_url]
+    assert_equal 'https://packages.ecosyste.ms/api/v1/registries/rubygems.org/packages/foo/versions/1.0.0', payload[:version_url]
+    assert_equal 'foo', payload[:package]['name']
+    assert_equal '1.0.0', payload[:version]['number']
+    assert_equal 'pkg:gem/foo@1.0.0', payload[:version]['purl']
+    assert payload[:version].key?('published_at')
+    assert payload[:version].key?('download_url')
+  end
+
+  test 'live_event_payload encodes package name in url' do
+    npm = Registry.create(default: true, name: 'npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm')
+    pkg = npm.packages.create(name: '@scope/pkg', ecosystem: 'npm')
+
+    assert_equal 'https://packages.ecosyste.ms/api/v1/registries/npmjs.org/packages/%40scope%2Fpkg',
+                 pkg.live_event_payload(event: 'package.created')[:package_url]
+  end
+
+  test 'emit_new_package_event calls LiveEvent.emit' do
+    LiveEvent.stubs(:enabled?).returns(true)
+    LiveEvent.expects(:emit).with(has_entry(:event, 'package.created'))
+    @package.emit_new_package_event
+  end
+
+  test 'emit_new_package_event does nothing when LiveEvent disabled' do
+    LiveEvent.stubs(:enabled?).returns(false)
+    LiveEvent.expects(:emit).never
+    @package.emit_new_package_event
+  end
+
+  test 'emit_new_version_events calls LiveEvent.emit with one event per version' do
+    LiveEvent.stubs(:enabled?).returns(true)
+    LiveEvent.expects(:emit).with do |events|
+      events.length == 2 &&
+        events.all? { |e| e[:event] == 'version.created' } &&
+        events.map { |e| e[:version]['number'] } == ['1.0.0', '2.0.0']
+    end
+    @package.emit_new_version_events([@version, @version2])
+  end
+
+  test 'emit_new_version_events does nothing with empty array' do
+    LiveEvent.stubs(:enabled?).returns(true)
+    LiveEvent.expects(:emit).never
+    @package.emit_new_version_events([])
+  end
+
+  test 'emit_new_version_events does nothing when LiveEvent disabled' do
+    LiveEvent.stubs(:enabled?).returns(false)
+    LiveEvent.expects(:emit).never
+    @package.emit_new_version_events([@version])
+  end
 end

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -188,6 +188,23 @@ class RegistryTest < ActiveSupport::TestCase
     @registry.sync_package('existing')
   end
 
+  test 'sync_package does not emit version.created for status updates to existing versions' do
+    LiveEvent.stubs(:enabled?).returns(true)
+    pkg = @registry.packages.create(name: 'existing', ecosystem: 'rubygems', last_synced_at: 2.days.ago)
+    pkg.versions.create(number: '1.0.0', registry_id: @registry.id)
+
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.stubs(:package_metadata).returns({ name: 'existing' })
+    ecosystem.stubs(:versions_metadata).returns([{ number: '1.0.0', status: 'yanked' }])
+    ecosystem.stubs(:dependencies_metadata).returns([])
+    Package.any_instance.stubs(:check_status)
+    Package.any_instance.stubs(:update_repo_metadata_async)
+
+    Package.any_instance.expects(:emit_new_version_events).never
+
+    @registry.sync_package('existing')
+  end
+
   test 'sync_package skips version reload when LiveEvent disabled' do
     LiveEvent.stubs(:enabled?).returns(false)
 

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -154,6 +154,55 @@ class RegistryTest < ActiveSupport::TestCase
     @registry.sync_package_async('split')
   end
 
+  test 'sync_package emits package.created and version.created for new package' do
+    LiveEvent.stubs(:enabled?).returns(true)
+
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.stubs(:package_metadata).returns({ name: 'newpkg' })
+    ecosystem.stubs(:versions_metadata).returns([{ number: '1.0.0', published_at: Time.now }])
+    ecosystem.stubs(:dependencies_metadata).returns([])
+    Package.any_instance.stubs(:check_status)
+    Package.any_instance.stubs(:update_repo_metadata_async)
+
+    Package.any_instance.expects(:emit_new_package_event).once
+    Package.any_instance.expects(:emit_new_version_events).with do |records|
+      records.length == 1 && records.first.is_a?(Version) && records.first.number == '1.0.0'
+    end
+
+    @registry.sync_package('newpkg')
+  end
+
+  test 'sync_package does not emit package.created for existing package' do
+    LiveEvent.stubs(:enabled?).returns(true)
+    @registry.packages.create(name: 'existing', ecosystem: 'rubygems', last_synced_at: 2.days.ago)
+
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.stubs(:package_metadata).returns({ name: 'existing' })
+    ecosystem.stubs(:versions_metadata).returns([])
+    ecosystem.stubs(:dependencies_metadata).returns([])
+    Package.any_instance.stubs(:check_status)
+    Package.any_instance.stubs(:update_repo_metadata_async)
+
+    Package.any_instance.expects(:emit_new_package_event).never
+
+    @registry.sync_package('existing')
+  end
+
+  test 'sync_package skips version reload when LiveEvent disabled' do
+    LiveEvent.stubs(:enabled?).returns(false)
+
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.stubs(:package_metadata).returns({ name: 'newpkg' })
+    ecosystem.stubs(:versions_metadata).returns([{ number: '1.0.0' }])
+    ecosystem.stubs(:dependencies_metadata).returns([])
+    Package.any_instance.stubs(:check_status)
+    Package.any_instance.stubs(:update_repo_metadata_async)
+
+    Package.any_instance.expects(:emit_new_version_events).never
+
+    @registry.sync_package('newpkg')
+  end
+
   test 'sync_all_recently_updated_packages_async' do
     @registry.expects(:sync_recently_updated_packages_async).returns(true)
     Registry.stubs(:frequently_synced).returns([@registry])

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -57,4 +57,16 @@ class VersionTest < ActiveSupport::TestCase
     assert Purl.parse(@version.purl)
   end
 
+  test 'as_live_event_json includes API fields' do
+    json = @version.as_live_event_json
+
+    assert_equal '1.0.0', json['number']
+    assert_equal 'pkg:gem/foo@1.0.0', json['purl']
+    assert_equal 'https://rubygems.org/downloads/foo-1.0.0.gem', json['download_url']
+    assert_equal 'https://rubygems.org/gems/foo/versions/1.0.0', json['registry_url']
+    assert json.key?('published_at')
+    assert json.key?('integrity')
+    assert json.key?('status')
+    refute json.key?('dependencies')
+  end
 end


### PR DESCRIPTION
Adds a fire-and-forget webhook that posts whenever `Registry#sync_package` or `Package#update_versions` records a new package or version. The receiver is intended to be an internal Go service on `live.ecosyste.ms` that fans events out to public SSE clients.

Enabled only when `LIVE_WEBHOOK_URL` is set; with it unset no payloads are built and no extra queries run. `LIVE_WEBHOOK_TOKEN` is sent as a bearer header when present. The POST has a 2s timeout and rescues `Faraday::Error` so a dead receiver never breaks a sync.

Each event carries `registry_url`, `package_url` and (for versions) `version_url` pointing at the corresponding API resources, plus inline `package` and `version` objects using the same field names as the public API minus the bits that need extra queries (maintainers, dependencies, large jsonb blobs). Consumers follow the URL breadcrumbs for anything not included inline.

See `docs/live-events.md` for the full payload contract.