### PR TITLE
Cache top dependent packages for sorted dependent_packages requests

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -186,6 +186,16 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:id])
 
+    if TopDependentPackage.cacheable_request?(params) &&
+       (cached = @package.top_dependent_packages.find_by(sort: params[:sort]))
+      @pagy, page_ids = pagy_array(cached.dependent_ids)
+      by_id = Package.where(id: page_ids).includes(:registry, { maintainers: :registry }).index_by(&:id)
+      @packages = page_ids.map { |i| by_id[i] }.compact
+      response.headers['X-Source'] = 'top_dependent_packages'
+      fresh_when([cached, *@packages], public: true)
+      return
+    end
+
     if params[:latest] == 'false'
       scope = @package.dependent_packages(kind: params[:kind]).includes(:registry, {maintainers: :registry})
     else

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -41,6 +41,23 @@ class PackagesController < ApplicationController
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:id])
 
+    if @package.dependent_packages_count.to_i > TopDependentPackage::THRESHOLD
+      @kinds = nil
+    elsif params[:latest] == 'false'
+      @kinds = @package.dependent_package_kinds
+    else
+      @kinds = @package.latest_dependent_package_kinds
+    end
+
+    if TopDependentPackage.cacheable_request?(params) &&
+       (cached = @package.top_dependent_packages.find_by(sort: params[:sort]))
+      @pagy, page_ids = pagy_array(cached.dependent_ids)
+      by_id = Package.where(id: page_ids).includes(:registry).index_by(&:id)
+      @dependent_packages = page_ids.map { |i| by_id[i] }.compact
+      fresh_when([cached, *@dependent_packages], public: true)
+      return
+    end
+
     if params[:latest] == 'false'
       scope = @package.dependent_packages(kind: params[:kind]).includes(:registry)
     else
@@ -59,12 +76,6 @@ class PackagesController < ApplicationController
       end
     else
       scope = scope.order('latest_release_published_at DESC')
-    end
-
-    if params[:latest] == 'false'
-      @kinds = @package.dependent_package_kinds
-    else
-      @kinds = @package.latest_dependent_package_kinds
     end
 
     @pagy, @dependent_packages = pagy_countless(scope)

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -11,6 +11,7 @@ class Package < ApplicationRecord
 
   has_many :maintainerships, dependent: :delete_all
   has_many :maintainers, through: :maintainerships
+  has_many :top_dependent_packages, dependent: :delete_all
 
   def self.sortable_columns
     {
@@ -27,6 +28,7 @@ class Package < ApplicationRecord
       'docker_dependents_count' => 'docker_dependents_count',
       'stargazers_count' => "(repo_metadata ->> 'stargazers_count')::text::integer",
       'forks_count' => "(repo_metadata ->> 'forks_count')::text::integer",
+      'rank' => "(rankings ->> 'average')::float",
     }
   end
 
@@ -159,6 +161,21 @@ class Package < ApplicationRecord
   def update_dependent_packages_details
     update_dependent_package_ids
     update_dependent_packages_count
+    update_top_dependent_packages
+  end
+
+  def update_top_dependent_packages
+    if dependent_packages_count.to_i <= TopDependentPackage::THRESHOLD
+      top_dependent_packages.delete_all
+      return
+    end
+
+    ids = latest_dependent_packages.pluck(:id)
+    rows = TopDependentPackage::SORTS.map do |key, cfg|
+      top = Package.where(id: ids).order(Arel.sql(cfg[:order])).limit(TopDependentPackage::LIMIT).pluck(:id)
+      { package_id: id, sort: key, dependent_ids: top, updated_at: Time.current }
+    end
+    TopDependentPackage.upsert_all(rows, unique_by: [:package_id, :sort])
   end
 
   def update_maintainers_count

--- a/app/models/top_dependent_package.rb
+++ b/app/models/top_dependent_package.rb
@@ -1,0 +1,24 @@
+class TopDependentPackage < ApplicationRecord
+  belongs_to :package
+
+  LIMIT = 100
+  THRESHOLD = 100
+
+  SORTS = {
+    'dependent_packages_count' => { order: 'dependent_packages_count DESC NULLS LAST', direction: :desc },
+    'dependent_repos_count'    => { order: 'dependent_repos_count DESC NULLS LAST',    direction: :desc },
+    'downloads'                => { order: 'downloads DESC NULLS LAST',                direction: :desc },
+    'rank'                     => { order: "(rankings ->> 'average')::float ASC NULLS LAST", direction: :asc },
+  }
+
+  def self.cacheable_request?(params)
+    return false unless SORTS.key?(params[:sort])
+    return false if params[:latest] == 'false'
+    return false if params[:kind].present?
+    return false if params[:created_after].present? || params[:updated_after].present?
+    return false if params[:min_stars].present? || params[:min_downloads].present?
+
+    requested = params[:order] == 'asc' ? :asc : :desc
+    requested == SORTS[params[:sort]][:direction]
+  end
+end

--- a/app/views/packages/dependent_packages.html.erb
+++ b/app/views/packages/dependent_packages.html.erb
@@ -59,22 +59,24 @@
         </div>
       </div>
 
-      <div class='card mb-4'>
-        <div class='card-header'>
-          <h6 class="mb-0">Filter by Kind</h6>
-        </div>
-        <div class='list-group list-group-flush'>
-          <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind].blank? %>" href="<%= dependent_packages_registry_package_path(@registry, @package, latest: params[:latest], min_stars: params[:min_stars], min_downloads: params[:min_downloads]) %>">
-            All kinds
-          </a>
-          <% @kinds.sort_by(&:last).reverse.first(100).each do |kind, count| %>
-            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind] == kind %>" href="<%= dependent_packages_registry_package_path(@registry, @package, kind: kind, latest: params[:latest], min_stars: params[:min_stars], min_downloads: params[:min_downloads]) %>">
-              <%= kind %>
-              <span class='badge bg-primary rounded-pill'><%= number_with_delimiter count %></span>
+      <% if @kinds %>
+        <div class='card mb-4'>
+          <div class='card-header'>
+            <h6 class="mb-0">Filter by Kind</h6>
+          </div>
+          <div class='list-group list-group-flush'>
+            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind].blank? %>" href="<%= dependent_packages_registry_package_path(@registry, @package, latest: params[:latest], min_stars: params[:min_stars], min_downloads: params[:min_downloads]) %>">
+              All kinds
             </a>
-          <% end %>
+            <% @kinds.sort_by(&:last).reverse.first(100).each do |kind, count| %>
+              <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-break <%= 'active' if params[:kind] == kind %>" href="<%= dependent_packages_registry_package_path(@registry, @package, kind: kind, latest: params[:latest], min_stars: params[:min_stars], min_downloads: params[:min_downloads]) %>">
+                <%= kind %>
+                <span class='badge bg-primary rounded-pill'><%= number_with_delimiter count %></span>
+              </a>
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <%= render 'sidebar' %>
     </div>

--- a/db/migrate/20260630204256_create_top_dependent_packages.rb
+++ b/db/migrate/20260630204256_create_top_dependent_packages.rb
@@ -1,0 +1,11 @@
+class CreateTopDependentPackages < ActiveRecord::Migration[8.1]
+  def change
+    create_table :top_dependent_packages do |t|
+      t.integer :package_id, null: false
+      t.string :sort, null: false
+      t.integer :dependent_ids, array: true, null: false, default: []
+      t.datetime :updated_at, null: false
+    end
+    add_index :top_dependent_packages, [:package_id, :sort], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_145308) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_204256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -214,6 +214,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_145308) do
     t.string "name"
     t.datetime "updated_at", null: false
     t.string "url"
+  end
+
+  create_table "top_dependent_packages", force: :cascade do |t|
+    t.integer "dependent_ids", default: [], null: false, array: true
+    t.integer "package_id", null: false
+    t.string "sort", null: false
+    t.datetime "updated_at", null: false
+    t.index ["package_id", "sort"], name: "index_top_dependent_packages_on_package_id_and_sort", unique: true
   end
 
   create_table "versions", force: :cascade do |t|

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -388,4 +388,19 @@ namespace :packages do
       puts "#{pkg},#{deps.size},#{deps.uniq.join(';')}"
     end;nil
   end
+
+  desc 'populate top_dependent_packages cache for packages above threshold'
+  task update_top_dependent_packages: :environment do
+    with_rake_lock('packages:update_top_dependent_packages', ttl: 24.hours.to_i) do
+      ids = Package.where('dependent_packages_count > ?', TopDependentPackage::THRESHOLD)
+                   .order(dependent_packages_count: :desc)
+                   .pluck(:id)
+      ids.each_with_index do |package_id, i|
+        package = Package.find_by(id: package_id)
+        next unless package
+        package.update_top_dependent_packages
+        puts "#{i + 1}/#{ids.length} #{package.ecosystem}/#{package.name} (#{package.dependent_packages_count})" if (i % 100).zero?
+      end
+    end
+  end
 end

--- a/test/controllers/api/v1/packages_controller_test.rb
+++ b/test/controllers/api/v1/packages_controller_test.rb
@@ -884,6 +884,62 @@ class ApiV1PackagesControllerTest < ActionDispatch::IntegrationTest
     assert_includes names, 'used-rand-once'
   end
 
+  test 'dependent_packages serves from top_dependent_packages cache when available' do
+    dep1 = @registry.packages.create(name: 'dep-one', ecosystem: @registry.ecosystem, downloads: 100)
+    dep2 = @registry.packages.create(name: 'dep-two', ecosystem: @registry.ecosystem, downloads: 200)
+    dep3 = @registry.packages.create(name: 'dep-three', ecosystem: @registry.ecosystem, downloads: 50)
+    TopDependentPackage.create!(package_id: @package.id, sort: 'downloads', dependent_ids: [dep2.id, dep1.id, dep3.id], updated_at: Time.current)
+
+    get dependent_packages_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'downloads', order: 'desc', per_page: 2)
+    assert_response :success
+    assert_equal 'top_dependent_packages', @response.headers['X-Source']
+
+    names = Oj.load(@response.body).map { |p| p['name'] }
+    assert_equal ['dep-two', 'dep-one'], names
+  end
+
+  test 'dependent_packages cache paginates within cached ids' do
+    deps = 3.times.map { |i| @registry.packages.create(name: "dep#{i}", ecosystem: @registry.ecosystem) }
+    TopDependentPackage.create!(package_id: @package.id, sort: 'downloads', dependent_ids: deps.map(&:id), updated_at: Time.current)
+
+    get dependent_packages_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'downloads', per_page: 2, page: 2)
+    assert_response :success
+    assert_equal 'top_dependent_packages', @response.headers['X-Source']
+
+    names = Oj.load(@response.body).map { |p| p['name'] }
+    assert_equal ['dep2'], names
+  end
+
+  test 'dependent_packages cache skipped when sort not cached' do
+    TopDependentPackage.create!(package_id: @package.id, sort: 'downloads', dependent_ids: [999], updated_at: Time.current)
+
+    get dependent_packages_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'name')
+    assert_response :success
+    assert_nil @response.headers['X-Source']
+  end
+
+  test 'dependent_packages cache skipped when filters present' do
+    dep = @registry.packages.create(name: 'cached-dep', ecosystem: @registry.ecosystem)
+    TopDependentPackage.create!(package_id: @package.id, sort: 'downloads', dependent_ids: [dep.id], updated_at: Time.current)
+
+    get dependent_packages_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'downloads', kind: 'runtime')
+    assert_response :success
+    assert_nil @response.headers['X-Source']
+  end
+
+  test 'dependent_packages cache skipped for rank with default desc order' do
+    dep = @registry.packages.create(name: 'cached-dep', ecosystem: @registry.ecosystem)
+    TopDependentPackage.create!(package_id: @package.id, sort: 'rank', dependent_ids: [dep.id], updated_at: Time.current)
+
+    get dependent_packages_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'rank')
+    assert_response :success
+    assert_nil @response.headers['X-Source']
+
+    get dependent_packages_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'rank', order: 'asc')
+    assert_response :success
+    assert_equal 'top_dependent_packages', @response.headers['X-Source']
+  end
+
   test 'dependent_package_kinds defaults to latest versions only' do
     dependent = @registry.packages.create(name: 'needs-rand', ecosystem: @registry.ecosystem)
     old = dependent.versions.create(number: '1.0.0', latest: false)

--- a/test/controllers/packages_controller_test.rb
+++ b/test/controllers/packages_controller_test.rb
@@ -58,6 +58,47 @@ class PackagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'dependent_packages serves from top_dependent_packages cache when available' do
+    dep1 = @registry.packages.create(name: 'dep-one', ecosystem: @registry.ecosystem)
+    dep2 = @registry.packages.create(name: 'dep-two', ecosystem: @registry.ecosystem)
+    TopDependentPackage.create!(package_id: @package.id, sort: 'downloads', dependent_ids: [dep2.id, dep1.id], updated_at: Time.current)
+
+    get dependent_packages_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'downloads', order: 'desc')
+    assert_response :success
+    assert_template 'packages/dependent_packages'
+    assert_equal [dep2, dep1], assigns(:dependent_packages)
+  end
+
+  test 'dependent_packages skips kinds sidebar above threshold' do
+    @package.update_column(:dependent_packages_count, TopDependentPackage::THRESHOLD + 1)
+
+    get dependent_packages_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :success
+    assert_nil assigns(:kinds)
+    assert_no_match 'Filter by Kind', @response.body
+  end
+
+  test 'dependent_packages renders kinds sidebar below threshold' do
+    dependent = @registry.packages.create(name: 'needs-rand', ecosystem: @registry.ecosystem)
+    v = dependent.versions.create(number: '1.0.0', latest: true)
+    v.dependencies.create(package_id: @package.id, package_name: @package.name, ecosystem: @registry.ecosystem, requirements: '>= 0', kind: 'runtime')
+
+    get dependent_packages_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :success
+    assert_equal({ 'runtime' => 1 }, assigns(:kinds))
+    assert_match 'Filter by Kind', @response.body
+  end
+
+  test 'dependent_packages falls through when no cache row exists' do
+    dependent = @registry.packages.create(name: 'needs-rand', ecosystem: @registry.ecosystem)
+    v = dependent.versions.create(number: '1.0.0', latest: true)
+    v.dependencies.create(package_id: @package.id, package_name: @package.name, ecosystem: @registry.ecosystem, requirements: '>= 0', kind: 'runtime')
+
+    get dependent_packages_registry_package_path(registry_id: @registry.name, id: @package.name, sort: 'downloads')
+    assert_response :success
+    assert_equal [dependent], assigns(:dependent_packages)
+  end
+
   test 'get maintainers for pypi package with underscore in name' do
     pypi_registry = Registry.create(name: 'pypi.org', url: 'https://pypi.org', ecosystem: 'pypi')
     pypi_package = pypi_registry.packages.create(

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -431,4 +431,53 @@ class PackageTest < ActiveSupport::TestCase
 
     assert_nothing_raised { @package.emit_new_version_events([@version]) }
   end
+
+  test 'update_top_dependent_packages does nothing below threshold' do
+    @package.update_column(:dependent_packages_count, TopDependentPackage::THRESHOLD)
+    @package.update_top_dependent_packages
+    assert_empty @package.top_dependent_packages
+  end
+
+  test 'update_top_dependent_packages clears stale rows below threshold' do
+    TopDependentPackage.create!(package_id: @package.id, sort: 'downloads', dependent_ids: [1, 2, 3], updated_at: Time.current)
+    @package.update_column(:dependent_packages_count, 5)
+    @package.update_top_dependent_packages
+    assert_empty @package.top_dependent_packages.reload
+  end
+
+  test 'update_top_dependent_packages writes one row per sort above threshold' do
+    deps = 3.times.map do |i|
+      d = @registry.packages.create!(name: "dep#{i}", ecosystem: @registry.ecosystem,
+                                      downloads: (i + 1) * 100,
+                                      dependent_packages_count: 3 - i,
+                                      dependent_repos_count: i,
+                                      rankings: { 'average' => (i + 1).to_f })
+      v = d.versions.create!(number: '1.0.0', latest: true)
+      v.dependencies.create!(package_id: @package.id, package_name: @package.name, ecosystem: @registry.ecosystem, requirements: '>= 0', kind: 'runtime')
+      d
+    end
+
+    @package.update_column(:dependent_packages_count, TopDependentPackage::THRESHOLD + 1)
+    @package.update_top_dependent_packages
+
+    rows = @package.top_dependent_packages.reload.index_by(&:sort)
+    assert_equal TopDependentPackage::SORTS.keys.sort, rows.keys.sort
+
+    assert_equal [deps[2].id, deps[1].id, deps[0].id], rows['downloads'].dependent_ids
+    assert_equal [deps[0].id, deps[1].id, deps[2].id], rows['dependent_packages_count'].dependent_ids
+    assert_equal [deps[2].id, deps[1].id, deps[0].id], rows['dependent_repos_count'].dependent_ids
+    assert_equal [deps[0].id, deps[1].id, deps[2].id], rows['rank'].dependent_ids
+  end
+
+  test 'update_top_dependent_packages upserts on repeat' do
+    dep = @registry.packages.create!(name: 'dep', ecosystem: @registry.ecosystem, downloads: 100)
+    v = dep.versions.create!(number: '1.0.0', latest: true)
+    v.dependencies.create!(package_id: @package.id, package_name: @package.name, ecosystem: @registry.ecosystem, requirements: '>= 0', kind: 'runtime')
+
+    @package.update_column(:dependent_packages_count, TopDependentPackage::THRESHOLD + 1)
+    @package.update_top_dependent_packages
+    @package.update_top_dependent_packages
+
+    assert_equal TopDependentPackage::SORTS.size, @package.top_dependent_packages.reload.count
+  end
 end

--- a/test/models/top_dependent_package_test.rb
+++ b/test/models/top_dependent_package_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class TopDependentPackageTest < ActiveSupport::TestCase
+  context 'associations' do
+    should belong_to(:package)
+  end
+
+  test 'cacheable_request? matches sort and direction' do
+    assert TopDependentPackage.cacheable_request?(sort: 'downloads')
+    assert TopDependentPackage.cacheable_request?(sort: 'downloads', order: 'desc')
+    assert TopDependentPackage.cacheable_request?(sort: 'rank', order: 'asc')
+    assert TopDependentPackage.cacheable_request?(sort: 'dependent_packages_count')
+    assert TopDependentPackage.cacheable_request?(sort: 'dependent_repos_count')
+  end
+
+  test 'cacheable_request? rejects wrong direction' do
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', order: 'asc')
+    refute TopDependentPackage.cacheable_request?(sort: 'rank')
+    refute TopDependentPackage.cacheable_request?(sort: 'rank', order: 'desc')
+  end
+
+  test 'cacheable_request? rejects unknown sort' do
+    refute TopDependentPackage.cacheable_request?(sort: 'name')
+    refute TopDependentPackage.cacheable_request?(sort: nil)
+    refute TopDependentPackage.cacheable_request?({})
+  end
+
+  test 'cacheable_request? rejects filters' do
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', latest: 'false')
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', kind: 'runtime')
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', min_stars: '10')
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', min_downloads: '100')
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', created_after: '2025-01-01')
+    refute TopDependentPackage.cacheable_request?(sort: 'downloads', updated_after: '2025-01-01')
+  end
+end


### PR DESCRIPTION
Sorted `dependent_packages` requests time out for heavy targets (e.g. `golang.org/x/sys` has ~2.9M rows in `dependencies`, ~179k distinct dependents). The cost is materialising the full dependent set via the `dependencies -> versions` join before sorting, so pagination tweaks don't help page 1.

This adds a `top_dependent_packages` side table holding the top 100 dependent package ids per `(package, sort)` for four sorts: `downloads`, `dependent_packages_count`, `dependent_repos_count`, and `rank` (`rankings->>'average'` asc). Only populated for packages with `dependent_packages_count > 100` (~30k packages, ~120k rows).

Both API and HTML `dependent_packages` actions serve from the cache when the request matches a cached sort/direction, `latest` is not `false`, and no `kind`/`min_*`/`*_after` filters are set. Cached responses set `X-Source: top_dependent_packages` and pagy reports the cached size as the total, so paging beyond 100 returns empty rather than falling back to the slow join. Non-matching requests fall through unchanged.

Population is via `Package#update_top_dependent_packages`, called from `update_dependent_packages_details` and a new `packages:update_top_dependent_packages` rake task that walks above-threshold packages heaviest-first under `with_rake_lock`. Nothing depends on the noop'd `UpdateDependentPackagesCountWorker`.

Also adds `rank` to `Package.sortable_columns`, and skips the kinds sidebar on the HTML page for packages above the threshold since `latest_dependent_package_kinds` runs the same slow join.


After merge + deploy:
```
dokku run rake db:migrate
dokku run rake packages:update_top_dependent_packages
```
The backfill processes heaviest-first so the 669 packages with >10k dependents get covered early; can be stopped once those are done if the full ~30k takes too long.
