### PR TITLE
Fix GitLab URL parsing for nested subgroups

### DIFF
--- a/app/services/gitlab_url_parser.rb
+++ b/app/services/gitlab_url_parser.rb
@@ -16,4 +16,27 @@ class GitlabUrlParser < UrlParser
   def remove_domain
     url.gsub!(/(gitlab.com)+?(:|\/)?/i, '')
   end
+
+  def remove_extra_segments
+    segments = url.dup.split('/').reject(&:blank?)
+    repository_segments = trim_repository_suffix(segments)
+
+    self.url = repository_segments
+  end
+
+  def format_url
+    return nil unless url.is_a?(Array) && url.length >= 2
+
+    url.join('/')
+  end
+
+  def trim_repository_suffix(segments)
+    gitlab_separator_index = segments.index('-')
+    return segments[0...gitlab_separator_index] if gitlab_separator_index
+
+    tags_index = segments.index('tags')
+    return segments[0...tags_index] if tags_index
+
+    segments
+  end
 end

--- a/app/services/gitlab_url_parser.rb
+++ b/app/services/gitlab_url_parser.rb
@@ -31,12 +31,16 @@ class GitlabUrlParser < UrlParser
   end
 
   def trim_repository_suffix(segments)
-    gitlab_separator_index = segments.index('-')
+    gitlab_separator_index = suffix_index(segments, '-')
     return segments[0...gitlab_separator_index] if gitlab_separator_index
 
-    tags_index = segments.index('tags')
+    tags_index = suffix_index(segments, 'tags')
     return segments[0...tags_index] if tags_index
 
     segments
+  end
+
+  def suffix_index(segments, segment)
+    segments.each_index.find { |index| index >= 2 && segments[index] == segment }
   end
 end

--- a/test/services/gitlab_url_parser_test.rb
+++ b/test/services/gitlab_url_parser_test.rb
@@ -5,6 +5,9 @@ class GitlabUrlParserTest < ActiveSupport::TestCase
     [
       ['https://gitlab.com/maxcdn/shml/', 'maxcdn/shml'],
       ['https://gitlab.com/group/subgroup/project.git', 'group/subgroup/project'],
+      ['https://gitlab.com/tags/project.git', 'tags/project'],
+      ['https://gitlab.com/group/tags/project.git', 'group/tags/project'],
+      ['https://gitlab.com/group/project/-/tree/main', 'group/project'],
       ['git+https://gitlab.com/hugojosefson/express-cluster-stability.git', 'hugojosefson/express-cluster-stability'],
       ['www.gitlab.com/37point2/brainfuckifyjs', '37point2/brainfuckifyjs'],
       ['ssh+git@gitlab.com:omardelarosa/tonka-npm.git', 'omardelarosa/tonka-npm'],

--- a/test/services/gitlab_url_parser_test.rb
+++ b/test/services/gitlab_url_parser_test.rb
@@ -4,6 +4,7 @@ class GitlabUrlParserTest < ActiveSupport::TestCase
   test 'parses gitlab urls' do
     [
       ['https://gitlab.com/maxcdn/shml/', 'maxcdn/shml'],
+      ['https://gitlab.com/group/subgroup/project.git', 'group/subgroup/project'],
       ['git+https://gitlab.com/hugojosefson/express-cluster-stability.git', 'hugojosefson/express-cluster-stability'],
       ['www.gitlab.com/37point2/brainfuckifyjs', '37point2/brainfuckifyjs'],
       ['ssh+git@gitlab.com:omardelarosa/tonka-npm.git', 'omardelarosa/tonka-npm'],

--- a/test/services/url_parser_test.rb
+++ b/test/services/url_parser_test.rb
@@ -4,6 +4,7 @@ class UrlParserTest < ActiveSupport::TestCase
   test 'parses gitlab urls' do
     [
       ['https://gitlab.com/maxcdn/shml/', 'https://gitlab.com/maxcdn/shml'],
+      ['https://gitlab.com/group/subgroup/project.git', 'https://gitlab.com/group/subgroup/project'],
       ['git+https://gitlab.com/hugojosefson/express-cluster-stability.git', 'https://gitlab.com/hugojosefson/express-cluster-stability'],
       ['www.gitlab.com/37point2/brainfuckifyjs', 'https://gitlab.com/37point2/brainfuckifyjs'],
       ['ssh+git@gitlab.com:omardelarosa/tonka-npm.git', 'https://gitlab.com/omardelarosa/tonka-npm'],


### PR DESCRIPTION
Fixes #1699
## Summary

Fixes GitLab repository URL parsing when the project lives under nested subgroups.

Previously, URLs like:

`https://gitlab.com/group/subgroup/project.git`

were parsed as:

`group/subgroup`

which dropped the actual project segment.

## Changes

- Preserve GitLab repository paths with two or more segments
- Keep single-segment GitLab paths invalid
- Continue trimming non-repository suffixes like `/tags/...` and `/-/...`
- Add coverage for nested GitLab subgroup URLs in both `GitlabUrlParser` and `UrlParser.try_all`

## Tests

```bash
rbenv exec bundle exec rails test test/services/gitlab_url_parser_test.rb test/services/url_parser_test.rb
```
Result:

8 runs, 72 assertions, 0 failures, 0 errors, 0 skips

