### PR TITLE
Add support for Codeberg and Gitea repository URLs

### DIFF
--- a/app/services/forge_url_parser.rb
+++ b/app/services/forge_url_parser.rb
@@ -1,5 +1,6 @@
 class ForgeUrlParser < UrlParser
   HOSTS = %w[codeberg.org gitea.com].freeze
+  HOST_PATTERN = HOSTS.map { |host| Regexp.escape(host) }.join('|').freeze
 
   private
 
@@ -20,12 +21,12 @@ class ForgeUrlParser < UrlParser
   end
 
   def remove_domain
-    url.gsub!(/(codeberg\.org|gitea\.com)+?(:|\/)?/i, '')
+    url.gsub!(/(?:#{HOST_PATTERN})(?::|\/)?/i, '')
   end
 
   def matched_host
-    @matched_host ||= HOSTS.find do |host|
-      url.match?(/(?:\A|[^a-z0-9.-])#{Regexp.escape(host)}(?=[:\/]|\z)/i)
-    end
+    @matched_host ||= url.gsub(/\s/, '').match(
+      /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)(?:(?:www|ssh|raw|git|wiki)\.)?(#{HOST_PATTERN})(?=[:\/]|\z)/i
+    )&.[](1)&.downcase
   end
 end

--- a/app/services/forge_url_parser.rb
+++ b/app/services/forge_url_parser.rb
@@ -1,0 +1,31 @@
+class ForgeUrlParser < UrlParser
+  HOSTS = %w[codeberg.org gitea.com].freeze
+
+  private
+
+  def full_domain
+    "https://#{matched_host}"
+  end
+
+  def parseable?
+    matched_host.present?
+  end
+
+  def includes_domain?
+    matched_host.present?
+  end
+
+  def extractable_early?
+    false
+  end
+
+  def remove_domain
+    url.gsub!(/(codeberg\.org|gitea\.com)+?(:|\/)?/i, '')
+  end
+
+  def matched_host
+    @matched_host ||= HOSTS.find do |host|
+      url.match?(/(?:\A|[^a-z0-9.-])#{Regexp.escape(host)}(?=[:\/]|\z)/i)
+    end
+  end
+end

--- a/app/services/url_parser.rb
+++ b/app/services/url_parser.rb
@@ -25,7 +25,8 @@ class UrlParser
   def self.try_all(url)
     GithubUrlParser.parse_to_full_url(url) ||
     GitlabUrlParser.parse_to_full_url(url) ||
-    BitbucketUrlParser.parse_to_full_url(url)
+    BitbucketUrlParser.parse_to_full_url(url) ||
+    ForgeUrlParser.parse_to_full_url(url)
   end
 
   def parse_to_full_url

--- a/test/services/forge_url_parser_test.rb
+++ b/test/services/forge_url_parser_test.rb
@@ -19,6 +19,7 @@ class ForgeUrlParserTest < ActiveSupport::TestCase
       'https://forgejo.example.com/group/project',
       'https://codeberg.org/project',
       'https://notcodeberg.org/group/project',
+      'https://example.com/codeberg.org/group/project',
       'https://gitea.com/project',
     ].each do |url|
       assert_nil ForgeUrlParser.parse(url)

--- a/test/services/forge_url_parser_test.rb
+++ b/test/services/forge_url_parser_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class ForgeUrlParserTest < ActiveSupport::TestCase
+  test 'parses known forge host urls' do
+    [
+      ['https://codeberg.org/dnkl/foot/', 'dnkl/foot'],
+      ['git+https://codeberg.org/forgejo/forgejo.git', 'forgejo/forgejo'],
+      ['ssh://git@codeberg.org:forgejo/forgejo.git', 'forgejo/forgejo'],
+      ['https://codeberg.org/forgejo/forgejo/src/branch/main', 'forgejo/forgejo'],
+      ['https://gitea.com/gitea/tea', 'gitea/tea'],
+      ['git@gitea.com:gitea/tea.git', 'gitea/tea'],
+    ].each do |url, full_name|
+      assert_equal full_name, ForgeUrlParser.parse(url)
+    end
+  end
+
+  test 'does not parse unknown forge-like hosts' do
+    [
+      'https://forgejo.example.com/group/project',
+      'https://codeberg.org/project',
+      'https://notcodeberg.org/group/project',
+      'https://gitea.com/project',
+    ].each do |url|
+      assert_nil ForgeUrlParser.parse(url)
+    end
+  end
+end

--- a/test/services/url_parser_test.rb
+++ b/test/services/url_parser_test.rb
@@ -39,4 +39,15 @@ class UrlParserTest < ActiveSupport::TestCase
       assert_equal result, full_name
     end
   end
+
+  test 'parses known forge host urls' do
+    [
+      ['https://codeberg.org/dnkl/foot/', 'https://codeberg.org/dnkl/foot'],
+      ['git+https://codeberg.org/forgejo/forgejo.git', 'https://codeberg.org/forgejo/forgejo'],
+      ['https://gitea.com/gitea/tea', 'https://gitea.com/gitea/tea'],
+    ].each do |url, full_name|
+      result = UrlParser.try_all(url)
+      assert_equal result, full_name
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Partially addresses #1700
Adds repository URL normalization for known public forge hosts:

- `codeberg.org` (Forgejo)
- `gitea.com`

`UrlParser.try_all` now recognizes HTTPS, Git, SSH and repository-page URLs from these hosts and returns canonical repository URLs.

## Scope

Support is intentionally limited to known public hosts. Arbitrary self-hosted Gitea/Forgejo domains are not inferred from a generic `host/owner/repository` path, avoiding false-positive repository URLs.

## Tests

Added coverage for:

- Codeberg HTTPS, Git, SSH, and source-page URLs
- Gitea HTTPS and Git URLs
- `UrlParser.try_all` canonical output
- Unsupported lookalike and arbitrary self-hosted domains

## Verification

```text
1414 runs, 32945 assertions, 0 failures, 0 errors, 5 skips
```