### PR TITLE
Support configured self-hosted forge URLs

### DIFF
--- a/app/services/forge_url_parser.rb
+++ b/app/services/forge_url_parser.rb
@@ -1,19 +1,50 @@
 class ForgeUrlParser < UrlParser
-  HOSTS = %w[codeberg.org gitea.com].freeze
-  HOST_PATTERN = HOSTS.map { |host| Regexp.escape(host) }.join('|').freeze
+  Host = Data.define(:hostname, :port, :path_prefix) do
+    def authority
+      port ? "#{hostname}:#{port}" : hostname
+    end
+
+    def base_url
+      path = path_prefix.any? ? "/#{path_prefix.join('/')}" : ''
+      "https://#{authority}#{path}"
+    end
+  end
+
+  DEFAULT_HOSTS = %w[https://codeberg.org https://gitea.com].freeze
+
+  def self.hosts
+    (DEFAULT_HOSTS + configured_hosts).filter_map { |url| build_host(url) }.uniq(&:base_url)
+  end
+
+  def self.configured_hosts
+    ENV.fetch('FORGE_HOSTS', '').split(',').map(&:strip)
+  end
+
+  def self.build_host(url)
+    uri = URI.parse(url)
+    return unless uri.is_a?(URI::HTTPS) && uri.host.present? && uri.userinfo.nil? && uri.query.nil? && uri.fragment.nil?
+
+    Host.new(
+      hostname: uri.host.downcase,
+      port: uri.port == uri.default_port ? nil : uri.port,
+      path_prefix: uri.path.split('/').reject(&:blank?)
+    )
+  rescue URI::InvalidURIError
+    nil
+  end
 
   private
 
   def full_domain
-    "https://#{matched_host}"
+    host_config.base_url
   end
 
   def parseable?
-    matched_host.present?
+    host_config.present?
   end
 
   def includes_domain?
-    matched_host.present?
+    host_config.present?
   end
 
   def extractable_early?
@@ -21,12 +52,24 @@ class ForgeUrlParser < UrlParser
   end
 
   def remove_domain
-    url.gsub!(/(?:#{HOST_PATTERN})(?::|\/)?/i, '')
+    url.gsub!(/#{Regexp.escape(host_config.authority)}(?::|\/)?/i, '')
   end
 
-  def matched_host
-    @matched_host ||= url.gsub(/\s/, '').match(
-      /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)(?:(?:www|ssh|raw|git|wiki)\.)?(#{HOST_PATTERN})(?=[:\/]|\z)/i
-    )&.[](1)&.downcase
+  def remove_extra_segments
+    segments = url.dup.split('/').reject(&:blank?)
+    path_prefix = host_config.path_prefix
+    return self.url = [] unless segments.first(path_prefix.length) == path_prefix
+
+    self.url = segments.drop(path_prefix.length).first(2)
+  end
+
+  def host_config
+    @host_config ||= self.class.hosts.find do |host|
+      url.gsub(/\s/, '').match?(authority_pattern(host))
+    end
+  end
+
+  def authority_pattern(host)
+    /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)(?:(?:www|ssh|raw|git|wiki)\.)?#{Regexp.escape(host.authority)}(?=[:\/]|\z)/i
   end
 end

--- a/app/services/forge_url_parser.rb
+++ b/app/services/forge_url_parser.rb
@@ -11,6 +11,8 @@ class ForgeUrlParser < UrlParser
   end
 
   DEFAULT_HOSTS = %w[https://codeberg.org https://gitea.com].freeze
+  COMMON_SUBDOMAINS = %w[www ssh raw git wiki].freeze
+  COMMON_SUBDOMAIN_PATTERN = "(?:(?:#{COMMON_SUBDOMAINS.join('|')})\\.)?".freeze
 
   def self.hosts
     configured_hosts_value = ENV.fetch('FORGE_HOSTS', '')
@@ -57,9 +59,14 @@ class ForgeUrlParser < UrlParser
     false
   end
 
+  def remove_subdomain
+    # Preserve configured forge hostnames exactly.
+    nil
+  end
+
   def remove_domain
     port = host_config.port ? ":#{host_config.port}" : '(?::443)?'
-    url.gsub!(/#{Regexp.escape(host_config.hostname)}#{port}(?::|\/)?/i, '')
+    url.gsub!(/#{optional_subdomain_pattern(host_config)}#{Regexp.escape(host_config.hostname)}#{port}(?::|\/)?/i, '')
   end
 
   def remove_extra_segments
@@ -77,13 +84,18 @@ class ForgeUrlParser < UrlParser
   end
 
   def authority_pattern(host)
-    subdomain = '(?:(?:www|ssh|raw|git|wiki)\\.)?'
     host_name = Regexp.escape(host.hostname)
 
     if host.port
-      /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)#{subdomain}#{host_name}:#{host.port}(?=\/|\z)/i
+      /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)#{optional_subdomain_pattern(host)}#{host_name}:#{host.port}(?=\/|\z)/i
     else
-      /(?:(?:\A|@|(?:git|ssh|https?|hg|svn|scm):)#{subdomain}#{host_name}(?=[:\/]|\z)|\/\/#{subdomain}#{host_name}(?::443)?(?=\/|\z))/i
+      /(?:(?:\A|@|(?:git|ssh|https?|hg|svn|scm):)#{optional_subdomain_pattern(host)}#{host_name}(?=[:\/]|\z)|\/\/#{optional_subdomain_pattern(host)}#{host_name}(?::443)?(?=\/|\z))/i
     end
+  end
+
+  def optional_subdomain_pattern(host)
+    return '' if COMMON_SUBDOMAINS.include?(host.hostname.split('.').first)
+
+    COMMON_SUBDOMAIN_PATTERN
   end
 end

--- a/app/services/forge_url_parser.rb
+++ b/app/services/forge_url_parser.rb
@@ -13,11 +13,17 @@ class ForgeUrlParser < UrlParser
   DEFAULT_HOSTS = %w[https://codeberg.org https://gitea.com].freeze
 
   def self.hosts
-    (DEFAULT_HOSTS + configured_hosts).filter_map { |url| build_host(url) }.uniq(&:base_url)
+    configured_hosts_value = ENV.fetch('FORGE_HOSTS', '')
+    return @hosts if defined?(@hosts) && @configured_hosts == configured_hosts_value
+
+    @configured_hosts = configured_hosts_value
+    @hosts = (DEFAULT_HOSTS + configured_hosts(configured_hosts_value))
+      .filter_map { |url| build_host(url) }
+      .uniq(&:base_url)
   end
 
-  def self.configured_hosts
-    ENV.fetch('FORGE_HOSTS', '').split(',').map(&:strip)
+  def self.configured_hosts(hosts)
+    hosts.split(',').map(&:strip)
   end
 
   def self.build_host(url)
@@ -52,7 +58,8 @@ class ForgeUrlParser < UrlParser
   end
 
   def remove_domain
-    url.gsub!(/#{Regexp.escape(host_config.authority)}(?::|\/)?/i, '')
+    port = host_config.port ? ":#{host_config.port}" : '(?::443)?'
+    url.gsub!(/#{Regexp.escape(host_config.hostname)}#{port}(?::|\/)?/i, '')
   end
 
   def remove_extra_segments
@@ -70,6 +77,13 @@ class ForgeUrlParser < UrlParser
   end
 
   def authority_pattern(host)
-    /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)(?:(?:www|ssh|raw|git|wiki)\.)?#{Regexp.escape(host.authority)}(?=[:\/]|\z)/i
+    subdomain = '(?:(?:www|ssh|raw|git|wiki)\\.)?'
+    host_name = Regexp.escape(host.hostname)
+
+    if host.port
+      /(?:\A|\/\/|@|(?:git|ssh|https?|hg|svn|scm):)#{subdomain}#{host_name}:#{host.port}(?=\/|\z)/i
+    else
+      /(?:(?:\A|@|(?:git|ssh|https?|hg|svn|scm):)#{subdomain}#{host_name}(?=[:\/]|\z)|\/\/#{subdomain}#{host_name}(?::443)?(?=\/|\z))/i
+    end
   end
 end

--- a/env.example
+++ b/env.example
@@ -2,3 +2,5 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=development
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
+# Comma-separated HTTPS base URLs for trusted self-hosted Gitea or Forgejo instances.
+FORGE_HOSTS=

--- a/env.example
+++ b/env.example
@@ -4,4 +4,5 @@ POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 # Comma-separated HTTPS base URLs for trusted self-hosted Gitea or Forgejo instances.
 # Entries may include a path prefix, for example: https://forgejo.example.com/forgejo
+# SSH clone URLs must include the configured path prefix.
 FORGE_HOSTS=

--- a/env.example
+++ b/env.example
@@ -3,4 +3,5 @@ POSTGRES_PASSWORD=development
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 # Comma-separated HTTPS base URLs for trusted self-hosted Gitea or Forgejo instances.
+# Entries may include a path prefix, for example: https://forgejo.example.com/forgejo
 FORGE_HOSTS=

--- a/test/services/forge_url_parser_test.rb
+++ b/test/services/forge_url_parser_test.rb
@@ -25,4 +25,30 @@ class ForgeUrlParserTest < ActiveSupport::TestCase
       assert_nil ForgeUrlParser.parse(url)
     end
   end
+
+  test 'parses configured self-hosted forge urls' do
+    with_forge_hosts('https://gitea.example.com,https://forgejo.example.com/forgejo') do
+      assert_equal 'org/repo', ForgeUrlParser.parse('https://gitea.example.com/org/repo')
+      assert_equal 'group/project', ForgeUrlParser.parse('https://forgejo.example.com/forgejo/group/project')
+      assert_equal 'https://forgejo.example.com/forgejo/group/project', ForgeUrlParser.parse_to_full_url('https://forgejo.example.com/forgejo/group/project')
+      assert_nil ForgeUrlParser.parse('https://forgejo.example.com/group/project')
+    end
+  end
+
+  test 'ignores invalid configured forge hosts' do
+    with_forge_hosts('gitea.example.com,https://forgejo.example.com?source=configuration') do
+      assert_nil ForgeUrlParser.parse('https://gitea.example.com/org/repo')
+      assert_nil ForgeUrlParser.parse('https://forgejo.example.com/group/project')
+    end
+  end
+
+  private
+
+  def with_forge_hosts(hosts)
+    original_hosts = ENV['FORGE_HOSTS']
+    ENV['FORGE_HOSTS'] = hosts
+    yield
+  ensure
+    original_hosts.nil? ? ENV.delete('FORGE_HOSTS') : ENV['FORGE_HOSTS'] = original_hosts
+  end
 end

--- a/test/services/forge_url_parser_test.rb
+++ b/test/services/forge_url_parser_test.rb
@@ -29,9 +29,19 @@ class ForgeUrlParserTest < ActiveSupport::TestCase
   test 'parses configured self-hosted forge urls' do
     with_forge_hosts('https://gitea.example.com,https://forgejo.example.com/forgejo') do
       assert_equal 'org/repo', ForgeUrlParser.parse('https://gitea.example.com/org/repo')
+      assert_equal 'org/repo', ForgeUrlParser.parse('https://gitea.example.com:443/org/repo')
       assert_equal 'group/project', ForgeUrlParser.parse('https://forgejo.example.com/forgejo/group/project')
       assert_equal 'https://forgejo.example.com/forgejo/group/project', ForgeUrlParser.parse_to_full_url('https://forgejo.example.com/forgejo/group/project')
+      assert_nil ForgeUrlParser.parse('https://gitea.example.com:8443/org/repo')
       assert_nil ForgeUrlParser.parse('https://forgejo.example.com/group/project')
+    end
+  end
+
+  test 'parses a configured forge host with a non-default port' do
+    with_forge_hosts('https://gitea.example.com:8443') do
+      assert_equal 'org/repo', ForgeUrlParser.parse('https://gitea.example.com:8443/org/repo')
+      assert_equal 'https://gitea.example.com:8443/org/repo', ForgeUrlParser.parse_to_full_url('https://gitea.example.com:8443/org/repo')
+      assert_nil ForgeUrlParser.parse('https://gitea.example.com/org/repo')
     end
   end
 

--- a/test/services/forge_url_parser_test.rb
+++ b/test/services/forge_url_parser_test.rb
@@ -34,6 +34,7 @@ class ForgeUrlParserTest < ActiveSupport::TestCase
       assert_equal 'https://forgejo.example.com/forgejo/group/project', ForgeUrlParser.parse_to_full_url('https://forgejo.example.com/forgejo/group/project')
       assert_nil ForgeUrlParser.parse('https://gitea.example.com:8443/org/repo')
       assert_nil ForgeUrlParser.parse('https://forgejo.example.com/group/project')
+      assert_nil ForgeUrlParser.parse('git@forgejo.example.com:group/project.git')
     end
   end
 
@@ -42,6 +43,17 @@ class ForgeUrlParserTest < ActiveSupport::TestCase
       assert_equal 'org/repo', ForgeUrlParser.parse('https://gitea.example.com:8443/org/repo')
       assert_equal 'https://gitea.example.com:8443/org/repo', ForgeUrlParser.parse_to_full_url('https://gitea.example.com:8443/org/repo')
       assert_nil ForgeUrlParser.parse('https://gitea.example.com/org/repo')
+    end
+  end
+
+  test 'parses configured hosts with forge-like subdomains' do
+    prefixes = %w[git www ssh raw wiki]
+    hosts = prefixes.map { |prefix| "https://#{prefix}.example.com" }.join(',')
+
+    with_forge_hosts(hosts) do
+      prefixes.each do |prefix|
+        assert_equal 'org/repo', ForgeUrlParser.parse("https://#{prefix}.example.com/org/repo")
+      end
     end
   end
 

--- a/test/services/url_parser_test.rb
+++ b/test/services/url_parser_test.rb
@@ -50,4 +50,20 @@ class UrlParserTest < ActiveSupport::TestCase
       assert_equal result, full_name
     end
   end
+
+  test 'parses configured self-hosted forge urls' do
+    with_forge_hosts('https://gitea.example.com') do
+      assert_equal 'https://gitea.example.com/org/repo', UrlParser.try_all('https://gitea.example.com/org/repo')
+    end
+  end
+
+  private
+
+  def with_forge_hosts(hosts)
+    original_hosts = ENV['FORGE_HOSTS']
+    ENV['FORGE_HOSTS'] = hosts
+    yield
+  ensure
+    original_hosts.nil? ? ENV.delete('FORGE_HOSTS') : ENV['FORGE_HOSTS'] = original_hosts
+  end
 end


### PR DESCRIPTION
Closes #1700

## Summary

Adds support for trusted self-hosted Gitea and Forgejo instances through a `FORGE_HOSTS` environment-variable allowlist.

```bash
FORGE_HOSTS=https://gitea.example.com,https://forgejo.example.com/forgejo
```

Each entry is an exact HTTPS base URL. Entries may include a path prefix for installations not hosted at the domain root.

## Behavior

- Keeps the existing built-in support for codeberg.org and gitea.com.
- Normalizes configured self-hosted repository URLs to canonical URLs.
- Preserves configured path prefixes in canonical URLs.
- Supports HTTPS, Git, SSH and SCM-style repository URLs.
- Rejects unconfigured hosts and invalid configuration entries to avoid false-positive repository metadata.

## Tests

Added coverage for:

- configured Gitea and Forgejo hosts
- a Forgejo installation under a path prefix
- UrlParser.try_all integration
- invalid configured URLs
- an unconfigured URL outside the configured base path

## Verification

1422 runs, 32989 assertions, 0 failures, 0 errors, 5 skips