### PR TITLE
Fix typo in getRegistries summary

### DIFF
--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -466,7 +466,7 @@ paths:
                 $ref: '#/components/schemas/KeywordWithPackages'
   /registries:
     get:
-      summary: list registies
+      summary: list registries
       operationId: getRegistries
       tags:
         - registries


### PR DESCRIPTION
Corrects `list registies` to `list registries` on the `/registries` endpoint.