### PR TITLE
Ingest NuGet verified package metadata

### DIFF
--- a/app/models/ecosystem/nuget.rb
+++ b/app/models/ecosystem/nuget.rb
@@ -134,12 +134,19 @@ module Ecosystem
         downloads_period: 'total',
         download_stats: package[:download_stats],
         
-        # Enhanced metadata from .nuspec file
-        metadata: build_package_nuspec_metadata(nuspec_metadata, package)
+        # Enhanced metadata from .nuspec file and the NuGet search response
+        metadata: build_package_nuspec_metadata(nuspec_metadata).merge(verified_metadata(package[:download_stats]))
       }
     end
 
-    def build_package_nuspec_metadata(nuspec_metadata, package)
+    def verified_metadata(download_stats)
+      search_result = download_stats&.dig("data")&.first
+      return {} unless search_result.is_a?(Hash)
+
+      { verified: search_result["verified"] == true }
+    end
+
+    def build_package_nuspec_metadata(nuspec_metadata)
       # Only include NuGet-specific fields that aren't duplicates of standard package fields
       return {} unless nuspec_metadata
 

--- a/app/models/ecosystem/nuget.rb
+++ b/app/models/ecosystem/nuget.rb
@@ -143,7 +143,10 @@ module Ecosystem
       search_result = download_stats&.dig("data")&.first
       return {} unless search_result.is_a?(Hash)
 
-      { verified: search_result["verified"] == true }
+      verified = search_result["verified"]
+      return {} unless [true, false].include?(verified)
+
+      { verified: verified }
     end
 
     def build_package_nuspec_metadata(nuspec_metadata)

--- a/app/sidekiq/sync_package_worker.rb
+++ b/app/sidekiq/sync_package_worker.rb
@@ -2,9 +2,10 @@ class SyncPackageWorker
   include Sidekiq::Worker
   sidekiq_options queue: :critical, lock: :until_executed, lock_expiration: 1.hour.to_i
 
-  def perform(registry_id, name)
+  def perform(registry_id, name, force = false)
     registry = Registry.find_by_id(registry_id)
     return if registry.nil? || registry.sync_in_batches?
-    registry.sync_package(name)
+
+    force ? registry.sync_package(name, force: true) : registry.sync_package(name)
   end
 end

--- a/app/sidekiq/sync_package_worker.rb
+++ b/app/sidekiq/sync_package_worker.rb
@@ -6,6 +6,6 @@ class SyncPackageWorker
     registry = Registry.find_by_id(registry_id)
     return if registry.nil? || registry.sync_in_batches?
 
-    force ? registry.sync_package(name, force: true) : registry.sync_package(name)
+    registry.sync_package(name, force: force)
   end
 end

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -36,6 +36,18 @@ namespace :packages do
     end
   end
 
+  desc 'backfill NuGet verified package metadata'
+  task backfill_nuget_verified: :environment do
+    with_rake_lock('packages:backfill_nuget_verified') do
+      registry = Registry.find_by!(ecosystem: 'nuget')
+      packages = registry.packages.where("NOT (COALESCE(metadata::jsonb, '{}'::jsonb) ? 'verified')")
+
+      packages.in_batches(of: 1_000) do |batch|
+        SyncPackageWorker.perform_bulk(batch.pluck(:name).map { |name| [registry.id, name, true] })
+      end
+    end
+  end
+
   desc 'sync_worst_one_percent'
   task sync_worst_one_percent: :environment do
     with_rake_lock('packages:sync_worst_one_percent') do

--- a/test/models/ecosystem/nuget_test.rb
+++ b/test/models/ecosystem/nuget_test.rb
@@ -106,6 +106,19 @@ class NugetTest < ActiveSupport::TestCase
     # Check that metadata is present (even if .nuspec requests fail)
     metadata = package_metadata[:metadata]
     assert_not_nil metadata
+    assert_equal false, metadata[:verified]
+  end
+
+  test 'package_metadata leaves verified unset when the search response has no package' do
+    stub_request(:get, "https://api.nuget.org/v3/registration5-gz-semver2/ogcapi.net.sqlserver/index.json")
+      .to_return({ status: 200, body: file_fixture('nuget/ogcapi.net.sqlserver') })
+    stub_request(:get, "https://azuresearch-usnc.nuget.org/query?q=packageid:ogcapi.net.sqlserver")
+      .to_return({ status: 200, body: '{"data":[]}' })
+    @ecosystem.stubs(:parse_nuspec_metadata).returns(nil)
+
+    package_metadata = @ecosystem.package_metadata('ogcapi.net.sqlserver')
+
+    assert_not package_metadata[:metadata].key?(:verified)
   end
 
   test 'versions_metadata' do
@@ -199,6 +212,7 @@ class NugetTest < ActiveSupport::TestCase
     # Enhanced package metadata from .nuspec (NuGet-specific only)
     metadata = package_metadata[:metadata]
     assert_not_nil metadata
+    assert_equal true, metadata[:verified]
     
     # NuGet-specific package information
     assert_equal "Copyright © James Newton-King 2008", metadata[:copyright]

--- a/test/models/ecosystem/nuget_test.rb
+++ b/test/models/ecosystem/nuget_test.rb
@@ -121,6 +121,10 @@ class NugetTest < ActiveSupport::TestCase
     assert_not package_metadata[:metadata].key?(:verified)
   end
 
+  test 'verified_metadata leaves verified unset when the search response omits it' do
+    assert_equal({}, @ecosystem.verified_metadata({ "data" => [{ "totalDownloads" => 0 }] }))
+  end
+
   test 'versions_metadata' do
     stub_request(:get, "https://api.nuget.org/v3/registration5-gz-semver2/ogcapi.net.sqlserver/index.json")
       .to_return({ status: 200, body: file_fixture('nuget/ogcapi.net.sqlserver') })

--- a/test/sidekiq/sync_package_worker_test.rb
+++ b/test/sidekiq/sync_package_worker_test.rb
@@ -8,4 +8,12 @@ class SyncPackageWorkerTest < ActiveSupport::TestCase
     job = SyncPackageWorker.new
     job.perform(@registry.id, 'foo')
   end
+
+  test 'perform force sync' do
+    @registry = Registry.create(name: 'Rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+    @registry.expects(:sync_package).with('foo', force: true)
+    Registry.expects(:find_by_id).with(@registry.id).returns(@registry)
+
+    SyncPackageWorker.new.perform(@registry.id, 'foo', true)
+  end
 end

--- a/test/sidekiq/sync_package_worker_test.rb
+++ b/test/sidekiq/sync_package_worker_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SyncPackageWorkerTest < ActiveSupport::TestCase
   test 'perform' do
     @registry = Registry.create(name: 'Rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
-    @registry.expects(:sync_package).with('foo')
+    @registry.expects(:sync_package).with('foo', force: false)
     Registry.expects(:find_by_id).with(@registry.id).returns(@registry)
     job = SyncPackageWorker.new
     job.perform(@registry.id, 'foo')

--- a/test/tasks/packages_rake_test.rb
+++ b/test/tasks/packages_rake_test.rb
@@ -27,6 +27,16 @@ class PackagesRakeTest < ActiveSupport::TestCase
     Rake::Task["packages:sync_least_recent"].invoke
   end
 
+  test "backfills NuGet packages without verified metadata" do
+    registry = Registry.create(name: 'NuGet.org', url: 'https://www.nuget.org', ecosystem: 'nuget')
+    registry.packages.create!(name: 'unchecked', ecosystem: 'nuget', metadata: {})
+    registry.packages.create!(name: 'verified', ecosystem: 'nuget', metadata: { 'verified' => false })
+
+    SyncPackageWorker.expects(:perform_bulk).with([[registry.id, 'unchecked', true]])
+
+    Rake::Task["packages:backfill_nuget_verified"].invoke
+  end
+
   test "nixpkgs_python_native_deps reports non-python dependencies" do
     registry = Registry.create(name: 'Nixpkgs', url: 'https://search.nixos.org', ecosystem: 'nixpkgs', packages_count: 3)
 


### PR DESCRIPTION
Closes #1740

## Summary

- Store NuGet's search API `verified` flag in package metadata.
- Preserve explicit `true` and `false` values from successful search results.
- Leave `metadata["verified"]` absent when NuGet returns no search result, so an unavailable check is not recorded as unverified.
- Add `packages:backfill_nuget_verified` to enqueue forced syncs for existing NuGet packages missing the field.
- Extend `SyncPackageWorker` with an optional forced-sync argument used only by the backfill task.

## Tests

```text
1422 runs, 32988 assertions, 0 failures, 0 errors, 5 skips
```