### PR TITLE
Fix registry package sort indexes

### DIFF
--- a/app/controllers/api/v1/critical_controller.rb
+++ b/app/controllers/api/v1/critical_controller.rb
@@ -6,12 +6,7 @@ class Api::V1::CriticalController < Api::V1::ApplicationController
     scope = scope.where(registry_id: @registry.id) if params[:registry]
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns, default: 'downloads')
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order(default: 'downloads'))
     else
       scope = scope.order('downloads DESC nulls last')
     end
@@ -27,12 +22,7 @@ class Api::V1::CriticalController < Api::V1::ApplicationController
     scope = scope.where(registry_id: @registry.id) if params[:registry]
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns, default: 'downloads')
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order(default: 'downloads'))
     else
       scope = scope.order_by_maintainer_count_asc.order('downloads DESC nulls last')
     end

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -14,12 +14,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     scope = scope.critical if params[:critical].present?
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     end
 
     @pagy, @packages = pagy_countless(scope.includes(:registry, {maintainers: :registry}))
@@ -37,12 +32,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     scope = scope.with_funding if params[:funding].present?
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     end
 
     @pagy, @packages = pagy_countless(scope.includes(:registry, {maintainers: :registry}))
@@ -58,12 +48,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     scope = scope.where(registry_id: @registry.id) if @registry
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns, default: 'downloads')
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order(default: 'downloads'))
     else
       scope = scope.order_by_maintainer_count_asc.order('downloads DESC nulls last')
     end
@@ -93,12 +78,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     end
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     end
 
     @pagy, @packages = pagy_countless(scope.includes(:registry, {maintainers: :registry}))
@@ -162,12 +142,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     scope = scope.name_postfix(params[:postfix]) if params[:postfix].present?
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     end
 
     @pagy, @packages = pagy_countless(scope, limit_max: 10000)
@@ -208,12 +183,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     scope = scope.where("downloads >= ?", params[:min_downloads].to_i) if params[:min_downloads].present?
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     end
 
     @pagy, @packages = pagy_countless(scope)
@@ -245,12 +215,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     scope = scope.updated_after(params[:updated_after]) if params[:updated_after].present?
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     end
 
     @pagy, @packages = pagy_countless(scope)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
   include Pagy::Backend
 
+  rescue_from Package::UnsupportedSortDirection do |error|
+    respond_to do |format|
+      format.json { render json: { error: error.message }, status: :unprocessable_content }
+      format.any { render plain: error.message, status: :unprocessable_content }
+    end
+  end
+
   skip_before_action :verify_authenticity_token
   before_action :reject_path_traversal_in_params
   before_action :set_cache_headers
@@ -87,5 +94,9 @@ class ApplicationController < ActionController::Base
     sort_param = params[:sort].presence || default
     sql = allowed_columns[sort_param] || allowed_columns[default] || default
     Arel.sql(sql)
+  end
+
+  def package_sort_order(default: 'updated_at')
+    Package.sort_order(sort: params[:sort], order: params[:order], default: default)
   end
 end

--- a/app/controllers/critical_controller.rb
+++ b/app/controllers/critical_controller.rb
@@ -9,12 +9,7 @@ class CriticalController < ApplicationController
     scope = scope.where(registry_id: @registry.id) if params[:registry]
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns, default: 'downloads')
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order(default: 'downloads'))
     else
       scope = scope.order('downloads DESC nulls last')
     end
@@ -34,12 +29,7 @@ class CriticalController < ApplicationController
     scope = scope.where(registry_id: @registry.id) if params[:registry]
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns, default: 'downloads')
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order(default: 'downloads'))
     else
       scope = scope.order('packages.downloads DESC nulls last')
     end
@@ -80,12 +70,7 @@ class CriticalController < ApplicationController
     scope = scope.where(registry_id: @registry.id) if params[:registry]
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns, default: 'downloads')
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order(default: 'downloads'))
     else
       scope = scope.order_by_maintainer_count_asc.order('downloads DESC nulls last')
     end

--- a/app/controllers/maintainers_controller.rb
+++ b/app/controllers/maintainers_controller.rb
@@ -27,12 +27,7 @@ class MaintainersController < ApplicationController
     scope = @maintainer.packages.includes(:registry)
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     else
       scope = scope.order('updated_at desc')
     end

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -11,12 +11,7 @@ class NamespacesController < ApplicationController
     scope = @registry.packages.namespace(@namespace)
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     else
       scope = scope.order('updated_at desc')
     end

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -8,12 +8,7 @@ class PackagesController < ApplicationController
     end
     
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     else
       scope = scope.order('updated_at DESC')
     end
@@ -68,12 +63,7 @@ class PackagesController < ApplicationController
     scope = scope.where("downloads >= ?", params[:min_downloads].to_i) if params[:min_downloads].present?
 
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     else
       scope = scope.order('latest_release_published_at DESC')
     end
@@ -95,12 +85,7 @@ class PackagesController < ApplicationController
 
     scope = @package.related_packages.includes(:registry)
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     else
       scope = scope.order('latest_release_published_at DESC')
     end

--- a/app/controllers/registries_controller.rb
+++ b/app/controllers/registries_controller.rb
@@ -24,12 +24,7 @@ class RegistriesController < ApplicationController
     @keyword = params[:keyword]
     scope = @registry.packages.where('keywords @> ARRAY[?]::varchar[]', @keyword)
     if params[:sort].present? || params[:order].present?
-      sort = sanitize_sort(Package.sortable_columns)
-      if params[:order] == 'asc'
-        scope = scope.order(sort.asc.nulls_last)
-      else
-        scope = scope.order(sort.desc.nulls_last)
-      end
+      scope = scope.order(package_sort_order)
     else
       scope = scope.order('updated_at desc')
     end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -1,5 +1,14 @@
 class Package < ApplicationRecord
   include EcosystemsApiClient
+
+  UnsupportedSortDirection = Class.new(ArgumentError)
+  DESCENDING_ONLY_SORTS = %w[
+    downloads
+    dependent_repos_count
+    dependent_packages_count
+    stargazers_count
+    forks_count
+  ].freeze
   
   # Matches a name where any /-delimited segment is exactly "." or "..".
   # Such names generate URLs that CDNs and browsers normalise into other
@@ -36,6 +45,18 @@ class Package < ApplicationRecord
       'forks_count' => "(repo_metadata ->> 'forks_count')::text::integer",
       'rank' => "(rankings ->> 'average')::float",
     }
+  end
+
+  def self.sort_order(sort:, order:, default: 'updated_at')
+    sort_key = sortable_columns.key?(sort) ? sort : default
+    direction = order == 'asc' ? :asc : :desc
+
+    if direction == :asc && DESCENDING_ONLY_SORTS.include?(sort_key)
+      raise UnsupportedSortDirection, "#{sort_key} only supports descending order"
+    end
+
+    ordering = Arel.sql(sortable_columns.fetch(sort_key)).public_send(direction)
+    sort_key == 'updated_at' ? ordering : ordering.nulls_last
   end
 
   scope :ecosystem, ->(ecosystem) { where(ecosystem: ecosystem.downcase) }

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -48,11 +48,13 @@ class Package < ApplicationRecord
   end
 
   def self.sort_order(sort:, order:, default: 'updated_at')
-    sort_key = sortable_columns.key?(sort) ? sort : default
+    requested_sort = sortable_columns.key?(sort)
+    sort_key = requested_sort ? sort : default
     direction = order == 'asc' ? :asc : :desc
 
     if direction == :asc && DESCENDING_ONLY_SORTS.include?(sort_key)
-      raise UnsupportedSortDirection, "#{sort_key} only supports descending order"
+      sort_name = requested_sort ? sort_key : "the default #{sort_key} sort"
+      raise UnsupportedSortDirection, "#{sort_name} only supports descending order"
     end
 
     ordering = Arel.sql(sortable_columns.fetch(sort_key)).public_send(direction)

--- a/app/views/packages/_sort.html.erb
+++ b/app/views/packages/_sort.html.erb
@@ -13,7 +13,6 @@
       <li><a class="dropdown-item <%= 'active' if params[:sort] == 'downloads' %>" href="<%= url_for(request.query_parameters.merge(sort: 'downloads', order: 'desc', keyword: params[:keyword])) %>">Downloads</a></li>
       <li><a class="dropdown-item <%= 'active' if params[:sort] == 'maintainers_count' %>" href="<%= url_for(request.query_parameters.merge(sort: 'maintainers_count', order: 'desc', keyword: params[:keyword])) %>">Maintainers</a></li>
       <li><a class="dropdown-item <%= 'active' if params[:sort] == 'stargazers_count' && params[:order] == 'desc' %>" href="<%= url_for(request.query_parameters.merge(sort: 'stargazers_count', order: 'desc', keyword: params[:keyword])) %>">Most Stars</a></li>
-      <li><a class="dropdown-item <%= 'active' if params[:sort] == 'stargazers_count' && params[:order] == 'asc' %>" href="<%= url_for(request.query_parameters.merge(sort: 'stargazers_count', order: 'asc', keyword: params[:keyword])) %>">Least Stars</a></li>
     </ul>
   </div>
 </li>

--- a/db/migrate/20260722190000_add_descending_registry_package_sort_indexes.rb
+++ b/db/migrate/20260722190000_add_descending_registry_package_sort_indexes.rb
@@ -1,0 +1,56 @@
+class AddDescendingRegistryPackageSortIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    ActiveRecord::Base.connection.execute('SET statement_timeout TO 0')
+
+    add_index :packages,
+              'registry_id, downloads DESC NULLS LAST',
+              name: 'index_packages_on_registry_downloads_desc',
+              algorithm: :concurrently,
+              if_not_exists: true
+    add_index :packages,
+              'registry_id, dependent_packages_count DESC NULLS LAST',
+              name: 'index_packages_on_registry_dependent_packages_desc',
+              algorithm: :concurrently,
+              if_not_exists: true
+    add_index :packages,
+              'registry_id, dependent_repos_count DESC NULLS LAST',
+              name: 'index_packages_on_registry_dependent_repos_desc',
+              algorithm: :concurrently,
+              if_not_exists: true
+    add_index :packages,
+              "registry_id, ((repo_metadata ->> 'stargazers_count')::text::integer) DESC NULLS LAST",
+              name: 'index_packages_on_registry_stargazers_desc',
+              algorithm: :concurrently,
+              if_not_exists: true
+    add_index :packages,
+              "registry_id, ((repo_metadata ->> 'forks_count')::text::integer) DESC NULLS LAST",
+              name: 'index_packages_on_registry_forks_desc',
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+
+  def down
+    remove_index :packages,
+                 name: 'index_packages_on_registry_downloads_desc',
+                 algorithm: :concurrently,
+                 if_exists: true
+    remove_index :packages,
+                 name: 'index_packages_on_registry_dependent_packages_desc',
+                 algorithm: :concurrently,
+                 if_exists: true
+    remove_index :packages,
+                 name: 'index_packages_on_registry_dependent_repos_desc',
+                 algorithm: :concurrently,
+                 if_exists: true
+    remove_index :packages,
+                 name: 'index_packages_on_registry_stargazers_desc',
+                 algorithm: :concurrently,
+                 if_exists: true
+    remove_index :packages,
+                 name: 'index_packages_on_registry_forks_desc',
+                 algorithm: :concurrently,
+                 if_exists: true
+  end
+end

--- a/db/migrate/20260722190000_add_descending_registry_package_sort_indexes.rb
+++ b/db/migrate/20260722190000_add_descending_registry_package_sort_indexes.rb
@@ -7,28 +7,23 @@ class AddDescendingRegistryPackageSortIndexes < ActiveRecord::Migration[8.1]
     add_index :packages,
               'registry_id, downloads DESC NULLS LAST',
               name: 'index_packages_on_registry_downloads_desc',
-              algorithm: :concurrently,
-              if_not_exists: true
+              algorithm: :concurrently
     add_index :packages,
               'registry_id, dependent_packages_count DESC NULLS LAST',
               name: 'index_packages_on_registry_dependent_packages_desc',
-              algorithm: :concurrently,
-              if_not_exists: true
+              algorithm: :concurrently
     add_index :packages,
               'registry_id, dependent_repos_count DESC NULLS LAST',
               name: 'index_packages_on_registry_dependent_repos_desc',
-              algorithm: :concurrently,
-              if_not_exists: true
+              algorithm: :concurrently
     add_index :packages,
               "registry_id, ((repo_metadata ->> 'stargazers_count')::text::integer) DESC NULLS LAST",
               name: 'index_packages_on_registry_stargazers_desc',
-              algorithm: :concurrently,
-              if_not_exists: true
+              algorithm: :concurrently
     add_index :packages,
               "registry_id, ((repo_metadata ->> 'forks_count')::text::integer) DESC NULLS LAST",
               name: 'index_packages_on_registry_forks_desc',
-              algorithm: :concurrently,
-              if_not_exists: true
+              algorithm: :concurrently
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_204256) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -132,16 +132,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_204256) do
     t.index "(((rankings ->> 'average'::text))::double precision)", name: "index_packages_on_rankings_average"
     t.index "(((repo_metadata ->> 'stargazers_count'::text))::integer) DESC NULLS LAST", name: "index_packages_on_stargazers_desc", where: "(length((repo_metadata)::text) > 2)"
     t.index "lower((repository_url)::text)", name: "index_packages_on_lower_repository_url"
+    t.index "registry_id, (((repo_metadata ->> 'forks_count'::text))::integer) DESC NULLS LAST", name: "index_packages_on_registry_forks_desc"
     t.index "registry_id, (((repo_metadata ->> 'forks_count'::text))::integer)", name: "index_packages_on_forks_count"
+    t.index "registry_id, (((repo_metadata ->> 'stargazers_count'::text))::integer) DESC NULLS LAST", name: "index_packages_on_registry_stargazers_desc"
     t.index "registry_id, (((repo_metadata ->> 'stargazers_count'::text))::integer)", name: "index_packages_on_stargazers_count"
     t.index "registry_id, ((metadata ->> 'normalized_name'::text))", name: "index_packages_on_registry_id_and_normalized_name", where: "((metadata ->> 'normalized_name'::text) IS NOT NULL)"
     t.index ["critical"], name: "index_packages_on_critical", where: "(critical = true)"
     t.index ["first_release_published_at"], name: "index_packages_on_first_release_published_at"
     t.index ["keywords"], name: "index_packages_on_keywords", using: :gin
     t.index ["latest_release_published_at"], name: "index_packages_on_latest_release_published_at"
+    t.index ["registry_id", "dependent_packages_count"], name: "index_packages_on_registry_dependent_packages_desc", order: { dependent_packages_count: "DESC NULLS LAST" }
     t.index ["registry_id", "dependent_packages_count"], name: "index_packages_on_registry_id_and_dependent_packages_count"
+    t.index ["registry_id", "dependent_repos_count"], name: "index_packages_on_registry_dependent_repos_desc", order: { dependent_repos_count: "DESC NULLS LAST" }
     t.index ["registry_id", "dependent_repos_count"], name: "index_packages_on_registry_id_and_dependent_repos_count"
     t.index ["registry_id", "docker_downloads_count"], name: "index_packages_on_registry_id_and_docker_downloads_count"
+    t.index ["registry_id", "downloads"], name: "index_packages_on_registry_downloads_desc", order: { downloads: "DESC NULLS LAST" }
     t.index ["registry_id", "downloads"], name: "index_packages_on_registry_id_and_downloads"
     t.index ["registry_id", "name"], name: "index_packages_on_registry_id_and_name", unique: true
     t.index ["registry_id", "namespace"], name: "index_packages_on_registry_id_and_namespace"

--- a/test/controllers/packages_controller_test.rb
+++ b/test/controllers/packages_controller_test.rb
@@ -10,6 +10,7 @@ class PackagesControllerTest < ActionDispatch::IntegrationTest
     get registry_packages_path(registry_id: @registry.name)
     assert_response :success
     assert_template 'packages/index', file: 'packages/index.html.erb'
+    assert_not_includes response.body, 'Least Stars'
   end
 
   test 'get a package for a registry' do

--- a/test/controllers/sort_sanitization_test.rb
+++ b/test/controllers/sort_sanitization_test.rb
@@ -104,6 +104,18 @@ class SortSanitizationTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
+  test 'critical index explains ascending default sort errors' do
+    @package.update(critical: true)
+
+    get critical_path(order: 'asc')
+    assert_response :unprocessable_content
+    assert_equal 'the default downloads sort only supports descending order', response.body
+
+    get critical_path(sort: 'invalid', order: 'asc')
+    assert_response :unprocessable_content
+    assert_equal 'the default downloads sort only supports descending order', response.body
+  end
+
   test 'critical index with invalid sort falls back to default' do
     @package.update(critical: true)
     get critical_path(sort: '1;DROP TABLE packages--')
@@ -162,6 +174,14 @@ class SortSanitizationTest < ActionDispatch::IntegrationTest
     get api_v1_critical_index_path(sort: '1;DROP TABLE packages--')
     assert_response :success
     assert_equal 1, @registry.packages.count
+  end
+
+  test 'api critical index explains ascending default sort errors' do
+    @package.update(critical: true)
+    get api_v1_critical_index_path(order: 'asc')
+
+    assert_response :unprocessable_content
+    assert_equal 'the default downloads sort only supports descending order', response.parsed_body['error']
   end
 
   # -- API VersionsController --

--- a/test/controllers/sort_sanitization_test.rb
+++ b/test/controllers/sort_sanitization_test.rb
@@ -18,6 +18,19 @@ class SortSanitizationTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'packages index rejects ascending usage metric sort' do
+    get registry_packages_path(registry_id: @registry.name, sort: 'downloads', order: 'asc')
+    assert_response :unprocessable_content
+  end
+
+  test 'packages index accepts updated_at in both directions' do
+    get registry_packages_path(registry_id: @registry.name, sort: 'updated_at', order: 'asc')
+    assert_response :success
+
+    get registry_packages_path(registry_id: @registry.name, sort: 'updated_at', order: 'desc')
+    assert_response :success
+  end
+
   test 'packages index with invalid sort falls back to default' do
     get registry_packages_path(registry_id: @registry.name, sort: '1;DROP TABLE packages--')
     assert_response :success
@@ -85,10 +98,10 @@ class SortSanitizationTest < ActionDispatch::IntegrationTest
 
   # -- CriticalController --
 
-  test 'critical index with valid sort' do
+  test 'critical index rejects ascending usage metric sort' do
     @package.update(critical: true)
     get critical_path(sort: 'downloads', order: 'asc')
-    assert_response :success
+    assert_response :unprocessable_content
   end
 
   test 'critical index with invalid sort falls back to default' do
@@ -114,6 +127,12 @@ class SortSanitizationTest < ActionDispatch::IntegrationTest
   test 'api packages index with stargazers_count sort' do
     get api_v1_registry_packages_path(registry_id: @registry.name, sort: 'stargazers_count')
     assert_response :success
+  end
+
+  test 'api packages index rejects ascending usage metric sort' do
+    get api_v1_registry_packages_path(registry_id: @registry.name, sort: 'stargazers_count', order: 'asc')
+    assert_response :unprocessable_content
+    assert_equal 'stargazers_count only supports descending order', response.parsed_body['error']
   end
 
   test 'api packages names with invalid sort falls back to default' do

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -38,6 +38,58 @@ class PackageTest < ActiveSupport::TestCase
     @version2 = @package.versions.create(number: '2.0.0', published_at: 1.week.ago)
   end
 
+  test 'sort_order restricts usage and popularity metrics to descending order' do
+    Package::DESCENDING_ONLY_SORTS.each do |sort|
+      error = assert_raises(Package::UnsupportedSortDirection) do
+        Package.sort_order(sort: sort, order: 'asc')
+      end
+      assert_equal "#{sort} only supports descending order", error.message
+    end
+  end
+
+  test 'sort_order uses descending nulls last ordering for nullable metrics' do
+    sql = Package.order(Package.sort_order(sort: 'downloads', order: 'desc')).to_sql
+
+    assert_includes sql, 'ORDER BY downloads DESC NULLS LAST'
+  end
+
+  test 'sort_order omits null ordering for updated_at' do
+    ascending_sql = Package.order(Package.sort_order(sort: 'updated_at', order: 'asc')).to_sql
+    descending_sql = Package.order(Package.sort_order(sort: 'updated_at', order: 'desc')).to_sql
+
+    assert_includes ascending_sql, 'ORDER BY updated_at ASC'
+    assert_includes descending_sql, 'ORDER BY updated_at DESC'
+    refute_includes ascending_sql, 'NULLS LAST'
+    refute_includes descending_sql, 'NULLS LAST'
+  end
+
+  test 'sort_order leaves docker downloads available in both directions' do
+    sql = Package.order(Package.sort_order(sort: 'docker_downloads_count', order: 'asc')).to_sql
+
+    assert_includes sql, 'ORDER BY docker_downloads_count ASC NULLS LAST'
+  end
+
+  test 'registry metric sort indexes use descending nulls last ordering' do
+    index_names = %w[
+      index_packages_on_registry_downloads_desc
+      index_packages_on_registry_dependent_packages_desc
+      index_packages_on_registry_dependent_repos_desc
+      index_packages_on_registry_stargazers_desc
+      index_packages_on_registry_forks_desc
+    ]
+    definitions = ActiveRecord::Base.connection.select_rows(<<~SQL).to_h
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE tablename = 'packages'
+        AND indexname IN (#{index_names.map { |name| ActiveRecord::Base.connection.quote(name) }.join(', ')})
+    SQL
+
+    assert_equal index_names.sort, definitions.keys.sort
+    definitions.each_value do |definition|
+      assert_includes definition, 'DESC NULLS LAST'
+    end
+  end
+
   test 'update_details' do
     @package.expects(:normalize_licenses).returns(true)
     @package.expects(:set_latest_release_published_at).returns(true)

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -47,6 +47,14 @@ class PackageTest < ActiveSupport::TestCase
     end
   end
 
+  test 'sort_order identifies a descending-only fallback as the default sort' do
+    error = assert_raises(Package::UnsupportedSortDirection) do
+      Package.sort_order(sort: 'invalid', order: 'asc', default: 'downloads')
+    end
+
+    assert_equal 'the default downloads sort only supports descending order', error.message
+  end
+
   test 'sort_order uses descending nulls last ordering for nullable metrics' do
     sql = Package.order(Package.sort_order(sort: 'downloads', order: 'desc')).to_sql
 


### PR DESCRIPTION
Adds `DESC NULLS LAST` indexes for the five registry package sorts seen in traffic and makes those sorts descending-only. Keeps both `updated_at` directions on the existing index by omitting the redundant null-order clause.

This is the first stage of the index replacement. The old ascending indexes remain so the new production plans can be verified. A follow-up PR is required to drop those five old indexes and return index storage and write overhead to its current level.

Closes #1744