### PR TITLE
Select only id, name, updated_at in package_names endpoint

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -131,7 +131,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
 
   def names
     @registry = Registry.find_by_name!(params[:id])
-    scope = @registry.packages
+    scope = @registry.packages.select(:id, :name, :updated_at)
     scope = scope.created_after(params[:created_after]) if params[:created_after].present?
     scope = scope.updated_after(params[:updated_after]) if params[:updated_after].present?
     scope = scope.created_before(params[:created_before]) if params[:created_before].present?


### PR DESCRIPTION
The `package_names` API action loads up to 10k rows via `pagy_countless` and returns only the names, but it was issuing `SELECT packages.*` which pulls the `metadata` and `repo_metadata` JSONB columns for every row.

AppSignal traces post-DB-move show ~90% of request time in that single `Package Load`: rubygems `?critical=true` ~1.8-2.3s, npm ~3.2s, and `?sort=downloads&page=9` on npm still hitting the 30s rack-timeout.

Narrow the select to `id, name, updated_at` so `stale?` can still build the etag and `pluck(:name)` still works, while moving far less data from postgres. No index added since writes on `packages` are already heavy.