### PR TITLE
Capture npm contentPolicy field

### DIFF
--- a/app/models/ecosystem/npm.rb
+++ b/app/models/ecosystem/npm.rb
@@ -110,7 +110,8 @@ module Ecosystem
         namespace: namespace(package),
         metadata: {
           "funding" => latest_version["funding"],
-          "dist-tags" => package["dist-tags"]
+          "dist-tags" => package["dist-tags"],
+          "contentPolicy" => latest_version["contentPolicy"]
         }
       }
 
@@ -196,7 +197,8 @@ module Ecosystem
             "directories" => v["directories"],
             "engines" => v["engines"],
             "exports" => v["exports"],
-            "browserify" => v["browserify"]
+            "browserify" => v["browserify"],
+            "contentPolicy" => v["contentPolicy"]
           }
         }
       end

--- a/test/fixtures/files/npm/react_fresh
+++ b/test/fixtures/files/npm/react_fresh
@@ -49,6 +49,9 @@
       "browserify": {
         "transform": ["loose-envify"]
       },
+      "contentPolicy": {
+        "class": "dual-use"
+      },
       "repository": {
         "url": "git+https://github.com/facebook/react.git",
         "type": "git",

--- a/test/models/ecosystem/npm_test.rb
+++ b/test/models/ecosystem/npm_test.rb
@@ -108,7 +108,7 @@ class NpmTest < ActiveSupport::TestCase
     assert_equal package_metadata[:downloads], 1076972
     assert_equal package_metadata[:downloads_period], "last-month"
     assert_nil package_metadata[:namespace]
-    assert_equal package_metadata[:metadata], {"funding"=>nil, "dist-tags"=>{"latest"=>"2.0.1"}}
+    assert_equal package_metadata[:metadata], {"funding"=>nil, "dist-tags"=>{"latest"=>"2.0.1"}, "contentPolicy"=>nil}
   end
 
   test 'versions_metadata' do
@@ -182,5 +182,7 @@ class NpmTest < ActiveSupport::TestCase
     assert_equal first_version[:metadata]["_npmVersion"], "10.5.0"
     assert_equal first_version[:metadata]["exports"]["."]["default"], "./index.js"
     assert_equal first_version[:metadata]["browserify"]["transform"], ["loose-envify"]
+    assert_equal first_version[:metadata]["contentPolicy"], {"class"=>"dual-use"}
+    assert_equal package_metadata[:metadata]["contentPolicy"], {"class"=>"dual-use"}
   end
 end


### PR DESCRIPTION
npm added a `contentPolicy` field to `package.json` for dual-use declarations (https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/). It passes through to the version doc in the packument like any other `package.json` key.

This stores it in per-version metadata and hoists the latest value to package-level metadata, same pattern as `funding`.

The `DISCLOSURE` file and scan verdicts are not in the packument so are not captured here.