### PR TITLE
Handle empty IPS catalog responses

### DIFF
--- a/app/models/ecosystem/ips.rb
+++ b/app/models/ecosystem/ips.rb
@@ -64,7 +64,7 @@ module Ecosystem
       cache_key = "ips-#{@registry.name}-#{part.gsub('.', '-')}"
       cached_file = download_and_cache(catalog_url(part), cache_key)
       return {} if cached_file.nil?
-      Oj.load(File.read(cached_file))
+      Oj.load(File.read(cached_file)) || {}
     end
 
     def base_catalog

--- a/test/models/ecosystem/ips_test.rb
+++ b/test/models/ecosystem/ips_test.rb
@@ -213,4 +213,11 @@ class IpsTest < ActiveSupport::TestCase
     assert_equal 'https://pkg.openindiana.org/hipster/openindiana.org/catalog/1/catalog.base.C',
                  @ecosystem.catalog_url('catalog.base.C')
   end
+
+  test 'summary_packages returns an empty hash for an empty catalog' do
+    @ecosystem.stubs(:download_and_cache).returns('/tmp/catalog.summary.C')
+    File.stubs(:read).with('/tmp/catalog.summary.C').returns('')
+
+    assert_equal({}, @ecosystem.summary_packages)
+  end
 end


### PR DESCRIPTION
Treat empty IPS catalog downloads as an empty catalog. This prevents `CheckStatusWorker` from calling `dig` on nil when `Oj.load` parses an empty response.