### PR TITLE
Record GitHub Actions release immutability

### DIFF
--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -131,7 +131,7 @@ module Ecosystem
 
     def map_package_metadata(package)
       return nil unless package
-      {
+      metadata = {
         name: package['name'],
         description: package['yaml']['description'].presence || package["description"],
         repository_url: package["repository_url"],
@@ -139,9 +139,12 @@ module Ecosystem
         keywords_array: package['topics'],
         homepage: package["homepage"],
         tags_url: package["tags_url"],
+        releases_url: package["releases_url"],
         namespace: package["owner"],
         metadata: package['yaml'].merge('default_branch' => package['default_branch'], 'path' => package['path'])
       }
+      metadata.delete(:releases_url) if metadata[:releases_url].blank?
+      metadata
     end
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
@@ -149,18 +152,69 @@ module Ecosystem
       tags_json = get_json(pkg_metadata[:tags_url]+'?per_page=1000')
       return [] if tags_json.blank?
 
+      releases_by_tag = {}
+      if pkg_metadata[:releases_url]
+        releases_json = begin
+          get_json(pkg_metadata[:releases_url]+'?per_page=1000') || []
+        rescue StandardError
+          []
+        end
+        releases_by_tag = releases_json.index_by { |release| release['tag_name'] }
+      end
+
       tags_json.map do |tag|
+        release = releases_by_tag[tag['name']]
+        metadata = {
+          sha: tag['sha'],
+          download_url: tag['download_url']
+        }
+        metadata[:immutable] = release['immutable'] if [true, false].include?(release&.fetch('immutable', nil))
+
         {
           number: tag['name'],
           published_at: tag['published_at'],
-          metadata: {
-            sha: tag['sha'],
-            download_url: tag['download_url']
-          }
+          metadata: metadata
         }
       end
     rescue StandardError
       []
+    end
+
+    def update_existing_versions(package, versions_metadata)
+      immutable_by_number = versions_metadata.each_with_object({}) do |version, result|
+        version = version.with_indifferent_access
+        metadata = version[:metadata]&.with_indifferent_access || {}
+        next unless metadata.key?(:immutable)
+        next unless [true, false].include?(metadata[:immutable])
+
+        result[version[:number].to_s.downcase] = metadata[:immutable]
+      end
+
+      package.versions.select(:id, :number, :metadata).find_each do |version|
+        normalized_number = version.number.downcase
+        next unless immutable_by_number.key?(normalized_number)
+
+        immutable = immutable_by_number[normalized_number]
+        next if version.immutable == immutable
+
+        version.update_columns(
+          metadata: version.metadata.merge('immutable' => immutable),
+          updated_at: Time.current
+        )
+      end
+    end
+
+    def merge_version_metadata(existing_metadata, new_metadata)
+      existing_metadata = (existing_metadata || {}).with_indifferent_access
+      new_metadata = (new_metadata || {}).with_indifferent_access
+      immutable = new_metadata[:immutable]
+
+      return new_metadata if [true, false].include?(immutable)
+
+      new_metadata.delete(:immutable)
+      existing_immutable = existing_metadata[:immutable]
+      new_metadata[:immutable] = existing_immutable if [true, false].include?(existing_immutable)
+      new_metadata
     end
 
     def dependencies_metadata(name, version, package)

--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -198,7 +198,7 @@ module Ecosystem
         next if version.immutable == immutable
 
         version.update_columns(
-          metadata: version.metadata.merge('immutable' => immutable),
+          metadata: (version.metadata || {}).merge('immutable' => immutable),
           updated_at: Time.current
         )
       end

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -233,6 +233,14 @@ module Ecosystem
       []
     end
 
+    def update_existing_versions(_package, _versions_metadata)
+      nil
+    end
+
+    def merge_version_metadata(_existing_metadata, new_metadata)
+      new_metadata
+    end
+
     def download_and_cache(url, cache_key, ttl: 1.hour)
       cache_dir = Rails.root.join('tmp', 'cache', 'ecosystems')
       FileUtils.mkdir_p(cache_dir)

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -427,9 +427,10 @@ class Package < ApplicationRecord
   end
 
   def update_versions
-    package_metadata = registry.ecosystem_instance.package_metadata(name)
+    ecosystem = registry.ecosystem_instance
+    package_metadata = ecosystem.package_metadata(name)
     return false unless package_metadata
-    versions_metadata = registry.ecosystem_instance.versions_metadata(package_metadata)
+    versions_metadata = ecosystem.versions_metadata(package_metadata)
 
     created_versions = []
     versions_metadata.each do |version|
@@ -441,6 +442,10 @@ class Package < ApplicationRecord
       begin
         if v
           v.registry_id = registry_id
+          metadata_key = version.key?(:metadata) ? :metadata : 'metadata'
+          if version.key?(metadata_key)
+            version = version.merge(metadata_key => ecosystem.merge_version_metadata(v.metadata, version[metadata_key]))
+          end
           v.assign_attributes(version)
           v.save(validate: false)
         else

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -188,7 +188,7 @@ class Registry < ApplicationRecord
       return
     end
 
-    package.assign_attributes(package_metadata.except(:name, :releases, :versions, :version, :dependencies, :properties, :page, :time, :download_stats, :tags_url))
+    package.assign_attributes(package_metadata.except(:name, :releases, :versions, :version, :dependencies, :properties, :page, :time, :download_stats, :tags_url, :releases_url))
 
     update_repo_metadata_after_save = package.changed?
     new_package = package.new_record?
@@ -202,6 +202,7 @@ class Registry < ApplicationRecord
     existing_version_numbers = package.versions.pluck('number')
 
     versions_metadata = ecosystem_instance.versions_metadata(package_metadata, existing_version_numbers)
+    ecosystem_instance.update_existing_versions(package, versions_metadata)
 
     versions_metadata.each do |version|
       new_versions << version.merge(package_id: package.id, registry_id: id, created_at: Time.now, updated_at: Time.now) unless existing_version_numbers.find { |v| v == version.with_indifferent_access[:number].to_s && version.with_indifferent_access[:status].nil? }

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -28,6 +28,10 @@ class Version < ApplicationRecord
 
   scope :active, -> { where(status: nil) }
 
+  def immutable
+    metadata['immutable'] if metadata.is_a?(Hash)
+  end
+
   def self.normalize_integrity(params)
     integrity = params[:integrity]
 

--- a/app/views/api/v1/versions/_version.json.jbuilder
+++ b/app/views/api/v1/versions/_version.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :immutable, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(version.package.registry, version.package, version)
 json.codemeta_url codemeta_api_v1_registry_package_version_url(version.package.registry, version.package, version)
 json.dependencies version.dependencies do |dependency|

--- a/app/views/api/v1/versions/_version_with_package.json.jbuilder
+++ b/app/views/api/v1/versions/_version_with_package.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :immutable, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(@registry, version.package, version)
 json.package_url api_v1_registry_package_url(@registry, version.package)

--- a/app/views/api/v1/versions/index.json.jbuilder
+++ b/app/views/api/v1/versions/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @versions do |version|
-  json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
+  json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :immutable, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
   json.version_url api_v1_registry_package_version_url(@registry, @package, version)
   # json.dependencies version.dependencies do |dependency|
   #   json.extract! dependency, :ecosystem, :package_name, :requirements, :kind, :optional

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -48,6 +48,17 @@ namespace :packages do
     end
   end
 
+  desc 'backfill GitHub Actions release immutability'
+  task backfill_github_actions_immutability: :environment do
+    with_rake_lock('packages:backfill_github_actions_immutability', ttl: 24.hours.to_i) do
+      registry = Registry.find_by!(ecosystem: 'actions')
+
+      registry.packages.in_batches(of: 1_000) do |batch|
+        UpdateVersionsWorker.perform_bulk(batch.pluck(:id).map { |id| [id] })
+      end
+    end
+  end
+
   desc 'sync_worst_one_percent'
   task sync_worst_one_percent: :environment do
     with_rake_lock('packages:sync_worst_one_percent') do

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -26,6 +26,7 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'get version of a package' do
+    @version.update!(metadata: { foo: 'bar', immutable: false })
     get api_v1_registry_package_version_path(registry_id: @registry.name, package_id: @package.name, id: '1.0.0')
     assert_response :success
     assert_template 'versions/show', file: 'versions/show.json.jbuilder'
@@ -33,7 +34,8 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     actual_response = Oj.load(@response.body)
 
     assert_equal actual_response['number'], "1.0.0"
-    assert_equal actual_response['metadata'], {"foo"=>"bar"}
+    assert_equal actual_response['immutable'], false
+    assert_equal actual_response['metadata'], {"foo"=>"bar", "immutable"=>false}
   end
 
   test 'get recent versions' do

--- a/test/fixtures/files/actions/releases
+++ b/test/fixtures/files/actions/releases
@@ -1,0 +1,6 @@
+[
+  {
+    "tag_name": "v1",
+    "immutable": true
+  }
+]

--- a/test/models/ecosystem/actions_test.rb
+++ b/test/models/ecosystem/actions_test.rb
@@ -238,6 +238,17 @@ class ActionsTest < ActiveSupport::TestCase
     assert @version.reload.immutable
   end
 
+  test 'update_existing_versions handles null metadata' do
+    @version.update_column(:metadata, nil)
+
+    @ecosystem.update_existing_versions(
+      @package,
+      [{ number: @version.number, metadata: { immutable: true } }]
+    )
+
+    assert_equal({ 'immutable' => true }, @version.reload.metadata)
+  end
+
   test 'update_versions preserves immutability when the release value is null' do
     @version.update!(metadata: @version.metadata.merge('immutable' => true))
     @registry.stubs(:ecosystem_instance).returns(@ecosystem)

--- a/test/models/ecosystem/actions_test.rb
+++ b/test/models/ecosystem/actions_test.rb
@@ -178,10 +178,14 @@ class ActionsTest < ActiveSupport::TestCase
   end
 
   test 'versions_metadata' do
+    lookup = Oj.load(file_fixture('actions/lookup?url=https:%2F%2Fgithub.com%2Fgetsentry%2Faction-git-diff-suggestions').read)
+    lookup['releases_url'] = 'http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/getsentry%2Faction-git-diff-suggestions/releases'
     stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/getsentry%2Faction-git-diff-suggestions/tags?per_page=1000")
       .to_return({ status: 200, body: file_fixture('actions/tags') })
+    stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/getsentry%2Faction-git-diff-suggestions/releases?per_page=1000")
+      .to_return({ status: 200, body: file_fixture('actions/releases') })
     stub_request(:get, "https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/getsentry/action-git-diff-suggestions")
-      .to_return({ status: 200, body: file_fixture('actions/lookup?url=https:%2F%2Fgithub.com%2Fgetsentry%2Faction-git-diff-suggestions') })
+      .to_return({ status: 200, body: lookup.to_json })
     stub_request(:get, "https://raw.githubusercontent.com/getsentry/action-git-diff-suggestions/main/action.yml")
       .to_return({ status: 200, body: file_fixture('actions/action.yml') })
     stub_request(:get, "https://raw.githubusercontent.com/getsentry/action-git-diff-suggestions/v1/action.yml")
@@ -189,7 +193,68 @@ class ActionsTest < ActiveSupport::TestCase
     package_metadata = @ecosystem.package_metadata('getsentry/action-git-diff-suggestions')
     versions_metadata = @ecosystem.versions_metadata(package_metadata)
 
-    assert_equal versions_metadata.first, {:number=>"v1", :published_at=>"2020-11-25T01:40:25.000Z", :metadata=>{:sha=>"8c75946d0d7bbe80a92cf3579d544321512c30b7", :download_url=>"https://codeload.github.com/getsentry/action-git-diff-suggestions/tar.gz/v1"}}
+    assert_equal versions_metadata.first, {:number=>"v1", :published_at=>"2020-11-25T01:40:25.000Z", :metadata=>{:sha=>"8c75946d0d7bbe80a92cf3579d544321512c30b7", :download_url=>"https://codeload.github.com/getsentry/action-git-diff-suggestions/tar.gz/v1", :immutable=>true}}
+  end
+
+  test 'versions_metadata keeps tags when releases are unavailable' do
+    tags_url = 'https://repos.ecosyste.ms/tags'
+    releases_url = 'https://repos.ecosyste.ms/releases'
+    tags = Oj.load(file_fixture('actions/tags').read)
+    @ecosystem.stubs(:get_json).with("#{tags_url}?per_page=1000").returns(tags)
+    @ecosystem.stubs(:get_json).with("#{releases_url}?per_page=1000").raises(StandardError)
+
+    versions_metadata = @ecosystem.versions_metadata(tags_url: tags_url, releases_url: releases_url)
+
+    assert_equal 1, versions_metadata.length
+    refute versions_metadata.first[:metadata].key?(:immutable)
+  end
+
+  test 'update_versions stores immutability on an existing version' do
+    @registry.stubs(:ecosystem_instance).returns(@ecosystem)
+    @ecosystem.stubs(:package_metadata).with(@package.name).returns({ name: @package.name })
+    @ecosystem.stubs(:versions_metadata).returns([
+      {
+        number: @version.number,
+        metadata: {
+          download_url: @version.metadata['download_url'],
+          immutable: true
+        }
+      }
+    ])
+
+    @package.update_versions
+
+    assert @version.reload.immutable
+  end
+
+  test 'update_existing_versions refreshes changed immutability' do
+    @version.update!(metadata: @version.metadata.merge('immutable' => false))
+
+    @ecosystem.update_existing_versions(
+      @package,
+      [{ number: @version.number.upcase, metadata: { immutable: true } }]
+    )
+
+    assert @version.reload.immutable
+  end
+
+  test 'update_versions preserves immutability when the release value is null' do
+    @version.update!(metadata: @version.metadata.merge('immutable' => true))
+    @registry.stubs(:ecosystem_instance).returns(@ecosystem)
+    @ecosystem.stubs(:package_metadata).with(@package.name).returns({ name: @package.name })
+    @ecosystem.stubs(:versions_metadata).returns([
+      {
+        number: @version.number,
+        metadata: {
+          download_url: @version.metadata['download_url'],
+          immutable: nil
+        }
+      }
+    ])
+
+    @package.update_versions
+
+    assert @version.reload.immutable
   end
 
   test 'purl' do

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -210,7 +210,11 @@ class RegistryTest < ActiveSupport::TestCase
 
     ecosystem = @registry.ecosystem_instance
     ecosystem.stubs(:package_metadata).returns({ name: 'newpkg' })
-    ecosystem.stubs(:versions_metadata).returns([{ number: '1.0.0' }])
+    versions_metadata = [{ number: '1.0.0' }]
+    ecosystem.stubs(:versions_metadata).returns(versions_metadata)
+    ecosystem.expects(:update_existing_versions).with do |package, metadata|
+      package.name == 'newpkg' && metadata == versions_metadata
+    end
     ecosystem.stubs(:dependencies_metadata).returns([])
     Package.any_instance.stubs(:check_status)
     Package.any_instance.stubs(:update_repo_metadata_async)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -23,6 +23,12 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal @version.published_at, @version.created_at
   end
 
+  test 'immutable reads version metadata' do
+    @version.update!(metadata: { immutable: false })
+
+    assert_equal false, @version.immutable
+  end
+
   test 'sort' do
     sorted = [@version, @version2].sort
     assert_equal sorted.first, @version2

--- a/test/tasks/packages_rake_test.rb
+++ b/test/tasks/packages_rake_test.rb
@@ -37,6 +37,18 @@ class PackagesRakeTest < ActiveSupport::TestCase
     Rake::Task["packages:backfill_nuget_verified"].invoke
   end
 
+  test "backfills GitHub Actions release immutability" do
+    registry = Registry.create(name: 'GitHub Actions', url: 'https://github.com', ecosystem: 'actions')
+    first_package = registry.packages.create!(name: 'actions/checkout', ecosystem: 'actions')
+    second_package = registry.packages.create!(name: 'actions/cache', ecosystem: 'actions')
+
+    UpdateVersionsWorker.expects(:perform_bulk).with([[first_package.id], [second_package.id]])
+
+    task = Rake::Task["packages:backfill_github_actions_immutability"]
+    task.reenable
+    task.invoke
+  end
+
   test "nixpkgs_python_native_deps reports non-python dependencies" do
     registry = Registry.create(name: 'Nixpkgs', url: 'https://search.nixos.org', ecosystem: 'nixpkgs', packages_count: 3)
 


### PR DESCRIPTION
Store GitHub release immutability in GitHub Actions version metadata and expose it on version API responses. Existing versions are updated only when repos reports a boolean value, so missing and null values are ignored.

Add `packages:backfill_github_actions_immutability`, which queues the existing version update worker in batches for every GitHub Actions package.

Depends on ecosyste-ms/repos#1172.

Refs #1757