### PR TITLE
Sync moved tags and removed tags into tag-backed versions

### DIFF
--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -149,7 +149,7 @@ module Ecosystem
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       return [] unless pkg_metadata[:tags_url]
-      tags_json = get_json(pkg_metadata[:tags_url]+'?per_page=1000')
+      tags_json = get_json(pkg_metadata[:tags_url]+"?per_page=#{REPOS_TAGS_PER_PAGE}")
       return [] if tags_json.blank?
 
       releases_by_tag = {}
@@ -181,6 +181,8 @@ module Ecosystem
     end
 
     def update_existing_versions(package, versions_metadata)
+      sync_tag_backed_versions(package, versions_metadata)
+
       immutable_by_number = versions_metadata.each_with_object({}) do |version, result|
         version = version.with_indifferent_access
         metadata = version[:metadata]&.with_indifferent_access || {}

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -237,6 +237,44 @@ module Ecosystem
       nil
     end
 
+    REPOS_TAGS_PER_PAGE = 1000
+
+    def sync_tag_backed_versions(package, versions_metadata)
+      return if versions_metadata.blank?
+
+      remote = versions_metadata.each_with_object({}) do |version, result|
+        version = version.with_indifferent_access
+        result[version[:number].to_s.downcase] = version
+      end
+      mark_removed = versions_metadata.size < REPOS_TAGS_PER_PAGE
+      now = Time.current
+
+      package.versions.select(:id, :number, :status, :published_at, :metadata).find_each do |version|
+        incoming = remote[version.number.to_s.downcase]
+        if incoming.nil?
+          next unless mark_removed
+          next if version.status == 'removed'
+          version.update_columns(status: 'removed', updated_at: now)
+          next
+        end
+
+        updates = {}
+        updates[:status] = nil if version.status == 'removed'
+
+        incoming_metadata = (incoming[:metadata] || {}).with_indifferent_access
+        existing_metadata = (version.metadata || {}).with_indifferent_access
+        if incoming_metadata[:sha].present? && incoming_metadata[:sha] != existing_metadata[:sha]
+          updates[:metadata] = existing_metadata.merge(
+            'sha' => incoming_metadata[:sha],
+            'download_url' => incoming_metadata[:download_url]
+          ).compact
+          updates[:published_at] = incoming[:published_at] if incoming[:published_at].present?
+        end
+
+        version.update_columns(updates.merge(updated_at: now)) if updates.any?
+      end
+    end
+
     def merge_version_metadata(_existing_metadata, new_metadata)
       new_metadata
     end

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -264,10 +264,9 @@ module Ecosystem
         incoming_metadata = (incoming[:metadata] || {}).with_indifferent_access
         existing_metadata = (version.metadata || {}).with_indifferent_access
         if incoming_metadata[:sha].present? && incoming_metadata[:sha] != existing_metadata[:sha]
-          updates[:metadata] = existing_metadata.merge(
-            'sha' => incoming_metadata[:sha],
-            'download_url' => incoming_metadata[:download_url]
-          ).compact
+          new_metadata = existing_metadata.merge('sha' => incoming_metadata[:sha])
+          new_metadata['download_url'] = incoming_metadata[:download_url] if incoming_metadata[:download_url].present?
+          updates[:metadata] = new_metadata
           updates[:published_at] = incoming[:published_at] if incoming[:published_at].present?
         end
 

--- a/app/models/ecosystem/bower.rb
+++ b/app/models/ecosystem/bower.rb
@@ -69,7 +69,7 @@ module Ecosystem
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       repo_json = get_json("https://repos.ecosyste.ms/api/v1/repositories/lookup?url=#{CGI.escape(pkg_metadata[:repository_url])}")
       return [] if repo_json.blank?
-      tags_json = get_json("https://repos.ecosyste.ms/api/v1/hosts/#{repo_json['host']['name']}/repositories/#{repo_json['full_name']}/tags")
+      tags_json = get_json("https://repos.ecosyste.ms/api/v1/hosts/#{repo_json['host']['name']}/repositories/#{repo_json['full_name']}/tags?per_page=#{REPOS_TAGS_PER_PAGE}")
       return [] if tags_json.blank?
 
       tags_json.map do |tag|
@@ -84,6 +84,10 @@ module Ecosystem
       end
     rescue StandardError
       []
+    end
+
+    def update_existing_versions(package, versions_metadata)
+      sync_tag_backed_versions(package, versions_metadata)
     end
 
     def fetch_package_metadata_uncached(name)

--- a/app/models/ecosystem/carthage.rb
+++ b/app/models/ecosystem/carthage.rb
@@ -67,7 +67,7 @@ module Ecosystem
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       return [] unless pkg_metadata[:tags_url]
-      tags_json = get_json(pkg_metadata[:tags_url])
+      tags_json = get_json(pkg_metadata[:tags_url]+"?per_page=#{REPOS_TAGS_PER_PAGE}")
       return [] if tags_json.blank?
 
       tags_json.map do |tag|
@@ -84,9 +84,13 @@ module Ecosystem
       []
     end
 
+    def update_existing_versions(package, versions_metadata)
+      sync_tag_backed_versions(package, versions_metadata)
+    end
+
     def dependencies_metadata(name, version, package)
       return [] unless package[:repository_url]
-      github_name_with_owner = GithubUrlParser.parse(package[:repository_url]) 
+      github_name_with_owner = GithubUrlParser.parse(package[:repository_url])
       return [] unless github_name_with_owner
       deps = get_raw_no_exception("https://raw.githubusercontent.com/#{github_name_with_owner}/#{version}/Cartfile")
       return [] unless deps.present?

--- a/app/models/ecosystem/swiftpm.rb
+++ b/app/models/ecosystem/swiftpm.rb
@@ -75,7 +75,7 @@ module Ecosystem
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       return [] unless pkg_metadata[:tags_url]
-      tags_json = get_json(pkg_metadata[:tags_url])
+      tags_json = get_json(pkg_metadata[:tags_url]+"?per_page=#{REPOS_TAGS_PER_PAGE}")
       return [] if tags_json.blank?
 
       tags_json.map do |tag|
@@ -90,6 +90,10 @@ module Ecosystem
       end
     rescue StandardError
       []
+    end
+
+    def update_existing_versions(package, versions_metadata)
+      sync_tag_backed_versions(package, versions_metadata)
     end
 
     def fetch_package_metadata_uncached(name)

--- a/test/models/carthage_test.rb
+++ b/test/models/carthage_test.rb
@@ -82,7 +82,7 @@ class CarthageTest < ActiveSupport::TestCase
   end
 
   test 'versions_metadata' do
-    stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/Carthage%2FReactiveTask/tags")
+    stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/Carthage%2FReactiveTask/tags?per_page=1000")
       .to_return({ status: 200, body: file_fixture('carthage/tags') })
     stub_request(:get, "https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/Carthage/ReactiveTask")
       .to_return({ status: 200, body: file_fixture('carthage/lookup?url=https:%2F%2Fgithub.com%2FCarthage%2FReactiveTask') })

--- a/test/models/carthage_test.rb
+++ b/test/models/carthage_test.rb
@@ -91,4 +91,9 @@ class CarthageTest < ActiveSupport::TestCase
 
     assert_equal versions_metadata.first, {:number=>"0.16.0", :published_at=>"2019-05-29T17:11:59.000Z", :metadata=>{:sha=>"df1bf7625684180b9377a8ba3c076db08d98757e", :download_url=>"https://codeload.github.com/Carthage/ReactiveTask/tar.gz/0.16.0"}}
   end
+
+  test 'update_existing_versions syncs tag-backed changes' do
+    @ecosystem.expects(:sync_tag_backed_versions).with(@package, [{ number: '0.16.0' }])
+    @ecosystem.update_existing_versions(@package, [{ number: '0.16.0' }])
+  end
 end

--- a/test/models/ecosystem/base_test.rb
+++ b/test/models/ecosystem/base_test.rb
@@ -131,4 +131,64 @@ class BaseTest < ActiveSupport::TestCase
     assert cached_file.exist?
     FileUtils.rm_f(cached_file)
   end
+
+  test 'sync_tag_backed_versions refreshes moved sha and published_at' do
+    version = @package.versions.create(number: 'v2', published_at: 2.days.ago, metadata: { 'sha' => 'old', 'download_url' => 'old_url', 'other' => 'kept' })
+    published = 1.hour.ago.change(usec: 0)
+
+    @ecosystem.sync_tag_backed_versions(@package, [
+      { number: 'v2', published_at: published, metadata: { sha: 'new', download_url: 'new_url' } }
+    ])
+
+    version.reload
+    assert_equal 'new', version.metadata['sha']
+    assert_equal 'new_url', version.metadata['download_url']
+    assert_equal 'kept', version.metadata['other']
+    assert_equal published, version.published_at
+    assert_nil version.status
+  end
+
+  test 'sync_tag_backed_versions marks missing versions removed and restores returning versions' do
+    gone = @package.versions.create(number: 'gone', metadata: { 'sha' => 'a' })
+    already_removed = @package.versions.create(number: 'also-gone', status: 'removed', updated_at: 2.days.ago)
+    already_removed_updated_at = already_removed.updated_at
+    back = @package.versions.create(number: 'back', status: 'removed', metadata: { 'sha' => 'same' })
+
+    @ecosystem.sync_tag_backed_versions(@package, [
+      { 'number' => 'back', 'metadata' => { 'sha' => 'same' } },
+      { 'number' => 'kept', 'metadata' => { 'sha' => 'x' } }
+    ])
+
+    assert_equal 'removed', gone.reload.status
+    assert_equal 'removed', already_removed.reload.status
+    assert_equal already_removed_updated_at.to_i, already_removed.updated_at.to_i
+    assert_nil back.reload.status
+  end
+
+  test 'sync_tag_backed_versions leaves non-removed status alone when sha is unchanged' do
+    version = @package.versions.create(number: 'v1', status: 'deprecated', metadata: { 'sha' => 'same' })
+
+    @ecosystem.sync_tag_backed_versions(@package, [
+      { number: 'v1', metadata: { sha: 'same' } }
+    ])
+
+    assert_equal 'deprecated', version.reload.status
+  end
+
+  test 'sync_tag_backed_versions does nothing when versions_metadata is empty' do
+    version = @package.versions.create(number: 'v1', metadata: { 'sha' => 'a' })
+
+    @ecosystem.sync_tag_backed_versions(@package, [])
+
+    assert_nil version.reload.status
+  end
+
+  test 'sync_tag_backed_versions skips removal when the tags page is full' do
+    beyond_page = @package.versions.create(number: 'old', metadata: { 'sha' => 'a' })
+    full_page = Array.new(Ecosystem::Base::REPOS_TAGS_PER_PAGE) { |i| { number: "v#{i}", metadata: { sha: "s#{i}" } } }
+
+    @ecosystem.sync_tag_backed_versions(@package, full_page)
+
+    assert_nil beyond_page.reload.status
+  end
 end

--- a/test/models/ecosystem/base_test.rb
+++ b/test/models/ecosystem/base_test.rb
@@ -148,6 +148,18 @@ class BaseTest < ActiveSupport::TestCase
     assert_nil version.status
   end
 
+  test 'sync_tag_backed_versions keeps existing download_url when incoming omits it' do
+    version = @package.versions.create(number: 'v3', metadata: { 'sha' => 'old', 'download_url' => 'keep_me' })
+
+    @ecosystem.sync_tag_backed_versions(@package, [
+      { number: 'v3', metadata: { sha: 'new' } }
+    ])
+
+    version.reload
+    assert_equal 'new', version.metadata['sha']
+    assert_equal 'keep_me', version.metadata['download_url']
+  end
+
   test 'sync_tag_backed_versions marks missing versions removed and restores returning versions' do
     gone = @package.versions.create(number: 'gone', metadata: { 'sha' => 'a' })
     already_removed = @package.versions.create(number: 'also-gone', status: 'removed', updated_at: 2.days.ago)

--- a/test/models/ecosystem/bower_test.rb
+++ b/test/models/ecosystem/bower_test.rb
@@ -94,7 +94,7 @@ class BowerTest < ActiveSupport::TestCase
   test 'versions_metadata' do
     stub_request(:get, "https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/angular/bower-angular")
       .to_return({ status: 200, body: file_fixture('bower/lookup?url=https:%2F%2Fgithub.com%2Fangular%2Fbower-angular') })
-    stub_request(:get, "https://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/angular/bower-angular/tags")
+    stub_request(:get, "https://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/angular/bower-angular/tags?per_page=1000")
       .to_return({ status: 200, body: file_fixture('bower/tags') })
     versions_metadata = @ecosystem.versions_metadata({name: 'bower-angular', repository_url: "https://github.com/angular/bower-angular"})
 

--- a/test/models/ecosystem/bower_test.rb
+++ b/test/models/ecosystem/bower_test.rb
@@ -103,6 +103,11 @@ class BowerTest < ActiveSupport::TestCase
       {:number=>"v1.2.8-build.2092+sha.95e1b2d", :published_at=>"2014-01-08T08:49:35.000Z", :metadata=>{:sha=>"24c0a22b32631277c6da4c419a484278e560c7a1", :download_url=>"https://codeload.github.com/angular/bower-angular/tar.gz/v1.2.8-build.2092+sha.95e1b2d"}}]
   end
 
+  test 'update_existing_versions syncs tag-backed changes' do
+    @ecosystem.expects(:sync_tag_backed_versions).with(@package, [{ number: '1.0.0' }])
+    @ecosystem.update_existing_versions(@package, [{ number: '1.0.0' }])
+  end
+
   test 'check_status reuses memoized metadata without extra HTTP request' do
     stub_request(:get, "https://registry.bower.io/packages")
       .to_return({ status: 200, body: file_fixture('bower/packages') })

--- a/test/models/ecosystem/swiftpm_test.rb
+++ b/test/models/ecosystem/swiftpm_test.rb
@@ -123,7 +123,7 @@ class SwiftpmTest < ActiveSupport::TestCase
   end
 
   test 'versions_metadata' do
-    stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/swift-cloud%2FCompute/tags")
+    stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/swift-cloud%2FCompute/tags?per_page=1000")
       .to_return({ status: 200, body: file_fixture('swiftpm/tags') })
     stub_request(:get, "https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/swift-cloud/Compute")
       .to_return({ status: 200, body: file_fixture('swiftpm/lookup?url=https:%2F%2Fgithub.com%2Fswift-cloud%2FCompute') })
@@ -177,5 +177,10 @@ class SwiftpmTest < ActiveSupport::TestCase
       {:package_name=>"github.com/krzyzanowskim/CryptoSwift", :requirements=>"1.6.0", :kind=>"runtime", :ecosystem=>"swiftpm"},
       {:package_name=>"github.com/apple/swift-docc-plugin", :requirements=>"1.0.0", :kind=>"runtime", :ecosystem=>"swiftpm"}
     ], dependencies_metadata
+  end
+
+  test 'update_existing_versions syncs tag-backed changes' do
+    @ecosystem.expects(:sync_tag_backed_versions).with(@package, [{ number: '2.3.1' }])
+    @ecosystem.update_existing_versions(@package, [{ number: '2.3.1' }])
   end
 end


### PR DESCRIPTION
repos now updates moved-tag shas and deletes tags/releases that no longer exist on GitHub (ecosyste-ms/repos#1177). `Registry#sync_package` skips any version number it already has, so those changes never reached actions/bower/carthage/swiftpm versions: a rolling `v2` tag kept its original sha forever, and a deleted tag stayed as an active version.

`Ecosystem::Base#sync_tag_backed_versions` refreshes `metadata.sha` / `download_url` / `published_at` when the sha changes, marks versions `removed` when their tag disappears from the repos response, and clears `removed` if it comes back. It's wired into `update_existing_versions` for actions, bower, carthage and swiftpm; actions keeps its immutable refresh on top. Cocoapods is left alone since it enriches spec-repo versions with tag data rather than deriving versions from tags.

Removal is skipped when the tags response is a full page (`REPOS_TAGS_PER_PAGE`, 1000) so a truncated fetch can't wipe the tail. bower/carthage/swiftpm now request `per_page=1000` — they were defaulting to 100, which would have made removal misfire immediately — and actions uses the same constant so the guard tracks it.

Refs #1757.