### PR TITLE
Cap missing_package_names at 5000 per registry

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -91,6 +91,8 @@ class Registry < ApplicationRecord
     packages.pluck(:name)
   end
 
+  MISSING_PACKAGE_NAMES_LIMIT = 5_000
+
   def missing_package_names
     all_names = all_package_names
     all_names = all_names.keys if all_names.is_a?(Hash)
@@ -101,6 +103,11 @@ class Registry < ApplicationRecord
     all_names.each_slice(10_000) do |batch|
       existing_in_batch = packages.where(name: batch).pluck(:name).to_set
       missing.concat(batch.reject { |name| existing_in_batch.include?(name) })
+      break if missing.length >= MISSING_PACKAGE_NAMES_LIMIT
+    end
+    if missing.length > MISSING_PACKAGE_NAMES_LIMIT
+      Rails.logger.warn("missing_package_names for #{name} (#{ecosystem}) returned #{missing.length}+ names; capping at #{MISSING_PACKAGE_NAMES_LIMIT}")
+      missing = missing.first(MISSING_PACKAGE_NAMES_LIMIT)
     end
     missing
   rescue => e

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -100,13 +100,16 @@ class Registry < ApplicationRecord
     return [] if all_names.empty?
 
     missing = []
+    scanned = 0
     all_names.each_slice(10_000) do |batch|
+      scanned += batch.length
       existing_in_batch = packages.where(name: batch).pluck(:name).to_set
       missing.concat(batch.reject { |name| existing_in_batch.include?(name) })
       break if missing.length >= MISSING_PACKAGE_NAMES_LIMIT
     end
-    if missing.length > MISSING_PACKAGE_NAMES_LIMIT
-      Rails.logger.warn("missing_package_names for #{name} (#{ecosystem}) returned #{missing.length}+ names; capping at #{MISSING_PACKAGE_NAMES_LIMIT}")
+    if missing.length >= MISSING_PACKAGE_NAMES_LIMIT
+      more = scanned < all_names.length ? '+' : ''
+      Rails.logger.warn("missing_package_names for #{name} (#{ecosystem}) found #{missing.length}#{more} names; capping at #{MISSING_PACKAGE_NAMES_LIMIT}")
       missing = missing.first(MISSING_PACKAGE_NAMES_LIMIT)
     end
     missing

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -67,6 +67,14 @@ class RegistryTest < ActiveSupport::TestCase
     assert_equal limit, @registry.missing_package_names.length
   end
 
+  test 'missing_package_names warns when exactly at the cap' do
+    limit = Registry::MISSING_PACKAGE_NAMES_LIMIT
+    names = (1..limit).map { |i| "pkg-#{i}" }
+    @registry.expects(:all_package_names).returns(names)
+    Rails.logger.expects(:warn).with { |msg| msg.include?("found #{limit} names") && !msg.include?("#{limit}+") }
+    assert_equal limit, @registry.missing_package_names.length
+  end
+
   test 'existing_package_names' do
     @registry.save
     @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -50,6 +50,23 @@ class RegistryTest < ActiveSupport::TestCase
     assert_equal @registry.missing_package_names, []
   end
 
+  test 'missing_package_names caps at MISSING_PACKAGE_NAMES_LIMIT' do
+    limit = Registry::MISSING_PACKAGE_NAMES_LIMIT
+    names = (1..(limit + 200)).map { |i| "pkg-#{i}" }
+    @registry.expects(:all_package_names).returns(names)
+    result = @registry.missing_package_names
+    assert_equal limit, result.length
+    assert_equal names.first(limit), result
+  end
+
+  test 'missing_package_names stops scanning batches once cap is reached' do
+    limit = Registry::MISSING_PACKAGE_NAMES_LIMIT
+    names = (1..30_000).map { |i| "pkg-#{i}" }
+    @registry.expects(:all_package_names).returns(names)
+    @registry.packages.expects(:where).once.returns(stub(pluck: []))
+    assert_equal limit, @registry.missing_package_names.length
+  end
+
   test 'existing_package_names' do
     @registry.save
     @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)


### PR DESCRIPTION
The nightly `packages:sync_missing` cron has been enqueueing ~450-575k `SyncPackageWorker` jobs onto the `critical` queue once a day (varying hour, 05:00-10:00 UTC) when a registry's `all_package_names` returns names that don't exactly match stored `packages.name` values, making most of the registry appear missing. Draining that starves the `default` and `low` queues for 3-4 hours, then the backed-up `low` queue drains in a burst that hammers repos.ecosyste.ms.

This caps `missing_package_names` at 5,000 per registry with a warning log when hit, and breaks out of the batch loop early once the cap is reached so a fully-mismatched registry runs one 10k-name `IN` query instead of ~84.

5,000/day is well above genuine new-package rates for any single registry (npm ~3k/day, pypi ~1k/day, nuget ~500/day). A real backlog will clear over multiple nights; a name-mismatch bug is bounded to 5k wasted jobs instead of 575k.

The underlying mismatch (likely nuget case handling) still needs fixing separately.