### PR TITLE
Add normalized_name for Go and use it in missing_package_names

### DIFF
--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -14,6 +14,15 @@ module Ecosystem
       false
     end
 
+    # Return a normalized form of the package name for this ecosystem, or nil
+    # if the ecosystem does not define one. When set, the value is stored in
+    # metadata['normalized_name'] (indexed) and used by
+    # Registry#missing_package_names to recognise a package that already exists
+    # under a different literal name (e.g. Go module path case-variants).
+    def normalized_name(name)
+      nil
+    end
+
     def sync_maintainers_inline?
       false
     end

--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -47,6 +47,10 @@ module Ecosystem
       "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/#{version}.zip"
     end
 
+    def normalized_name(name)
+      name.downcase
+    end
+
     def all_package_names
       names = []
       pkgs = get_raw("https://index.golang.org/index").split("\n").map{|row| Oj.load(row)}
@@ -110,10 +114,15 @@ module Ecosystem
           licenses: licenses,
           repository_url: url,
           homepage: url,
-          namespace: package[:name].split('/')[0..-2].join('/')
+          namespace: package[:name].split('/')[0..-2].join('/'),
+          metadata: { 'normalized_name' => normalized_name(package[:name]) }
         }
       else
-        { name: package[:name], repository_url: UrlParser.try_all(package[:name]) }
+        {
+          name: package[:name],
+          repository_url: UrlParser.try_all(package[:name]),
+          metadata: { 'normalized_name' => normalized_name(package[:name]) }
+        }
       end
     end
 

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -102,10 +102,29 @@ class Registry < ApplicationRecord
       existing_in_batch = packages.where(name: batch).pluck(:name).to_set
       missing.concat(batch.reject { |name| existing_in_batch.include?(name) })
     end
-    missing
+    reject_known_by_normalized_name(missing)
   rescue => e
     Rails.logger.error("Error in missing_package_names for registry #{id} (#{ecosystem}): #{e.message}")
     []
+  end
+
+  # For ecosystems that define normalized_name (e.g. Go), drop names whose
+  # normalized form matches an existing package's metadata['normalized_name'].
+  # Uses index_packages_on_registry_id_and_normalized_name. No-op for
+  # ecosystems whose normalized_name returns nil.
+  def reject_known_by_normalized_name(names)
+    return names if names.empty?
+    pairs = names.filter_map { |n| nn = ecosystem_instance.normalized_name(n); [n, nn] if nn }
+    return names if pairs.empty?
+
+    known = Set.new
+    pairs.map(&:last).uniq.each_slice(10_000) do |batch|
+      known.merge(packages.where("metadata->>'normalized_name' = ANY(ARRAY[?]::text[])", batch).pluck(Arel.sql("metadata->>'normalized_name'")))
+    end
+    return names if known.empty?
+
+    known_originals = pairs.filter_map { |n, nn| n if known.include?(nn) }.to_set
+    names.reject { |n| known_originals.include?(n) }
   end
 
   def sync_all_packages

--- a/test/models/ecosystem/go_test.rb
+++ b/test/models/ecosystem/go_test.rb
@@ -83,6 +83,10 @@ class GoTest < ActiveSupport::TestCase
     assert_equal recently_updated_package_names.last, 'github.com/xenolf/lego'
   end
 
+  test 'normalized_name downcases' do
+    assert_equal 'github.com/burntsushi/toml', @ecosystem.normalized_name('github.com/BurntSushi/toml')
+  end
+
   test 'package_metadata' do
     stub_request(:get, "https://pkg.go.dev/v1beta/module/github.com/aws/smithy-go?licenses=true")
       .to_return({ status: 200, body: file_fixture('go/api_module_smithy-go.json') })
@@ -97,6 +101,18 @@ class GoTest < ActiveSupport::TestCase
     assert_equal package_metadata[:repository_url], "https://github.com/aws/smithy-go"
     assert_nil package_metadata[:keywords_array]
     assert_equal package_metadata[:namespace], "github.com/aws"
+    assert_equal package_metadata[:metadata], { 'normalized_name' => 'github.com/aws/smithy-go' }
+  end
+
+  test 'package_metadata sets normalized_name for mixed-case module path' do
+    stub_request(:get, "https://pkg.go.dev/v1beta/module/github.com/BurntSushi/toml?licenses=true")
+      .to_return({ status: 200, body: file_fixture('go/api_module_smithy-go.json') })
+    stub_request(:get, "https://pkg.go.dev/v1beta/package/github.com/BurntSushi/toml")
+      .to_return({ status: 200, body: file_fixture('go/api_package_smithy-go.json') })
+    package_metadata = @ecosystem.package_metadata('github.com/BurntSushi/toml')
+
+    assert_equal package_metadata[:name], 'github.com/BurntSushi/toml'
+    assert_equal package_metadata[:metadata], { 'normalized_name' => 'github.com/burntsushi/toml' }
   end
 
   test 'package_metadata falls back to proxy when API misses' do
@@ -108,6 +124,7 @@ class GoTest < ActiveSupport::TestCase
 
     assert_equal package_metadata[:name], "github.com/aws/smithy-go"
     assert_equal package_metadata[:repository_url], "https://github.com/aws/smithy-go"
+    assert_equal package_metadata[:metadata], { 'normalized_name' => 'github.com/aws/smithy-go' }
   end
 
   test 'versions_metadata' do

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -50,6 +50,25 @@ class RegistryTest < ActiveSupport::TestCase
     assert_equal @registry.missing_package_names, []
   end
 
+  test 'reject_known_by_normalized_name is a no-op when the ecosystem does not normalize' do
+    @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)
+    assert_equal ['foo', 'bar'], @registry.reject_known_by_normalized_name(['foo', 'bar'])
+  end
+
+  test 'missing_package_names drops case-variants of existing packages via normalized_name' do
+    go = Registry.create(name: 'proxy.golang.org', url: 'https://proxy.golang.org', ecosystem: 'go')
+    go.packages.create!(ecosystem: 'go', name: 'github.com/BurntSushi/toml', metadata: { 'normalized_name' => 'github.com/burntsushi/toml' })
+    go.expects(:all_package_names).returns(['github.com/BurntSushi/toml', 'github.com/burntsushi/toml', 'github.com/Burntsushi/toml', 'github.com/new/module'])
+    assert_equal ['github.com/new/module'], go.missing_package_names
+  end
+
+  test 'missing_package_names still returns names when normalized_name is not populated' do
+    go = Registry.create(name: 'proxy.golang.org', url: 'https://proxy.golang.org', ecosystem: 'go')
+    go.packages.create!(ecosystem: 'go', name: 'github.com/BurntSushi/toml', metadata: {})
+    go.expects(:all_package_names).returns(['github.com/burntsushi/toml', 'github.com/new/module'])
+    assert_equal ['github.com/burntsushi/toml', 'github.com/new/module'], go.missing_package_names
+  end
+
   test 'existing_package_names' do
     @registry.save
     @registry.packages.create(name: 'foo', ecosystem: @registry.ecosystem)


### PR DESCRIPTION
`index.golang.org/index` is an append-only log of every proxy fetch, recorded with whatever case the caller typed in `go get`, so the same module appears under multiple casings (`github.com/BurntSushi/toml`, `github.com/burntsushi/toml`, etc). `Registry#missing_package_names` diffs by exact name, so ~575k case-variants of already-stored Go packages were being enqueued onto the `critical` queue every night by `packages:sync_missing`, each doing ~1.8s of failed pkg.go.dev/proxy lookups before storing nothing.

This follows the existing pypi `normalized_name` pattern:

- `Ecosystem::Base#normalized_name` returns nil (no normalization by default)
- `Ecosystem::Go#normalized_name` returns `name.downcase`
- Go's `map_package_metadata` sets `metadata['normalized_name']`, which is already indexed via `index_packages_on_registry_id_and_normalized_name`
- `Registry#missing_package_names` does a second pass for ecosystems that define `normalized_name`: batch-look-up the post-exact-diff remainder against the indexed metadata field and drop matches. Ecosystems that return nil skip the second pass entirely (zero extra queries).

For Go's ~575k post-diff names this is ~40 batched indexed queries and ~90MB peak for the working arrays.

Existing 2.26M Go packages don't have `metadata['normalized_name']` yet, so a one-time backfill is needed before the second pass has anything to match:

```ruby
r = Registry.find_by(ecosystem: 'go'); done = 0; r.packages.in_batches(of: 5_000) { |b| n = b.where("metadata->>'normalized_name' IS NULL").update_all("metadata = (COALESCE(metadata::jsonb, '{}'::jsonb) || jsonb_build_object('normalized_name', lower(name)))::json"); done += n; puts "updated: #{done}" if (done % 50_000) < 5_000 }; nil
```

Related: #1762 caps `missing_package_names` at 5,000 as a general safety net; this PR is the Go-specific fix.