### PR TITLE
Fix Go missing package discovery

### DIFF
--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -14,6 +14,10 @@ module Ecosystem
       false
     end
 
+    def sync_missing_packages_incrementally?
+      false
+    end
+
     def sync_maintainers_inline?
       false
     end
@@ -113,14 +117,25 @@ module Ecosystem
       []
     end
 
-    def fetch_package_metadata(name)
-      return @last_fetched_metadata if @last_fetched_name == name
-      @last_fetched_name = name
-      @last_fetched_metadata = fetch_package_metadata_uncached(name)
+    def fetch_package_metadata(name, version: nil)
+      cache_key = [name, version]
+      return @last_fetched_metadata if @last_fetched_key == cache_key
+
+      metadata = if version
+                   fetch_package_metadata_for_version(name, version)
+                 else
+                   fetch_package_metadata_uncached(name)
+                 end
+      @last_fetched_key = cache_key
+      @last_fetched_metadata = metadata
     end
 
-    def package_metadata(name)
-      map_package_metadata(fetch_package_metadata(name))
+    def fetch_package_metadata_for_version(name, _version)
+      fetch_package_metadata_uncached(name)
+    end
+
+    def package_metadata(name, version: nil)
+      map_package_metadata(fetch_package_metadata(name, version: version))
     end
 
     def map_dependencies(deps, kind, optional = false, ecosystem = self.class.name.demodulize.downcase)

--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -236,26 +236,24 @@ module Ecosystem
 
     def map_package_metadata(package)
       return false unless package
-      if package[:module]
-        mod = package[:module]
-        url = mod['repoUrl']
-        licenses = Array(mod['licenses']).flat_map { |l| l['types'] }.compact.uniq.join(',')
+      metadata = if package[:module]
+                   mod = package[:module]
+                   url = mod['repoUrl']
+                   licenses = Array(mod['licenses']).flat_map { |l| l['types'] }.compact.uniq.join(',')
 
-        metadata = {
-          name: package[:name],
-          description: package[:synopsis],
-          licenses: licenses,
-          repository_url: url,
-          homepage: url,
-          namespace: package[:name].split('/')[0..-2].join('/')
-        }
-        metadata[:version] = package[:version] if package[:version].present?
-        metadata
-      else
-        metadata = { name: package[:name], repository_url: UrlParser.try_all(package[:name]) }
-        metadata[:version] = package[:version] if package[:version].present?
-        metadata
-      end
+                   {
+                     name: package[:name],
+                     description: package[:synopsis],
+                     licenses: licenses,
+                     repository_url: url,
+                     homepage: url,
+                     namespace: package[:name].split('/')[0..-2].join('/')
+                   }
+                 else
+                   { name: package[:name], repository_url: UrlParser.try_all(package[:name]) }
+                 end
+      metadata[:version] = package[:version] if package[:version].present?
+      metadata
     end
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])

--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -1,6 +1,9 @@
 module Ecosystem
   class Go < Base
     PKGSITE_API = "https://pkg.go.dev/v1beta"
+    INDEX_API = "https://index.golang.org/index"
+    INDEX_PAGE_SIZE = 2_000
+    SYNC_MISSING_CURSOR_KEY = "sync_missing_packages_cursor"
 
     def self.purl_type
       'golang'
@@ -32,9 +35,16 @@ module Ecosystem
       if [400, 404, 410, 302, 301].include?(response.status)
         proxy_url = "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/list"
         response = Faraday.get(proxy_url)
-        if [400, 404, 410].include?(response.status) || response.body.length.zero?
-          "removed"
-        end
+        return "removed" if [400, 404, 410].include?(response.status)
+        return unless response.success?
+        return unless response.body.length.zero?
+
+        version = package.versions.active.order(id: :desc).pick(:number)
+        return "removed" unless version
+
+        version_url = "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/#{encode_for_proxy(version)}.info"
+        version_response = Faraday.get(version_url)
+        return "removed" if [400, 404, 410].include?(version_response.status)
       end
     end
 
@@ -44,17 +54,106 @@ module Ecosystem
 
     def download_url(package, version)
       return nil unless version.present?
-      "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/#{version}.zip"
+      "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/#{encode_for_proxy(version.to_s)}.zip"
+    end
+
+    def sync_missing_packages_incrementally?
+      true
+    end
+
+    def sync_missing_packages_async
+      cursor = sync_missing_packages_cursor
+      latest_by_path = {}
+      next_cursor = cursor
+
+      loop do
+        rows = index_versions(cursor)
+        break if rows.empty?
+
+        new_rows = index_versions_after_cursor(rows, cursor)
+        break if new_rows.empty?
+
+        new_rows.each do |row|
+          latest_by_path[row["Path"]] = row if row["Path"].present? && row["Version"].present?
+        end
+        next_cursor = index_cursor_for(new_rows.last)
+        break if rows.length < INDEX_PAGE_SIZE || next_cursor == cursor
+
+        cursor = next_cursor
+      end
+
+      enqueued = enqueue_missing_package_versions(latest_by_path)
+      save_sync_missing_packages_cursor(next_cursor)
+      enqueued
+    rescue => e
+      Rails.logger.error("Error syncing missing Go packages for registry #{@registry.id}: #{e.message}")
+      0
+    end
+
+    def sync_missing_packages_cursor
+      cursor = @registry.metadata.to_h[SYNC_MISSING_CURSOR_KEY]
+      return cursor if cursor.is_a?(Hash) && cursor["timestamp"].present?
+
+      {"timestamp" => 1.day.ago.utc.iso8601(9)}
+    end
+
+    def index_versions(cursor)
+      url = "#{INDEX_API}?since=#{cursor.fetch("timestamp")}&limit=#{INDEX_PAGE_SIZE}"
+      response = request(url)
+      raise "Go index returned #{response.status}" unless response.success?
+
+      response.body.split("\n").filter_map do |row|
+        Oj.load(row) unless row.blank?
+      end
+    end
+
+    def index_versions_after_cursor(rows, cursor)
+      return rows unless cursor["path"].present? && cursor["version"].present?
+
+      cursor_index = rows.index do |row|
+        row["Timestamp"] == cursor["timestamp"] &&
+          row["Path"] == cursor["path"] &&
+          row["Version"] == cursor["version"]
+      end
+      cursor_index ? rows.drop(cursor_index + 1) : rows
+    end
+
+    def enqueue_missing_package_versions(latest_by_path)
+      return 0 if latest_by_path.empty?
+
+      existing_names = Set.new
+      latest_by_path.keys.each_slice(1_000) do |names|
+        existing_names.merge(@registry.packages.where(name: names).pluck(:name))
+      end
+
+      jobs = latest_by_path.filter_map do |name, row|
+        [@registry.id, name, row["Version"]] unless existing_names.include?(name)
+      end
+      jobs.each_slice(1_000) { |batch| SyncPackageVersionWorker.perform_bulk(batch) }
+      jobs.length
+    end
+
+    def index_cursor_for(row)
+      {
+        "timestamp" => row.fetch("Timestamp"),
+        "path" => row.fetch("Path"),
+        "version" => row.fetch("Version")
+      }
+    end
+
+    def save_sync_missing_packages_cursor(cursor)
+      metadata = @registry.metadata.to_h.merge(SYNC_MISSING_CURSOR_KEY => cursor)
+      @registry.update!(metadata: metadata)
     end
 
     def all_package_names
       names = []
-      pkgs = get_raw("https://index.golang.org/index").split("\n").map{|row| Oj.load(row)}
+      pkgs = get_raw(INDEX_API).split("\n").map{|row| Oj.load(row)}
       names += pkgs.map{|j| j['Path' ]}
       since = pkgs.last['Timestamp']
 
       while 
-        pkgs = get_raw("https://index.golang.org/index?since=#{since}").split("\n").map{|row| Oj.load(row)}
+        pkgs = get_raw("#{INDEX_API}?since=#{since}").split("\n").map{|row| Oj.load(row)}
         break if pkgs.last['Timestamp'] == since
         since = pkgs.last['Timestamp']
         names += pkgs.map{|j| j['Path' ]}
@@ -66,27 +165,61 @@ module Ecosystem
     end
 
     def recently_updated_package_names
-      get_raw("https://index.golang.org/index?since=#{Time.now.utc.beginning_of_day.to_fs(:iso8601)}").split("\n").map{|row| Oj.load(row)['Path']}.uniq
+      get_raw("#{INDEX_API}?since=#{Time.now.utc.beginning_of_day.to_fs(:iso8601)}").split("\n").map{|row| Oj.load(row)['Path']}.uniq
     rescue
       []
     end
 
     def fetch_package_metadata_uncached(name)
-      resp = request("#{PKGSITE_API}/module/#{name}?licenses=true")
+      package = fetch_package_metadata_from_pkgsite(name)
+      return package if package
 
-      if resp.success?
-        mod = Oj.load(resp.body)
-        { name: name, module: mod, synopsis: fetch_synopsis(name) }
+      resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/list")
+      if resp.success? && resp.body.length > 0
+        { name: name, repository_url: UrlParser.try_all(name) }
       else
-        resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/list")
-        if resp.success? && resp.body.length > 0
-          { name: name, repository_url: UrlParser.try_all(name) }
-        else
-          false
-        end
+        false
       end
     rescue
       false
+    end
+
+    def fetch_package_metadata_from_pkgsite(name)
+      resp = request("#{PKGSITE_API}/module/#{name}?licenses=true")
+      return nil unless resp.success?
+
+      mod = Oj.load(resp.body)
+      { name: name, module: mod, synopsis: fetch_synopsis(name) }
+    rescue
+      nil
+    end
+
+    def fetch_package_metadata_for_version(name, version)
+      resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/#{encode_for_proxy(version)}.mod")
+      return false if [400, 404, 410].include?(resp.status)
+      raise "Go proxy returned #{resp.status} for #{name}@#{version}.mod" unless resp.success?
+
+      declared_name = module_path_from_go_mod(resp.body)
+      if declared_name.blank?
+        Rails.logger.warn("Go module #{name}@#{version} has no module directive")
+        return false
+      end
+      if declared_name != name
+        Rails.logger.info("Ignoring alternative Go module path #{name}@#{version}; go.mod declares #{declared_name}")
+        return false
+      end
+
+      package = fetch_package_metadata_from_pkgsite(name)
+      package ||= { name: name, repository_url: UrlParser.try_all(name) }
+      package.merge(version: version)
+    end
+
+    def module_path_from_go_mod(contents)
+      contents.each_line do |line|
+        match = line.match(/\A\s*module\s+(?:"([^"]+)"|`([^`]+)`|(\S+))/)
+        return match.captures.compact.first if match
+      end
+      nil
     end
 
     def fetch_synopsis(name)
@@ -104,7 +237,7 @@ module Ecosystem
         url = mod['repoUrl']
         licenses = Array(mod['licenses']).flat_map { |l| l['types'] }.compact.uniq.join(',')
 
-        {
+        metadata = {
           name: package[:name],
           description: package[:synopsis],
           licenses: licenses,
@@ -112,27 +245,45 @@ module Ecosystem
           homepage: url,
           namespace: package[:name].split('/')[0..-2].join('/')
         }
+        metadata[:version] = package[:version] if package[:version].present?
+        metadata
       else
-        { name: package[:name], repository_url: UrlParser.try_all(package[:name]) }
+        metadata = { name: package[:name], repository_url: UrlParser.try_all(package[:name]) }
+        metadata[:version] = package[:version] if package[:version].present?
+        metadata
       end
     end
 
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       name = pkg_metadata[:name]
       items = fetch_all_versions(name)
-      return versions_from_proxy(name, existing_version_numbers) if items.empty?
+      versions = if items.empty?
+                   versions_from_proxy(name, existing_version_numbers)
+                 else
+                   items.filter_map do |item|
+                     next unless item['modulePath'] == name
+                     status = version_status(item)
+                     next if existing_version_numbers.include?(item['version']) && status.nil?
 
-      items.filter_map do |item|
-        next unless item['modulePath'] == name
-        status = version_status(item)
-        next if existing_version_numbers.include?(item['version']) && status.nil?
+                     {
+                       number: item['version'],
+                       published_at: item['commitTime'],
+                       status: status
+                     }
+                   end
+                 end
 
-        {
-          number: item['version'],
-          published_at: item['commitTime'],
-          status: status
+      discovered_version = pkg_metadata[:version]
+      if discovered_version.present? &&
+          !existing_version_numbers.include?(discovered_version) &&
+          versions.none? { |item| item[:number] == discovered_version }
+        versions << {
+          number: discovered_version,
+          published_at: get_version(name, discovered_version).fetch('Time', nil),
+          status: nil
         }
       end
+      versions
     rescue StandardError
       []
     end
@@ -178,7 +329,7 @@ module Ecosystem
       # Go proxy spec: https://golang.org/cmd/go/#hdr-Module_proxy_protocol
       # TODO: this can take up to 2sec if it's a cache miss on the proxy. Might be able
       # to scrape the webpage or wait for an API for a faster fetch here.
-      resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/#{version}.mod")
+      resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/#{encode_for_proxy(version)}.mod")
       if resp.status == 200
         go_mod_file = resp.body
         result = Bibliothecary::Parsers::Go.parse_go_mod(go_mod_file)
@@ -198,7 +349,7 @@ module Ecosystem
     end
 
     def get_version(package_name, version)
-      get_json("#{@registry_url}/#{encode_for_proxy(package_name)}/@v/#{version}.info") rescue {}
+      get_json("#{@registry_url}/#{encode_for_proxy(package_name)}/@v/#{encode_for_proxy(version)}.info") rescue {}
     end
 
     # will convert a string with capital letters and replace with a "!" prepended to the lowercase letter

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -125,6 +125,10 @@ class Registry < ApplicationRecord
   end
 
   def sync_missing_packages_async
+    if ecosystem_instance.sync_missing_packages_incrementally?
+      return ecosystem_instance.sync_missing_packages_async
+    end
+
     sync_in_batches? ? sync_missing_packages : sync_packages_async(missing_package_names)
   end
 
@@ -156,9 +160,13 @@ class Registry < ApplicationRecord
     end
   end
 
-  def sync_package(name, force: false)
+  def sync_package(name, force: false, version: nil)
     logger.info "Syncing #{name}"
-    package_metadata = ecosystem_instance.package_metadata(name)
+    package_metadata = if version
+                         ecosystem_instance.package_metadata(name, version: version)
+                       else
+                         ecosystem_instance.package_metadata(name)
+                       end
     unless package_metadata
       logger.error "Failed to sync #{name}: package_metadata returned nil or false"
       return false

--- a/app/sidekiq/sync_package_version_worker.rb
+++ b/app/sidekiq/sync_package_version_worker.rb
@@ -2,12 +2,7 @@ class SyncPackageVersionWorker
   include Sidekiq::Worker
   sidekiq_options queue: :low,
                   lock: :until_executed,
-                  lock_expiration: 1.hour.to_i,
-                  lock_args_method: :lock_args
-
-  def self.lock_args(args)
-    args.first(3)
-  end
+                  lock_expiration: 1.hour.to_i
 
   def perform(registry_id, name, version)
     registry = Registry.find_by_id(registry_id)

--- a/app/sidekiq/sync_package_version_worker.rb
+++ b/app/sidekiq/sync_package_version_worker.rb
@@ -1,0 +1,18 @@
+class SyncPackageVersionWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :low,
+                  lock: :until_executed,
+                  lock_expiration: 1.hour.to_i,
+                  lock_args_method: :lock_args
+
+  def self.lock_args(args)
+    args.first(2)
+  end
+
+  def perform(registry_id, name, version)
+    registry = Registry.find_by_id(registry_id)
+    return if registry.nil? || registry.packages.exists?(name: name)
+
+    registry.sync_package(name, version: version)
+  end
+end

--- a/app/sidekiq/sync_package_version_worker.rb
+++ b/app/sidekiq/sync_package_version_worker.rb
@@ -6,13 +6,16 @@ class SyncPackageVersionWorker
                   lock_args_method: :lock_args
 
   def self.lock_args(args)
-    args.first(2)
+    args.first(3)
   end
 
   def perform(registry_id, name, version)
     registry = Registry.find_by_id(registry_id)
-    return if registry.nil? || registry.packages.exists?(name: name)
+    return if registry.nil?
 
-    registry.sync_package(name, version: version)
+    package = registry.packages.find_by(name: name)
+    return if package&.versions&.exists?(number: version)
+
+    registry.sync_package(name, force: package.present?, version: version)
   end
 end

--- a/test/models/ecosystem/go_test.rb
+++ b/test/models/ecosystem/go_test.rb
@@ -23,6 +23,13 @@ class GoTest < ActiveSupport::TestCase
     assert_equal download_url, 'https://proxy.golang.org/github.com/aws/smithy-go/@v/v1.11.1.zip'
   end
 
+  test 'download_url escapes uppercase version characters for the proxy' do
+    version = @package.versions.build(number: 'v1.0.0-RC1')
+
+    assert_equal 'https://proxy.golang.org/github.com/aws/smithy-go/@v/v1.0.0-!r!c1.zip',
+      @ecosystem.download_url(@package, version)
+  end
+
   test 'documentation_url' do
     documentation_url = @ecosystem.documentation_url(@package)
     assert_equal documentation_url, "https://pkg.go.dev/github.com/aws/smithy-go#section-documentation"
@@ -41,6 +48,19 @@ class GoTest < ActiveSupport::TestCase
   test 'install_command with version' do
     install_command = @ecosystem.install_command(@package, @version.number)
     assert_equal install_command, 'go get github.com/aws/smithy-go@v1.11.1'
+  end
+
+  test 'check_status accepts a pseudo-version when the version list is empty' do
+    registry = Registry.create!(name: 'Go status', url: 'https://go-status.example', ecosystem: 'Go')
+    package = registry.packages.create!(name: 'example.com/pseudo-only', ecosystem: 'go')
+    package.versions.create!(number: 'v0.0.0-20260810161643-097856497a66', registry: registry)
+    ecosystem = Ecosystem::Go.new(registry)
+    stub_request(:head, 'https://pkg.go.dev/example.com/pseudo-only').to_return(status: 404)
+    stub_request(:get, 'https://go-status.example/example.com/pseudo-only/@v/list').to_return(status: 200, body: '')
+    stub_request(:get, 'https://go-status.example/example.com/pseudo-only/@v/v0.0.0-20260810161643-097856497a66.info')
+      .to_return(status: 200, body: '{}')
+
+    assert_nil ecosystem.check_status(package)
   end
 
   test 'purl' do
@@ -73,6 +93,75 @@ class GoTest < ActiveSupport::TestCase
   
     assert_equal all_package_names.length, 864
     assert_equal all_package_names.last, 'github.com/xenolf/lego'
+  end
+
+  test 'sync_missing_packages_async enqueues the latest indexed version for missing paths' do
+    registry = Registry.create!(default: true, name: 'Go discovery', url: 'https://go-discovery.example', ecosystem: 'Go')
+    registry.packages.create!(name: 'example.com/existing', ecosystem: 'go')
+    cursor = {
+      'timestamp' => '2026-08-09T00:00:00Z',
+      'path' => 'example.com/cursor',
+      'version' => 'v1.0.0'
+    }
+    registry.update!(metadata: { Ecosystem::Go::SYNC_MISSING_CURSOR_KEY => cursor })
+    ecosystem = Ecosystem::Go.new(registry)
+    body = [
+      { 'Path' => 'example.com/cursor', 'Version' => 'v1.0.0', 'Timestamp' => '2026-08-09T00:00:00Z' },
+      { 'Path' => 'example.com/existing', 'Version' => 'v1.1.0', 'Timestamp' => '2026-08-09T00:01:00Z' },
+      { 'Path' => 'example.com/missing', 'Version' => 'v1.0.0', 'Timestamp' => '2026-08-09T00:02:00Z' },
+      { 'Path' => 'example.com/missing', 'Version' => 'v1.1.0', 'Timestamp' => '2026-08-09T00:03:00Z' }
+    ].map { |row| Oj.dump(row) }.join("\n")
+    stub_request(:get, "https://index.golang.org/index?since=2026-08-09T00:00:00Z&limit=2000")
+      .to_return(status: 200, body: body)
+    SyncPackageVersionWorker.expects(:perform_bulk).with([
+      [registry.id, 'example.com/missing', 'v1.1.0']
+    ])
+
+    assert_equal 1, ecosystem.sync_missing_packages_async
+    assert_equal({
+      'timestamp' => '2026-08-09T00:03:00Z',
+      'path' => 'example.com/missing',
+      'version' => 'v1.1.0'
+    }, registry.reload.metadata[Ecosystem::Go::SYNC_MISSING_CURSOR_KEY])
+  end
+
+  test 'sync_missing_packages_async keeps the latest version across index pages' do
+    registry = Registry.create!(default: true, name: 'Go paged discovery', url: 'https://go-paged-discovery.example', ecosystem: 'Go')
+    ecosystem = Ecosystem::Go.new(registry)
+    first_page = Ecosystem::Go::INDEX_PAGE_SIZE.times.map do |index|
+      {
+        'Path' => 'example.com/missing',
+        'Version' => "v1.0.#{index}",
+        'Timestamp' => (Time.utc(2026, 8, 9) + index.seconds).iso8601(9)
+      }
+    end
+    last_row = {
+      'Path' => 'example.com/missing',
+      'Version' => 'v2.0.0',
+      'Timestamp' => '2026-08-10T00:00:00Z'
+    }
+    ecosystem.stubs(:index_versions).returns(first_page, [last_row])
+    SyncPackageVersionWorker.expects(:perform_bulk).with([
+      [registry.id, 'example.com/missing', 'v2.0.0']
+    ])
+
+    assert_equal 1, ecosystem.sync_missing_packages_async
+  end
+
+  test 'sync_missing_packages_cursor starts one day ago' do
+    travel_to Time.utc(2026, 8, 10, 12) do
+      assert_equal({ 'timestamp' => '2026-08-09T12:00:00.000000000Z' }, @ecosystem.sync_missing_packages_cursor)
+    end
+  end
+
+  test 'sync_missing_packages_async does not save its cursor when the index fails' do
+    registry = Registry.create!(default: true, name: 'Go failed discovery', url: 'https://go-failed-discovery.example', ecosystem: 'Go')
+    ecosystem = Ecosystem::Go.new(registry)
+    stub_request(:get, %r{\Ahttps://index\.golang\.org/index\?.*\z})
+      .to_return(status: 503, body: '')
+
+    assert_equal 0, ecosystem.sync_missing_packages_async
+    assert_nil registry.reload.metadata[Ecosystem::Go::SYNC_MISSING_CURSOR_KEY]
   end
 
   test 'recently_updated_package_names' do
@@ -110,6 +199,30 @@ class GoTest < ActiveSupport::TestCase
     assert_equal package_metadata[:repository_url], "https://github.com/aws/smithy-go"
   end
 
+  test 'package_metadata rejects an indexed version with an alternative module path' do
+    name = 'github.com/googlecloudplatform/professional-services/tools/lambda-compat'
+    version = 'v0.0.0-20260810161643-097856497a66'
+    stub_request(:get, "https://proxy.golang.org/#{name}/@v/#{version}.mod")
+      .to_return(status: 200, body: "module github.com/GoogleCloudPlatform/professional-services/tools/lambda-compat\n")
+
+    assert_equal false, @ecosystem.package_metadata(name, version: version)
+  end
+
+  test 'package_metadata accepts an exact indexed version when the version list is empty' do
+    name = 'github.com/example/pseudo-only'
+    version = 'v0.0.0-20260810161643-097856497a66'
+    stub_request(:get, "https://proxy.golang.org/#{name}/@v/#{version}.mod")
+      .to_return(status: 200, body: "module #{name}\n")
+    stub_request(:get, "https://pkg.go.dev/v1beta/module/#{name}?licenses=true")
+      .to_return(status: 404, body: '{"code":404,"message":"not found"}')
+
+    package_metadata = @ecosystem.package_metadata(name, version: version)
+
+    assert_equal name, package_metadata[:name]
+    assert_equal version, package_metadata[:version]
+    assert_equal "https://#{name}", package_metadata[:repository_url]
+  end
+
   test 'versions_metadata' do
     stub_request(:get, "https://pkg.go.dev/v1beta/versions/github.com/aws/smithy-go?limit=1000")
       .to_return({ status: 200, body: file_fixture('go/api_versions_smithy-go.json') })
@@ -144,6 +257,16 @@ class GoTest < ActiveSupport::TestCase
     assert_equal dependencies_metadata, [{:package_name=>"github.com/google/go-cmp", :requirements=>"v0.5.4", :kind=>"runtime", :ecosystem=>"go"}]
   end
 
+  test 'dependencies_metadata escapes uppercase version characters for the proxy' do
+    version = 'v1.0.0-RC1'
+    stub_request(:get, 'https://proxy.golang.org/github.com/aws/smithy-go/@v/v1.0.0-!r!c1.mod')
+      .to_return(status: 200, body: file_fixture('go/v1.9.0.mod'))
+
+    dependencies = @ecosystem.dependencies_metadata('github.com/aws/smithy-go', version, nil)
+
+    assert_equal 'github.com/google/go-cmp', dependencies.first[:package_name]
+  end
+
   test 'versions_metadata falls back to proxy when API misses' do
     stub_request(:get, "https://pkg.go.dev/v1beta/versions/github.com/aws/smithy-go?limit=1000")
       .to_return({ status: 404, body: '{"code":404,"message":"not found"}' })
@@ -155,5 +278,20 @@ class GoTest < ActiveSupport::TestCase
     versions_metadata = @ecosystem.versions_metadata({ name: 'github.com/aws/smithy-go' })
 
     assert_equal versions_metadata, [{ number: "v1.9.0", published_at: "2021-11-05T22:57:36Z", status: nil }]
+  end
+
+  test 'versions_metadata includes an indexed pseudo-version omitted from the version list' do
+    name = 'example.com/pseudo-only'
+    version = 'v0.0.0-20260810161643-097856497a66'
+    stub_request(:get, "https://pkg.go.dev/v1beta/versions/#{name}?limit=1000")
+      .to_return(status: 404, body: '{"code":404,"message":"not found"}')
+    stub_request(:get, "https://proxy.golang.org/#{name}/@v/list")
+      .to_return(status: 200, body: '')
+    stub_request(:get, "https://proxy.golang.org/#{name}/@v/#{version}.info")
+      .to_return(status: 200, body: Oj.dump('Version' => version, 'Time' => '2026-08-10T16:16:43Z'))
+
+    versions_metadata = @ecosystem.versions_metadata({ name: name, version: version })
+
+    assert_equal [{ number: version, published_at: '2026-08-10T16:16:43Z', status: nil }], versions_metadata
   end
 end

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -85,6 +85,14 @@ class RegistryTest < ActiveSupport::TestCase
     @registry.expects(:sync_packages_async).with(['foo', 'bar', 'baz'])
     @registry.sync_missing_packages_async
   end
+
+  test 'sync_missing_packages_async delegates incremental discovery to the ecosystem' do
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.expects(:sync_missing_packages_incrementally?).returns(true)
+    ecosystem.expects(:sync_missing_packages_async).returns(2)
+    @registry.expects(:missing_package_names).never
+    assert_equal 2, @registry.sync_missing_packages_async
+  end
   
   test 'sync_recently_updated_packages_async' do
     @registry.expects(:recently_updated_package_names_excluding_recently_synced).returns(['foo', 'bar', 'baz'])
@@ -147,6 +155,19 @@ class RegistryTest < ActiveSupport::TestCase
 
     result = @registry.sync_package('some-package')
     assert_equal false, result
+  end
+
+  test 'sync_package forwards an indexed version and updates last_synced_at' do
+    ecosystem = @registry.ecosystem_instance
+    ecosystem.expects(:package_metadata).with('newpkg', version: '1.2.3').returns({ name: 'newpkg' })
+    ecosystem.stubs(:versions_metadata).returns([])
+    Package.any_instance.stubs(:check_status)
+    Package.any_instance.stubs(:update_repo_metadata_async)
+
+    package = @registry.sync_package('newpkg', version: '1.2.3')
+
+    assert package.persisted?
+    assert package.last_synced_at
   end
 
   test 'sync_package_async' do

--- a/test/sidekiq/sync_package_version_worker_test.rb
+++ b/test/sidekiq/sync_package_version_worker_test.rb
@@ -1,21 +1,31 @@
 require "test_helper"
 
 class SyncPackageVersionWorkerTest < ActiveSupport::TestCase
-  test 'lock_args ignores the indexed version' do
-    assert_equal [5, 'example.com/module'], SyncPackageVersionWorker.lock_args([5, 'example.com/module', 'v1.2.3'])
+  test 'lock_args includes the indexed version' do
+    assert_equal [5, 'example.com/module', 'v1.2.3'], SyncPackageVersionWorker.lock_args([5, 'example.com/module', 'v1.2.3'])
   end
 
   test 'perform syncs a missing package with its indexed version' do
     registry = Registry.create!(name: 'Go modules', url: 'https://go.example', ecosystem: 'Go')
-    registry.expects(:sync_package).with('example.com/module', version: 'v1.2.3')
+    registry.expects(:sync_package).with('example.com/module', force: false, version: 'v1.2.3')
     Registry.expects(:find_by_id).with(registry.id).returns(registry)
 
     SyncPackageVersionWorker.new.perform(registry.id, 'example.com/module', 'v1.2.3')
   end
 
-  test 'perform skips a package created after discovery' do
+  test 'perform syncs a missing version when the package was created after discovery' do
     registry = Registry.create!(name: 'Go modules', url: 'https://go.example', ecosystem: 'Go')
     registry.packages.create!(name: 'example.com/module', ecosystem: 'go')
+    registry.expects(:sync_package).with('example.com/module', force: true, version: 'v1.2.3')
+    Registry.expects(:find_by_id).with(registry.id).returns(registry)
+
+    SyncPackageVersionWorker.new.perform(registry.id, 'example.com/module', 'v1.2.3')
+  end
+
+  test 'perform skips an indexed version that already exists' do
+    registry = Registry.create!(name: 'Go modules', url: 'https://go.example', ecosystem: 'Go')
+    package = registry.packages.create!(name: 'example.com/module', ecosystem: 'go')
+    package.versions.create!(number: 'v1.2.3', registry: registry)
     registry.expects(:sync_package).never
 
     SyncPackageVersionWorker.new.perform(registry.id, 'example.com/module', 'v1.2.3')

--- a/test/sidekiq/sync_package_version_worker_test.rb
+++ b/test/sidekiq/sync_package_version_worker_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
 class SyncPackageVersionWorkerTest < ActiveSupport::TestCase
-  test 'lock_args includes the indexed version' do
-    assert_equal [5, 'example.com/module', 'v1.2.3'], SyncPackageVersionWorker.lock_args([5, 'example.com/module', 'v1.2.3'])
-  end
-
   test 'perform syncs a missing package with its indexed version' do
     registry = Registry.create!(name: 'Go modules', url: 'https://go.example', ecosystem: 'Go')
     registry.expects(:sync_package).with('example.com/module', force: false, version: 'v1.2.3')

--- a/test/sidekiq/sync_package_version_worker_test.rb
+++ b/test/sidekiq/sync_package_version_worker_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class SyncPackageVersionWorkerTest < ActiveSupport::TestCase
+  test 'lock_args ignores the indexed version' do
+    assert_equal [5, 'example.com/module'], SyncPackageVersionWorker.lock_args([5, 'example.com/module', 'v1.2.3'])
+  end
+
+  test 'perform syncs a missing package with its indexed version' do
+    registry = Registry.create!(name: 'Go modules', url: 'https://go.example', ecosystem: 'Go')
+    registry.expects(:sync_package).with('example.com/module', version: 'v1.2.3')
+    Registry.expects(:find_by_id).with(registry.id).returns(registry)
+
+    SyncPackageVersionWorker.new.perform(registry.id, 'example.com/module', 'v1.2.3')
+  end
+
+  test 'perform skips a package created after discovery' do
+    registry = Registry.create!(name: 'Go modules', url: 'https://go.example', ecosystem: 'Go')
+    registry.packages.create!(name: 'example.com/module', ecosystem: 'go')
+    registry.expects(:sync_package).never
+
+    SyncPackageVersionWorker.new.perform(registry.id, 'example.com/module', 'v1.2.3')
+  end
+end


### PR DESCRIPTION
Consume `index.golang.org` incrementally for Go missing-package discovery instead of diffing its full case-sensitive history each night. Store the cursor in registry metadata and enqueue version-aware jobs on the low queue.

Validate each candidate against the module directive from the indexed version’s `.mod` file, so user-typed case variants are consumed without creating package records. Preserve indexed pseudo-versions that are absent from `/@v/list`, and check their exact `.info` response before marking a package removed.

This requires no schema changes.