### PR TITLE
Use cached-only Go proxy endpoint

### DIFF
--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -180,8 +180,6 @@ module Ecosystem
 
     def dependencies_metadata(name, version, _package)
       # Go proxy spec: https://golang.org/cmd/go/#hdr-Module_proxy_protocol
-      # TODO: this can take up to 2sec if it's a cache miss on the proxy. Might be able
-      # to scrape the webpage or wait for an API for a faster fetch here.
       resp = request("#{proxy_url}/#{encode_for_proxy(name)}/@v/#{version}.mod")
       if resp.status == 200
         go_mod_file = resp.body

--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -1,6 +1,11 @@
 module Ecosystem
   class Go < Base
     PKGSITE_API = "https://pkg.go.dev/v1beta"
+    DEFAULT_PROXY_URL = "https://proxy.golang.org/cached-only"
+
+    def proxy_url
+      ENV.fetch('GO_PROXY_URL', DEFAULT_PROXY_URL).delete_suffix('/')
+    end
 
     def self.purl_type
       'golang'
@@ -30,8 +35,7 @@ module Ecosystem
       url = "https://pkg.go.dev/#{package.name}"
       response = Faraday.head(url)
       if [400, 404, 410, 302, 301].include?(response.status)
-        proxy_url = "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/list"
-        response = Faraday.get(proxy_url)
+        response = Faraday.get("#{proxy_url}/#{encode_for_proxy(package.name)}/@v/list")
         if [400, 404, 410].include?(response.status) || response.body.length.zero?
           "removed"
         end
@@ -44,7 +48,7 @@ module Ecosystem
 
     def download_url(package, version)
       return nil unless version.present?
-      "#{@registry_url}/#{encode_for_proxy(package.name)}/@v/#{version}.zip"
+      "#{proxy_url}/#{encode_for_proxy(package.name)}/@v/#{version}.zip"
     end
 
     def all_package_names
@@ -78,7 +82,7 @@ module Ecosystem
         mod = Oj.load(resp.body)
         { name: name, module: mod, synopsis: fetch_synopsis(name) }
       else
-        resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/list")
+        resp = request("#{proxy_url}/#{encode_for_proxy(name)}/@v/list")
         if resp.success? && resp.body.length > 0
           { name: name, repository_url: UrlParser.try_all(name) }
         else
@@ -160,7 +164,7 @@ module Ecosystem
     end
 
     def versions_from_proxy(name, existing_version_numbers)
-      resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/list")
+      resp = request("#{proxy_url}/#{encode_for_proxy(name)}/@v/list")
       return [] unless resp.success?
 
       resp.body.split("\n").map(&:strip).reject(&:empty?)
@@ -178,7 +182,7 @@ module Ecosystem
       # Go proxy spec: https://golang.org/cmd/go/#hdr-Module_proxy_protocol
       # TODO: this can take up to 2sec if it's a cache miss on the proxy. Might be able
       # to scrape the webpage or wait for an API for a faster fetch here.
-      resp = request("#{@registry_url}/#{encode_for_proxy(name)}/@v/#{version}.mod")
+      resp = request("#{proxy_url}/#{encode_for_proxy(name)}/@v/#{version}.mod")
       if resp.status == 200
         go_mod_file = resp.body
         result = Bibliothecary::Parsers::Go.parse_go_mod(go_mod_file)
@@ -198,7 +202,7 @@ module Ecosystem
     end
 
     def get_version(package_name, version)
-      get_json("#{@registry_url}/#{encode_for_proxy(package_name)}/@v/#{version}.info") rescue {}
+      get_json("#{proxy_url}/#{encode_for_proxy(package_name)}/@v/#{version}.info") rescue {}
     end
 
     # will convert a string with capital letters and replace with a "!" prepended to the lowercase letter

--- a/env.example
+++ b/env.example
@@ -6,3 +6,4 @@ POSTGRES_PORT=5432
 # Entries may include a path prefix, for example: https://forgejo.example.com/forgejo
 # SSH clone URLs must include the configured path prefix.
 FORGE_HOSTS=
+GO_PROXY_URL=https://proxy.golang.org/cached-only

--- a/test/models/ecosystem/go_test.rb
+++ b/test/models/ecosystem/go_test.rb
@@ -2,10 +2,15 @@ require "test_helper"
 
 class GoTest < ActiveSupport::TestCase
   setup do
+    @original_go_proxy_url = ENV.delete('GO_PROXY_URL')
     @registry = Registry.new(default: true, name: 'proxy.golang.org', url: 'https://proxy.golang.org', ecosystem: 'Go')
     @ecosystem = Ecosystem::Go.new(@registry)
     @package = Package.new(ecosystem: 'Go', name: 'github.com/aws/smithy-go')
     @version = @package.versions.build(number: 'v1.11.1')
+  end
+
+  teardown do
+    @original_go_proxy_url.nil? ? ENV.delete('GO_PROXY_URL') : ENV['GO_PROXY_URL'] = @original_go_proxy_url
   end
 
   test 'registry_url' do
@@ -20,7 +25,15 @@ class GoTest < ActiveSupport::TestCase
 
   test 'download_url' do
     download_url = @ecosystem.download_url(@package, @version)
-    assert_equal download_url, 'https://proxy.golang.org/github.com/aws/smithy-go/@v/v1.11.1.zip'
+    assert_equal download_url, 'https://proxy.golang.org/cached-only/github.com/aws/smithy-go/@v/v1.11.1.zip'
+  end
+
+  test 'download_url uses configured proxy' do
+    ENV['GO_PROXY_URL'] = 'https://go-proxy.example.com/'
+
+    download_url = @ecosystem.download_url(@package, @version)
+
+    assert_equal download_url, 'https://go-proxy.example.com/github.com/aws/smithy-go/@v/v1.11.1.zip'
   end
 
   test 'documentation_url' do
@@ -102,7 +115,7 @@ class GoTest < ActiveSupport::TestCase
   test 'package_metadata falls back to proxy when API misses' do
     stub_request(:get, "https://pkg.go.dev/v1beta/module/github.com/aws/smithy-go?licenses=true")
       .to_return({ status: 404, body: '{"code":404,"message":"not found"}' })
-    stub_request(:get, "https://proxy.golang.org/github.com/aws/smithy-go/@v/list")
+    stub_request(:get, "https://proxy.golang.org/cached-only/github.com/aws/smithy-go/@v/list")
       .to_return({ status: 200, body: file_fixture('go/list') })
     package_metadata = @ecosystem.package_metadata('github.com/aws/smithy-go')
 
@@ -137,7 +150,7 @@ class GoTest < ActiveSupport::TestCase
   end
 
   test 'dependencies_metadata' do
-    stub_request(:get, "https://proxy.golang.org/github.com/aws/smithy-go/@v/v1.9.0.mod")
+    stub_request(:get, "https://proxy.golang.org/cached-only/github.com/aws/smithy-go/@v/v1.9.0.mod")
       .to_return({ status: 200, body: file_fixture('go/v1.9.0.mod') })
     dependencies_metadata = @ecosystem.dependencies_metadata('github.com/aws/smithy-go', 'v1.9.0', nil)
 
@@ -147,9 +160,9 @@ class GoTest < ActiveSupport::TestCase
   test 'versions_metadata falls back to proxy when API misses' do
     stub_request(:get, "https://pkg.go.dev/v1beta/versions/github.com/aws/smithy-go?limit=1000")
       .to_return({ status: 404, body: '{"code":404,"message":"not found"}' })
-    stub_request(:get, "https://proxy.golang.org/github.com/aws/smithy-go/@v/list")
+    stub_request(:get, "https://proxy.golang.org/cached-only/github.com/aws/smithy-go/@v/list")
       .to_return({ status: 200, body: file_fixture('go/list') })
-    stub_request(:get, "https://proxy.golang.org/github.com/aws/smithy-go/@v/v1.9.0.info")
+    stub_request(:get, "https://proxy.golang.org/cached-only/github.com/aws/smithy-go/@v/v1.9.0.info")
       .to_return({ status: 200, body: file_fixture('go/v1.9.0.info') })
 
     versions_metadata = @ecosystem.versions_metadata({ name: 'github.com/aws/smithy-go' })

--- a/test/models/ecosystem/go_test.rb
+++ b/test/models/ecosystem/go_test.rb
@@ -10,7 +10,7 @@ class GoTest < ActiveSupport::TestCase
   end
 
   teardown do
-    @original_go_proxy_url.nil? ? ENV.delete('GO_PROXY_URL') : ENV['GO_PROXY_URL'] = @original_go_proxy_url
+    ENV['GO_PROXY_URL'] = @original_go_proxy_url
   end
 
   test 'registry_url' do


### PR DESCRIPTION
Use `https://proxy.golang.org/cached-only` as the default endpoint for Go module proxy requests.

Allow deployments to override it through `GO_PROXY_URL` while keeping the existing registry identity unchanged.