### PR TITLE
Instrument outbound registry HTTP requests

### DIFF
--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -37,6 +37,7 @@ module Ecosystem
 
       connection = Faraday.new(url) do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :instrumentation
         faraday.adapter Faraday.default_adapter
       end
 

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -97,6 +97,7 @@ module Ecosystem
 
       connection = Faraday.new(url) do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :instrumentation
         faraday.adapter Faraday.default_adapter
         faraday.options.timeout = 10
         faraday.options.open_timeout = 5

--- a/app/models/ecosystem/bioconductor.rb
+++ b/app/models/ecosystem/bioconductor.rb
@@ -105,7 +105,10 @@ module Ecosystem
       tarball_name = "#{folder_name}.tar.gz"
       downloaded_file = File.open "/tmp/#{tarball_name}", "wb"
 
-      connection = Faraday.new
+      connection = Faraday.new do |builder|
+        builder.request :instrumentation
+        builder.adapter Faraday.default_adapter
+      end
       response = connection.get(url)
 
       File.open(downloaded_file, 'wb') do |file|

--- a/app/models/ecosystem/bower.rb
+++ b/app/models/ecosystem/bower.rb
@@ -57,6 +57,7 @@ module Ecosystem
       return "removed" if pkg.nil?
       connection = Faraday.new do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :instrumentation
         faraday.adapter Faraday.default_adapter
       end
 

--- a/app/models/ecosystem/cocoapods.rb
+++ b/app/models/ecosystem/cocoapods.rb
@@ -44,6 +44,7 @@ module Ecosystem
 
         connection = Faraday.new do |faraday|
           faraday.use Faraday::FollowRedirects::Middleware
+          faraday.request :instrumentation
           faraday.adapter Faraday.default_adapter
         end
 

--- a/app/models/ecosystem/cran.rb
+++ b/app/models/ecosystem/cran.rb
@@ -107,6 +107,7 @@ module Ecosystem
         url = "https://cran.rstudio.com/src/contrib/#{name}_#{version}.tar.gz"
         connection = Faraday.new do |builder|
           builder.use Faraday::FollowRedirects::Middleware
+          builder.request :instrumentation
           builder.adapter Faraday.default_adapter
         end
 
@@ -120,7 +121,10 @@ module Ecosystem
       tarball_name = "#{folder_name}.tar.gz"
       downloaded_file = File.open "/tmp/#{tarball_name}", "wb"
 
-      connection = Faraday.new
+      connection = Faraday.new do |builder|
+        builder.request :instrumentation
+        builder.adapter Faraday.default_adapter
+      end
       response = connection.get(url)
 
       File.open(downloaded_file, 'wb') do |file|

--- a/app/models/ecosystem/deno.rb
+++ b/app/models/ecosystem/deno.rb
@@ -30,6 +30,7 @@ module Ecosystem
       url = check_status_url(package)
       connection = Faraday.new do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :instrumentation
         faraday.adapter Faraday.default_adapter
       end
 

--- a/app/models/ecosystem/julia.rb
+++ b/app/models/ecosystem/julia.rb
@@ -19,6 +19,7 @@ module Ecosystem
       url = check_status_url(package)
       connection = Faraday.new do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :instrumentation
         faraday.adapter Faraday.default_adapter
       end
 

--- a/app/models/ecosystem/nixpkgs.rb
+++ b/app/models/ecosystem/nixpkgs.rb
@@ -122,6 +122,7 @@ module Ecosystem
       connection = Faraday.new(packages_url) do |builder|
         builder.use Faraday::FollowRedirects::Middleware
         builder.request :retry, { max: 3, interval: 0.5, backoff_factor: 2 }
+        builder.request :instrumentation
         builder.headers['Accept-Encoding'] = 'identity'
         builder.adapter :net_http
       end

--- a/app/models/ecosystem/racket.rb
+++ b/app/models/ecosystem/racket.rb
@@ -21,6 +21,7 @@ module Ecosystem
       url = check_status_url(package)
       connection = Faraday.new do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :instrumentation
         faraday.adapter Faraday.default_adapter
       end
 

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -10,8 +10,11 @@ Faraday.default_connection_options = {
 
 ActiveSupport::Notifications.subscribe("request.faraday") do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
-  host = event.payload[:url].host
-  status = event.payload.response&.status || 0
+  env = event.payload
+  host = env[:url].host
+  status = env[:status] || 0
   Appsignal.increment_counter("registry_http_requests", 1, host: host, status: status.to_s)
   Appsignal.add_distribution_value("registry_http_duration", event.duration, host: host)
+rescue => e
+  Rails.logger.warn("request.faraday subscriber error: #{e.class} #{e.message}")
 end

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -7,3 +7,11 @@ Faraday.default_connection_options = {
     'User-Agent' => 'packages.ecosyste.ms'
   }
 }
+
+ActiveSupport::Notifications.subscribe("request.faraday") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  host = event.payload[:url].host
+  status = event.payload.response&.status || 0
+  Appsignal.increment_counter("registry_http_requests", 1, host: host, status: status.to_s)
+  Appsignal.add_distribution_value("registry_http_duration", event.duration, host: host)
+end

--- a/test/models/ecosystem/base_test.rb
+++ b/test/models/ecosystem/base_test.rb
@@ -45,6 +45,27 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal 'removed', status
   end
 
+  test 'request emits registry_http_requests metric tagged by host and status' do
+    stub_request(:get, "https://registry.example.org/pkg.json")
+      .to_return(status: 200, body: '{}')
+
+    Appsignal.expects(:increment_counter).with("registry_http_requests", 1, host: "registry.example.org", status: "200")
+    Appsignal.expects(:add_distribution_value).with("registry_http_duration", anything, host: "registry.example.org")
+
+    @ecosystem.send(:get_raw, "https://registry.example.org/pkg.json")
+  end
+
+  test 'check_status emits registry_http_requests metric' do
+    stub_request(:head, "https://example.com/package")
+      .to_return(status: 404)
+
+    Appsignal.expects(:increment_counter).with("registry_http_requests", 1, host: "example.com", status: "404")
+    Appsignal.stubs(:add_distribution_value)
+
+    @ecosystem.stubs(:check_status_url).returns('https://example.com/package')
+    @ecosystem.check_status(@package)
+  end
+
   test 'check_status returns nil for 200 status' do
     stub_request(:head, "https://example.com/package")
       .to_return(status: 200)


### PR DESCRIPTION
Subscribe to `request.faraday` in `config/initializers/faraday.rb` and emit two AppSignal custom metrics for every outbound HTTP request:

- `registry_http_requests` counter, tagged `host` and `status`
- `registry_http_duration` distribution (ms), tagged `host`

`Ecosystem::Base#request` already had `builder.request :instrumentation`; this adds the same middleware to the remaining bespoke `Faraday.new` connections (`base#check_status` HEAD, actions, bioconductor, bower, cocoapods, cran, deno, julia, nixpkgs, racket) so every call is counted. There is no non-Faraday HTTP in `app/` or `lib/`.

This gives per-upstream-host request rates in AppSignal so we can see which registries we hit hardest before adding a shared rate limiter.