### PR TITLE
Per-host job throttling for registry sync workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "simple-rss"
 gem "redis"
 gem "sidekiq"
 gem 'sidekiq-unique-jobs'
+gem 'sidekiq-throttled'
 gem "ecosystems-bibliothecary", github: "ecosyste-ms/bibliothecary", branch: "main", require: "bibliothecary"
 gem "pagy", "~> 9.4.0"
 gem "pghero"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
       redis-client (= 0.30.1)
     redis-client (0.30.1)
       connection_pool
+    redis-prescription (2.6.0)
     reline (0.7.0)
       io-console (~> 0.5)
     request_store (1.7.0)
@@ -270,6 +271,10 @@ GEM
       logger (>= 1.7.0)
       rack (>= 3.2.0)
       redis-client (>= 0.29.0)
+    sidekiq-throttled (2.1.0)
+      concurrent-ruby (>= 1.2.0)
+      redis-prescription (~> 2.2)
+      sidekiq (>= 8.0)
     sidekiq-unique-jobs (8.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 9.0.0)
@@ -383,6 +388,7 @@ DEPENDENCIES
   shoulda-context (~> 3.0.0.rc1)
   shoulda-matchers
   sidekiq
+  sidekiq-throttled
   sidekiq-unique-jobs
   simple-rss
   sitemap_generator
@@ -497,6 +503,7 @@ CHECKSUMS
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   redis (6.0.0) sha256=de71c10edd106986b759ec7ecdd08b63b9c0ee7414a0d0c1da73d31ba2bccda6
   redis-client (0.30.1) sha256=5151bc5c7bbfe48623732cdae3b900d8a22dc691cc7cdfacfb351ac55116522d
+  redis-prescription (2.6.0) sha256=a5ad06f67e940a092aabd5f240f6a65e7b65da54bfed68b5ce487e883a04c163
   reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   request_store (1.7.0) sha256=e1b75d5346a315f452242a68c937ef8e48b215b9453a77a6c0acdca2934c88cb
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
@@ -513,6 +520,7 @@ CHECKSUMS
   shoulda-context (3.0.0.rc1) sha256=6e0d9d52ab798c13bc2b490c8537d4bf30cfd318a1ea839c39a66d1d293c6a1a
   shoulda-matchers (8.0.1) sha256=5dbb46e5765b9da225111b085e0819e8c8a121ff94bba430a153eb1ea2c60288
   sidekiq (8.1.6) sha256=be20cd051124b1a16cf97ea9157137abbd30a515c16a5ae9312d2eadd045e40f
+  sidekiq-throttled (2.1.0) sha256=430d4684b781b37f7f22b9b4a26dadf438b725718ecb821ae8bb8ea66f78fc4c
   sidekiq-unique-jobs (8.1.0) sha256=6a7eaa61ac408197a542350df905687b506acae2f485da03b11d28b1c367dc35
   simple-rss (2.2.0) sha256=77e09f7275cc27912dff58cbdfd6a56d87ab0dae30fad7d86f43cf834855c0c4
   sitemap_generator (7.1.1) sha256=ab2a133d512a7b33ed713a27a9977f61d8379c9943e3b79900243fc1c4f7f81d

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -3,6 +3,8 @@ class Registry < ApplicationRecord
 
   validates_uniqueness_of :name, :url
 
+  validate :rate_limit_must_be_positive
+
   has_many :packages
   has_many :versions
   has_many :maintainers
@@ -10,6 +12,51 @@ class Registry < ApplicationRecord
 
   scope :not_docker, -> { where.not(ecosystem: 'docker') }
   scope :frequently_synced, -> { where.not(ecosystem: ['docker', 'cocoapods', 'bower']) }
+
+  THROTTLE_CACHE_TTL = 60
+
+  def self.throttle_cache
+    if @throttle_cache.nil? || Process.clock_gettime(Process::CLOCK_MONOTONIC) > @throttle_cache_expires_at
+      @throttle_cache = pluck(:id, :url, :metadata).each_with_object({}) do |(id, url, meta), h|
+        limit = meta.is_a?(Hash) ? meta['rate_limit'] : nil
+        h[id] = { host: extract_host(url), rate_limit: (limit.to_i if limit) }
+      end
+      @throttle_cache_expires_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + THROTTLE_CACHE_TTL
+    end
+    @throttle_cache
+  end
+
+  def self.extract_host(url)
+    uri = Addressable::URI.heuristic_parse(url)
+    uri&.host.presence || url
+  rescue Addressable::URI::InvalidURIError
+    url
+  end
+
+  def self.reset_throttle_cache
+    @throttle_cache = nil
+  end
+
+  def self.host_for(id)
+    throttle_cache.dig(id, :host)
+  end
+
+  def self.rate_limit_for(id)
+    throttle_cache.dig(id, :rate_limit)
+  end
+
+  def rate_limit
+    metadata && metadata['rate_limit']
+  end
+
+  def rate_limit=(value)
+    self.metadata = (metadata || {}).merge('rate_limit' => value).compact
+  end
+
+  def rate_limit_must_be_positive
+    return if rate_limit.nil?
+    errors.add(:rate_limit, 'must be a positive integer') unless rate_limit.is_a?(Integer) && rate_limit > 0
+  end
 
   def self.find_by_name!(name)
     name = 'cocoapods.org' if name == 'cocoapod.org'

--- a/app/sidekiq/sync_package_version_worker.rb
+++ b/app/sidekiq/sync_package_version_worker.rb
@@ -1,8 +1,10 @@
 class SyncPackageVersionWorker
   include Sidekiq::Worker
+  include Sidekiq::Throttled::Job
   sidekiq_options queue: :low,
                   lock: :until_executed,
                   lock_expiration: 1.hour.to_i
+  sidekiq_throttle_as :registry_host
 
   def perform(registry_id, name, version)
     registry = Registry.find_by_id(registry_id)

--- a/app/sidekiq/sync_package_worker.rb
+++ b/app/sidekiq/sync_package_worker.rb
@@ -1,6 +1,8 @@
 class SyncPackageWorker
   include Sidekiq::Worker
+  include Sidekiq::Throttled::Job
   sidekiq_options queue: :critical, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_throttle_as :registry_host
 
   def perform(registry_id, name, force = false)
     registry = Registry.find_by_id(registry_id)

--- a/config/initializers/sidekiq_throttled.rb
+++ b/config/initializers/sidekiq_throttled.rb
@@ -1,0 +1,12 @@
+require "sidekiq/throttled"
+
+Rails.application.config.to_prepare do
+  Sidekiq::Throttled::Registry.add(
+    :registry_host,
+    threshold: {
+      limit: ->(registry_id, *) { Registry.rate_limit_for(registry_id) },
+      period: 1.second,
+      key_suffix: ->(registry_id, *) { (Registry.host_for(registry_id) || registry_id).to_s }
+    }
+  )
+end

--- a/test/initializers/sidekiq_throttled_test.rb
+++ b/test/initializers/sidekiq_throttled_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class SidekiqThrottledTest < ActiveSupport::TestCase
+  setup do
+    Registry.reset_throttle_cache
+    @npm = Registry.create!(name: 'npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm', rate_limit: 2)
+    @gems = Registry.create!(name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+    @strategy = Sidekiq::Throttled::Registry.get(:registry_host)
+    reset_buckets
+  end
+
+  teardown do
+    reset_buckets
+    Registry.reset_throttle_cache
+  end
+
+  def reset_buckets
+    Sidekiq.redis do |r|
+      keys = r.scan("MATCH", "throttled:*", "COUNT", 1000).to_a
+      r.call("DEL", *keys) if keys.any?
+    end
+  end
+
+  test "Registry.host_for and rate_limit_for read from cache" do
+    assert_equal 'registry.npmjs.org', Registry.host_for(@npm.id)
+    assert_equal 2, Registry.rate_limit_for(@npm.id)
+    assert_equal 'rubygems.org', Registry.host_for(@gems.id)
+    assert_nil Registry.rate_limit_for(@gems.id)
+  end
+
+  test "extract_host handles schemeless and invalid urls" do
+    assert_equal 'rubygems.org', Registry.extract_host('rubygems.org')
+    assert_equal 'rubygems.org', Registry.extract_host('https://rubygems.org/api')
+    assert_equal 'not a url', Registry.extract_host('not a url')
+  end
+
+  test "throttle cache expires after TTL" do
+    assert_equal 2, Registry.rate_limit_for(@npm.id)
+    @npm.update_column(:metadata, @npm.metadata.merge('rate_limit' => 5))
+    assert_equal 2, Registry.rate_limit_for(@npm.id)
+    Process.stubs(:clock_gettime).returns(Registry.instance_variable_get(:@throttle_cache_expires_at) + 1)
+    assert_equal 5, Registry.rate_limit_for(@npm.id)
+  end
+
+  test "rate_limit is stored in metadata and must be positive when set" do
+    refute @npm.update(rate_limit: 0)
+    refute @npm.update(rate_limit: -1)
+    refute @npm.update(rate_limit: '10')
+    assert @npm.update(rate_limit: 3)
+    assert_equal({ 'rate_limit' => 3 }, @npm.metadata)
+    assert @npm.update(rate_limit: nil)
+    assert_equal({}, @npm.metadata)
+  end
+
+  test "rate_limit writer preserves other metadata keys" do
+    @gems.update!(metadata: { 'api_url' => 'https://x' })
+    @gems.update!(rate_limit: 4)
+    assert_equal({ 'api_url' => 'https://x', 'rate_limit' => 4 }, @gems.metadata)
+  end
+
+  test "workers are aliased to the registry_host strategy" do
+    assert_same @strategy, Sidekiq::Throttled::Registry.get('SyncPackageWorker')
+    assert_same @strategy, Sidekiq::Throttled::Registry.get('SyncPackageVersionWorker')
+  end
+
+  test "nil rate_limit means never throttled" do
+    10.times do
+      refute @strategy.throttled?(SecureRandom.hex, @gems.id, 'pkg')
+    end
+  end
+
+  test "throttles after rate_limit jobs within the period" do
+    refute @strategy.throttled?(SecureRandom.hex, @npm.id, 'a')
+    refute @strategy.throttled?(SecureRandom.hex, @npm.id, 'b')
+    assert @strategy.throttled?(SecureRandom.hex, @npm.id, 'c')
+  end
+
+  test "registries with the same host share a bucket" do
+    npm2 = Registry.create!(name: 'npm-mirror', url: 'https://registry.npmjs.org/mirror', ecosystem: 'npm', rate_limit: 2)
+    assert_equal Registry.host_for(@npm.id), Registry.host_for(npm2.id)
+    refute @strategy.throttled?(SecureRandom.hex, @npm.id, 'a')
+    refute @strategy.throttled?(SecureRandom.hex, npm2.id, 'a')
+    assert @strategy.throttled?(SecureRandom.hex, @npm.id, 'b')
+  end
+
+  test "different hosts have independent buckets" do
+    other = Registry.create!(name: 'other', url: 'https://other.example.org', ecosystem: 'npm', rate_limit: 2)
+    refute @strategy.throttled?(SecureRandom.hex, @npm.id, 'a')
+    refute @strategy.throttled?(SecureRandom.hex, @npm.id, 'b')
+    refute @strategy.throttled?(SecureRandom.hex, other.id, 'a')
+    refute @strategy.throttled?(SecureRandom.hex, other.id, 'b')
+    assert @strategy.throttled?(SecureRandom.hex, @npm.id, 'c')
+    assert @strategy.throttled?(SecureRandom.hex, other.id, 'c')
+  end
+end

--- a/test/tasks/packages_rake_test.rb
+++ b/test/tasks/packages_rake_test.rb
@@ -42,7 +42,8 @@ class PackagesRakeTest < ActiveSupport::TestCase
     first_package = registry.packages.create!(name: 'actions/checkout', ecosystem: 'actions')
     second_package = registry.packages.create!(name: 'actions/cache', ecosystem: 'actions')
 
-    UpdateVersionsWorker.expects(:perform_bulk).with([[first_package.id], [second_package.id]])
+    expected = [[first_package.id], [second_package.id]]
+    UpdateVersionsWorker.expects(:perform_bulk).with { |arg| arg.sort == expected.sort }
 
     task = Rake::Task["packages:backfill_github_actions_immutability"]
     task.reenable


### PR DESCRIPTION
Adds a redis-backed per-host cap on how many sync jobs start per second, shared across all sidekiq processes.

`sidekiq-throttled` patches `Sidekiq::BasicFetch`: when a fetched job is over its threshold it is pushed back to the queue with `redis.lpush` and a different job is fetched instead. The push is raw redis, not `Sidekiq::Client`, so `sidekiq-unique-jobs` client middleware does not run and the existing `until_executed` lock stays intact rather than deduping the requeued job. The `:schedule` requeue mode would go through the client and lose the job, so this uses the default `:enqueue` mode.

A single shared `:registry_host` strategy is registered in `config/initializers/sidekiq_throttled.rb`:

- `key_suffix` is the registry URL host (parsed with `Addressable::URI.heuristic_parse` via `Registry.extract_host`, so schemeless URLs still resolve), so two registries on the same host share one bucket
- `limit` is `registry.metadata["rate_limit"]`; `nil` short-circuits `throttled?` before any redis call, so unthrottled registries have no overhead
- `SyncPackageWorker` and `SyncPackageVersionWorker` both `sidekiq_throttle_as :registry_host` and count against the same bucket

`Registry.host_for` / `.rate_limit_for` are backed by a class-memoized `pluck` with a 60s TTL, so the fetch-time lookup is a hash read and each sidekiq process re-reads the (small) registries table once a minute. A `rate_limit` change from a console reaches every worker within 60s without a restart. `rate_limit` is stored in the existing `metadata` json (no schema change), with reader/writer methods on `Registry` and a validation that rejects non-positive values since sidekiq-throttled treats `<= 0` as permanently throttled.

Because the limit is on job starts, every request a sync job makes scales with it. An npm sync calls both `registry.npmjs.org` (metadata) and `api.npmjs.org` (download counts) once each, so setting `rate_limit: 5` on the npm registry caps both hosts at ~5/s. Same for `pypi.org` / `pypistats.org`.

Not covered here:

- workers keyed on `package_id` (`CheckStatusWorker`, `SyncMaintainersWorker`, etc.) — need a `package_id -> registry_id` lookup at fetch time; add once the AppSignal host breakdown shows which of them matter
- rake-driven bulk syncs that loop inside one process

To set a limit:

```ruby
Registry.find_by_name!("npmjs.org").update!(rate_limit: 10)
```

Also makes the `backfill_github_actions_immutability` test assertion order-agnostic since `perform_bulk` argument ordering flapped in CI.