### PR TITLE
Instrument Faraday default-connection shortcuts

### DIFF
--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -8,10 +8,6 @@ Faraday.default_connection_options = {
   }
 }
 
-# Faraday.get / Faraday.head / Faraday.post use this connection. Building it
-# explicitly lets us include :instrumentation so those calls are counted by
-# the request.faraday subscriber below alongside calls that go through
-# Ecosystem::Base#request.
 Faraday.default_connection = Faraday.new do |builder|
   builder.request :instrumentation
   builder.adapter Faraday.default_adapter

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -8,6 +8,15 @@ Faraday.default_connection_options = {
   }
 }
 
+# Faraday.get / Faraday.head / Faraday.post use this connection. Building it
+# explicitly lets us include :instrumentation so those calls are counted by
+# the request.faraday subscriber below alongside calls that go through
+# Ecosystem::Base#request.
+Faraday.default_connection = Faraday.new do |builder|
+  builder.request :instrumentation
+  builder.adapter Faraday.default_adapter
+end
+
 ActiveSupport::Notifications.subscribe("request.faraday") do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
   env = event.payload

--- a/test/initializers/faraday_test.rb
+++ b/test/initializers/faraday_test.rb
@@ -32,6 +32,20 @@ class FaradayInitializerTest < ActiveSupport::TestCase
       headers: { 'User-Agent' => 'packages.ecosyste.ms' }
   end
 
+  test "Faraday.get emits registry_http_requests metric" do
+    stub_request(:get, "https://direct.example.org/x").to_return(status: 200)
+    Appsignal.expects(:increment_counter).with("registry_http_requests", 1, host: "direct.example.org", status: "200")
+    Appsignal.stubs(:add_distribution_value)
+    Faraday.get("https://direct.example.org/x")
+  end
+
+  test "Faraday.head emits registry_http_requests metric" do
+    stub_request(:head, "https://direct.example.org/x").to_return(status: 404)
+    Appsignal.expects(:increment_counter).with("registry_http_requests", 1, host: "direct.example.org", status: "404")
+    Appsignal.stubs(:add_distribution_value)
+    Faraday.head("https://direct.example.org/x")
+  end
+
   test "default User-Agent is applied to direct Faraday.post calls" do
     # Stub the request to check headers
     stub_request(:post, "https://example.com/test")


### PR DESCRIPTION
37 call sites across the ecosystem classes use `Faraday.get` / `Faraday.head` / `Faraday.post` directly rather than building a connection with `Faraday.new`. Those shortcuts route through `Faraday.default_connection`, which had no `:instrumentation` middleware, so none of them were emitting `request.faraday` events and the `registry_http_requests` metric from #1766 was undercounting.

Build `Faraday.default_connection` explicitly in the initializer with `:instrumentation` so every shortcut call is counted, without touching any of the 37 call sites. `Faraday.default_connection_options` (the `User-Agent` header) still applies because `Faraday.new` merges it in; the existing tests cover that.

No `FollowRedirects` on the default connection since several `check_status` implementations inspect 301/302 explicitly.