### PR TITLE
Set 30s default timeout on all Faraday connections

### DIFF
--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,10 +1,13 @@
 require 'faraday/typhoeus'
 Faraday.default_adapter = :typhoeus
 
-# Set default User-Agent for all Faraday connections
 Faraday.default_connection_options = {
   headers: {
     'User-Agent' => 'packages.ecosyste.ms'
+  },
+  request: {
+    timeout: 30,
+    open_timeout: 10
   }
 }
 

--- a/test/initializers/faraday_test.rb
+++ b/test/initializers/faraday_test.rb
@@ -1,6 +1,25 @@
 require 'test_helper'
 
 class FaradayInitializerTest < ActiveSupport::TestCase
+  test "sets default timeout on all Faraday connections" do
+    conn = Faraday.new(url: 'https://example.com')
+    assert_equal 30, conn.options.timeout
+    assert_equal 10, conn.options.open_timeout
+  end
+
+  test "sets default timeout on the default connection" do
+    assert_equal 30, Faraday.default_connection.options.timeout
+    assert_equal 10, Faraday.default_connection.options.open_timeout
+  end
+
+  test "explicit timeout overrides the default" do
+    conn = Faraday.new(url: 'https://example.com') do |f|
+      f.options.timeout = 5
+      f.adapter Faraday.default_adapter
+    end
+    assert_equal 5, conn.options.timeout
+  end
+
   test "sets default User-Agent header for Faraday connections" do
     # Create a new Faraday connection without any custom headers
     conn = Faraday.new(url: 'https://example.com')


### PR DESCRIPTION
The p95 duration graph shows requests to hosts like `gitlab.skysri.com` running past a minute. `Ecosystem::Base#request` and `Base#check_status` set 10s/5s timeouts, but the `Faraday.get`/`.head`/`.post` shortcuts (default connection) and most bespoke `Faraday.new` blocks in ecosystem classes have none.

Add `request: { timeout: 30, open_timeout: 10 }` to `Faraday.default_connection_options`. This flows into every `Faraday.new` call including the explicit default connection, so all outbound HTTP now has a ceiling. Connections that already set a tighter timeout keep it.