### PR TITLE
Throttle status checks per registry host

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -488,7 +488,7 @@ class Package < ApplicationRecord
   end
 
   def check_status_async
-    CheckStatusWorker.perform_async(id)
+    CheckPackageStatusWorker.perform_async(registry_id, id)
   end
 
   def repository_or_homepage_url

--- a/app/sidekiq/check_package_status_worker.rb
+++ b/app/sidekiq/check_package_status_worker.rb
@@ -1,0 +1,10 @@
+class CheckPackageStatusWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Job
+  sidekiq_options lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_throttle_as :registry_host
+
+  def perform(registry_id, package_id)
+    Package.find_by_id(package_id).try(:check_status)
+  end
+end

--- a/test/sidekiq/check_package_status_worker_test.rb
+++ b/test/sidekiq/check_package_status_worker_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class CheckPackageStatusWorkerTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.create!(name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+    @package = @registry.packages.create!(name: 'foo', ecosystem: 'rubygems')
+  end
+
+  test "perform calls Package#check_status" do
+    Package.any_instance.expects(:check_status)
+    CheckPackageStatusWorker.new.perform(@registry.id, @package.id)
+  end
+
+  test "perform is a no-op for missing package" do
+    assert_nothing_raised do
+      CheckPackageStatusWorker.new.perform(@registry.id, 0)
+    end
+  end
+
+  test "check_status_async enqueues CheckPackageStatusWorker with registry_id and package_id" do
+    CheckPackageStatusWorker.expects(:perform_async).with(@registry.id, @package.id)
+    @package.check_status_async
+  end
+
+  test "shares the registry_host throttle strategy" do
+    assert_same Sidekiq::Throttled::Registry.get(:registry_host),
+                Sidekiq::Throttled::Registry.get('CheckPackageStatusWorker')
+  end
+end


### PR DESCRIPTION
Adds `CheckPackageStatusWorker` taking `(registry_id, package_id)` and sharing the `:registry_host` sidekiq-throttled strategy from #1767, so `registries.metadata["rate_limit"]` caps status-check job starts alongside sync jobs. `Package#check_status_async` now enqueues the new worker.

`pkg.go.dev` and `www.nuget.org` 429s in the AppSignal `registry_http_requests` breakdown come from `check_status` calls, which the previous throttle could not reach because the old worker took only `package_id`.

`CheckStatusWorker` is left in place so already-queued jobs with the old single-argument signature drain normally; it can be removed in a follow-up once the queue is empty.