### PR TITLE
Remove CheckStatusWorker

### DIFF
--- a/app/sidekiq/check_status_worker.rb
+++ b/app/sidekiq/check_status_worker.rb
@@ -1,8 +1,0 @@
-class CheckStatusWorker
-  include Sidekiq::Worker
-  sidekiq_options lock: :until_executed, lock_expiration: 1.hour.to_i
-
-  def perform(package_id)
-    Package.find_by_id(package_id).try(:check_status)
-  end
-end


### PR DESCRIPTION
Superseded by `CheckPackageStatusWorker` in #1770. Queue, scheduled and retry sets are all empty in production so nothing left to drain.