### PR TITLE
Reject non-array package-name responses

### DIFF
--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -107,7 +107,7 @@ module Ecosystem
     end
 
     def recently_updated_package_names
-      get_json("https://repos.ecosyste.ms/api/v1/package_names/actions").first(20)
+      get_json_array("https://repos.ecosyste.ms/api/v1/package_names/actions").first(20)
     rescue
       []
     end
@@ -125,7 +125,7 @@ module Ecosystem
     end
 
     def all_package_names
-      get_json("https://repos.ecosyste.ms/api/v1/package_names/actions")
+      get_json_array("https://repos.ecosyste.ms/api/v1/package_names/actions")
     rescue
       []
     end

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -404,5 +404,10 @@ module Ecosystem
       options.deep_merge!(headers: { "Accept" => "application/json" })
       get(url, options)
     end
+
+    def get_json_array(url, options = {})
+      json = get_json(url, options)
+      json.is_a?(Array) ? json : []
+    end
   end
 end

--- a/app/models/ecosystem/carthage.rb
+++ b/app/models/ecosystem/carthage.rb
@@ -19,16 +19,12 @@ module Ecosystem
 
     def fetch_package_metadata_uncached(name)
       json = get_json("https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/#{CGI.escape(name)}")
-      return nil if json.nil?
-      return nil if json['error'].present?
+      return nil unless json.is_a?(Hash) && json['full_name'].present?
       json.merge('name' => name, 'repository_url' => "https://github.com/#{name}")
     end
 
     def recently_updated_package_names
-      json = get_json("https://repos.ecosyste.ms/api/v1/package_names/carthage")
-      return [] if json.nil?
-      return [] if json['error'].present?
-      json.first(20)
+      get_json_array("https://repos.ecosyste.ms/api/v1/package_names/carthage").first(20)
     rescue
       []
     end
@@ -46,7 +42,7 @@ module Ecosystem
     end
 
     def all_package_names
-      get_json("https://repos.ecosyste.ms/api/v1/package_names/carthage")
+      get_json_array("https://repos.ecosyste.ms/api/v1/package_names/carthage")
     rescue
       []
     end

--- a/app/models/ecosystem/docker.rb
+++ b/app/models/ecosystem/docker.rb
@@ -59,7 +59,7 @@ module Ecosystem
 
     def all_package_names
       official_packages = namespace_package_names('library')
-      community_packages = get_json("https://repos.ecosyste.ms/api/v1/package_names/docker")
+      community_packages = get_json_array("https://repos.ecosyste.ms/api/v1/package_names/docker")
       (official_packages + community_packages).uniq
     rescue
       []

--- a/test/models/carthage_test.rb
+++ b/test/models/carthage_test.rb
@@ -60,8 +60,8 @@ class CarthageTest < ActiveSupport::TestCase
     stub_request(:get, "https://repos.ecosyste.ms/api/v1/package_names/carthage")
       .to_return({ status: 200, body: file_fixture('carthage/carthage') })
     recently_updated_package_names = @ecosystem.recently_updated_package_names
-    assert_equal recently_updated_package_names.length, 0
-    # assert_equal recently_updated_package_names.last, nil
+    assert_equal 20, recently_updated_package_names.length
+    assert recently_updated_package_names.all? { |n| n.is_a?(String) }
   end
   
   test 'package_metadata' do
@@ -95,5 +95,23 @@ class CarthageTest < ActiveSupport::TestCase
   test 'update_existing_versions syncs tag-backed changes' do
     @ecosystem.expects(:sync_tag_backed_versions).with(@package, [{ number: '0.16.0' }])
     @ecosystem.update_existing_versions(@package, [{ number: '0.16.0' }])
+  end
+
+  test 'recently_updated_package_names ignores non-array upstream response' do
+    stub_request(:get, "https://repos.ecosyste.ms/api/v1/package_names/carthage")
+      .to_return(status: 520, body: '{"error_code":520,"ray_id":"x","instance":"y"}', headers: { 'Content-Type' => 'application/json' })
+    assert_equal [], @ecosystem.recently_updated_package_names
+  end
+
+  test 'all_package_names ignores non-array upstream response' do
+    stub_request(:get, "https://repos.ecosyste.ms/api/v1/package_names/carthage")
+      .to_return(status: 520, body: '{"error_code":520}', headers: { 'Content-Type' => 'application/json' })
+    assert_equal [], @ecosystem.all_package_names
+  end
+
+  test 'fetch_package_metadata rejects response without full_name' do
+    stub_request(:get, %r{https://repos.ecosyste.ms/api/v1/repositories/lookup})
+      .to_return(status: 520, body: '{"error_code":520,"ray_id":"x"}', headers: { 'Content-Type' => 'application/json' })
+    assert_nil @ecosystem.fetch_package_metadata('foo/bar')
   end
 end


### PR DESCRIPTION
`repos.ecosyste.ms` returned a Cloudflare 520 error whose JSON body is a hash (`error_code`, `ray_id`, `instance`, `what_you_should_do`, ...). `Carthage#recently_updated_package_names` did `json.first(20)` on it, which on a Hash yields `[key, value]` pairs; `Registry#recently_updated_package_names_excluding_recently_synced` then `.map(&:to_s)`ed those into "names" like `["ray_id", "a07a..."]` and enqueued syncs. `Carthage#fetch_package_metadata_uncached` got the same 520 hash back for the lookup, and since the CF body has no `error` key it merged it into a package record with `repository_url: "https://github.com/[\"ray_id\", ...]"`. Six garbage carthage packages were created and their `UpdatePackageWorker` retries fail with `URI::InvalidURIError`.

Adds `Ecosystem::Base#get_json_array` that returns `[]` unless the parsed body is an `Array`, and uses it in the carthage/actions/docker `package_names` callers. `Carthage#fetch_package_metadata_uncached` now requires `full_name` on the lookup response.

Also fixes a latent bug: `Carthage#recently_updated_package_names` had always returned `[]` on a valid array response, because `json["error"]` on an Array raised `TypeError` and the blanket `rescue` swallowed it. The one time it produced output was when the response was the CF error hash.