### PR TITLE
Route Package#sync_async through the registry_host throttle

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -423,7 +423,7 @@ class Package < ApplicationRecord
   def sync_async
     return if last_synced_at && last_synced_at > 1.day.ago
     return if registry&.sync_in_batches?
-    UpdatePackageWorker.perform_async(id)
+    SyncPackageByIdWorker.perform_async(registry_id, id)
   end
 
   def update_versions

--- a/app/sidekiq/sync_package_by_id_worker.rb
+++ b/app/sidekiq/sync_package_by_id_worker.rb
@@ -1,0 +1,10 @@
+class SyncPackageByIdWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Job
+  sidekiq_options queue: :critical, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_throttle_as :registry_host
+
+  def perform(registry_id, package_id)
+    Package.find_by_id(package_id).try(:sync)
+  end
+end

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -193,7 +193,7 @@ namespace :packages do
     with_rake_lock('packages:sync_outdated_docker') do
       registry = Registry.find_by(ecosystem: 'docker')
       registry.packages.active.outdated.limit(1000).order('RANDOM()').select(:id).each_with_index do |package, i|
-        UpdatePackageWorker.perform_in(i.seconds, package.id)
+        SyncPackageByIdWorker.perform_in(i.seconds, registry.id, package.id)
       end
     end
   end

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -298,22 +298,22 @@ class PackageTest < ActiveSupport::TestCase
     assert_includes result, scoped_package
   end
 
-  test 'sync_async enqueues UpdatePackageWorker' do
+  test 'sync_async enqueues SyncPackageByIdWorker' do
     @package.update(last_synced_at: 2.days.ago)
-    UpdatePackageWorker.expects(:perform_async).with(@package.id).once
+    SyncPackageByIdWorker.expects(:perform_async).with(@package.registry_id, @package.id).once
     @package.sync_async
   end
 
   test 'sync_async skips recently synced packages' do
     @package.update(last_synced_at: 1.hour.ago)
-    UpdatePackageWorker.expects(:perform_async).never
+    SyncPackageByIdWorker.expects(:perform_async).never
     @package.sync_async
   end
 
   test 'sync_async skips batch ecosystem packages' do
     batch_registry = Registry.create(name: 'nixpkgs-unstable', url: 'https://channels.nixos.org/nixos-unstable', ecosystem: 'nixpkgs', version: 'unstable')
     batch_package = batch_registry.packages.create(name: 'hello', ecosystem: 'nixpkgs', last_synced_at: 2.days.ago)
-    UpdatePackageWorker.expects(:perform_async).never
+    SyncPackageByIdWorker.expects(:perform_async).never
     batch_package.sync_async
   end
 

--- a/test/sidekiq/sync_package_by_id_worker_test.rb
+++ b/test/sidekiq/sync_package_by_id_worker_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class SyncPackageByIdWorkerTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.create!(name: 'rubygems.org', url: 'https://rubygems.org', ecosystem: 'rubygems')
+    @package = @registry.packages.create!(name: 'foo', ecosystem: 'rubygems')
+  end
+
+  test "perform calls Package#sync" do
+    Package.any_instance.expects(:sync)
+    SyncPackageByIdWorker.new.perform(@registry.id, @package.id)
+  end
+
+  test "perform is a no-op for missing package" do
+    assert_nothing_raised { SyncPackageByIdWorker.new.perform(@registry.id, 0) }
+  end
+
+  test "sync_async enqueues SyncPackageByIdWorker with registry_id and package_id" do
+    Registry.any_instance.stubs(:sync_in_batches?).returns(false)
+    SyncPackageByIdWorker.expects(:perform_async).with(@registry.id, @package.id)
+    @package.sync_async
+  end
+
+  test "shares the registry_host throttle strategy" do
+    assert_same Sidekiq::Throttled::Registry.get(:registry_host),
+                Sidekiq::Throttled::Registry.get('SyncPackageByIdWorker')
+  end
+end


### PR DESCRIPTION
`UpdatePackageWorker(package_id)` runs `Package#sync` → `registry.sync_package(name)`, the same code path as `SyncPackageWorker`, but was not in the `:registry_host` throttle. The periodic crons (`sync_least_recent` 4k jobs every 15m, `sync_least_recent_top` 3k every 30m, `sync_worst_one_percent` every 20m, `sync_outdated_docker` hourly, `sync_download_counts`) all enqueue via `Package#sync_async` → `UpdatePackageWorker`, so the bulk of sync traffic bypassed the per-host limit and the 429 rate did not move.

Adds `SyncPackageByIdWorker(registry_id, package_id)` sharing `:registry_host`, switches `Package#sync_async` and the `sync_outdated_docker` rake task to it. `UpdatePackageWorker` stays for already-queued jobs to drain, same as `CheckStatusWorker` in #1770.