### PR TITLE
Stagger cron schedules off the 15/30-minute boundaries

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,27 +10,27 @@
     },
     {
       "command": "bundle exec rake packages:sync_recent",
-      "schedule": "*/15 * * * *"
+      "schedule": "3,18,33,48 * * * *"
     },
     {
       "command": "bundle exec rake packages:sync_least_recent",
-      "schedule": "*/15 * * * *"
+      "schedule": "7,22,37,52 * * * *"
     },
     {
       "command": "bundle exec rake packages:sync_least_recent_top",
-      "schedule": "*/30 * * * *"
+      "schedule": "11,41 * * * *"
     },
     {
       "command": "bundle exec rake packages:sync_worst_one_percent",
-      "schedule": "*/20 * * * *"
+      "schedule": "4,24,44 * * * *"
     },
     {
       "command": "bundle exec rake packages:update_repo_metadata_async",
-      "schedule": "*/30 * * * *"
+      "schedule": "9,39 * * * *"
     },
     {
       "command": "bundle exec rake packages:check_statuses",
-      "schedule": "0 * * * *"
+      "schedule": "26 * * * *"
     },
     {
       "command": "bundle exec rake packages:sync_missing",
@@ -42,11 +42,11 @@
     },
     {
       "command": "bundle exec rake packages:sync_maintainers",
-      "schedule": "*/30 * * * *"
+      "schedule": "13,43 * * * *"
     },
     {
       "command": "bundle exec rake packages:update_rankings",
-      "schedule": "*/30 * * * *"
+      "schedule": "17,47 * * * *"
     },
     {
       "command": "bundle exec rake sitemap:refresh",
@@ -54,11 +54,11 @@
     },
     {
       "command": "bundle exec rake packages:update_advisories",
-      "schedule": "0 * * * *"
+      "schedule": "19 * * * *"
     },
     {
       "command": "bundle exec rake packages:sync_outdated_docker",
-      "schedule": "0 * * * *"
+      "schedule": "31 * * * *"
     },
     {
       "command": "bundle exec rake packages:update_docker_usages",
@@ -66,11 +66,11 @@
     },
     {
       "command": "bundle exec rake packages:sync_batch_registries_outdated",
-      "schedule": "0 * * * *"
+      "schedule": "36 * * * *"
     },
     {
       "command": "bundle exec rake packages:crawl_recently_updated_github_marketplace",
-      "schedule": "0 */2 * * *"
+      "schedule": "23 */2 * * *"
     },
     {
       "command": "bundle exec rake packages:calculate_funding_domains",


### PR DESCRIPTION
Every `*/15`, `*/30`, `*/20` and hourly `0 * * * *` cron fired together at `:00` and `:30`, dumping tens of thousands of jobs onto the queues in one tick and producing the vertical stripes visible in the outbound-request charts. Give each a distinct minute offset while keeping the same frequency:

| task | before | after |
|---|---|---|
| sync_recent | `*/15` | `3,18,33,48` |
| sync_least_recent | `*/15` | `7,22,37,52` |
| sync_least_recent_top | `*/30` | `11,41` |
| sync_worst_one_percent | `*/20` | `4,24,44` |
| update_repo_metadata_async | `*/30` | `9,39` |
| sync_maintainers | `*/30` | `13,43` |
| update_rankings | `*/30` | `17,47` |
| update_advisories | `0` | `19` |
| crawl_recently_updated_github_marketplace | `0 */2` | `23 */2` |
| check_statuses | `0` | `26` |
| sync_outdated_docker | `0` | `31` |
| sync_batch_registries_outdated | `0` | `36` |

`sync_recent_npm` (`*/5`) and `sync_recent_pypi` (`*/2`) are left alone since they are near-continuous. Daily and weekly tasks are unchanged.