### PR TITLE
Reuse cached fetch result in Go#check_status

### DIFF
--- a/app/models/ecosystem/go.rb
+++ b/app/models/ecosystem/go.rb
@@ -35,21 +35,10 @@ module Ecosystem
     end
 
     def check_status(package)
-      url = "https://pkg.go.dev/#{package.name}"
-      response = Faraday.head(url)
-      if [400, 404, 410, 302, 301].include?(response.status)
-        response = Faraday.get("#{proxy_url}/#{encode_for_proxy(package.name)}/@v/list")
-        return "removed" if [400, 404, 410].include?(response.status)
-        return unless response.success?
-        return unless response.body.length.zero?
-
-        version = package.versions.active.order(id: :desc).pick(:number)
-        return "removed" unless version
-
-        version_url = "#{proxy_url}/#{encode_for_proxy(package.name)}/@v/#{encode_for_proxy(version)}.info"
-        version_response = Faraday.get(version_url)
-        return "removed" if [400, 404, 410].include?(version_response.status)
-      end
+      meta = fetch_package_metadata(package.name)
+      return nil if meta.is_a?(Hash) && meta[:name].present?
+      return "removed" if meta == false
+      nil
     end
 
     def install_command(package, version = nil)

--- a/test/models/ecosystem/go_test.rb
+++ b/test/models/ecosystem/go_test.rb
@@ -63,18 +63,26 @@ class GoTest < ActiveSupport::TestCase
     assert_equal install_command, 'go get github.com/aws/smithy-go@v1.11.1'
   end
 
-  test 'check_status accepts a pseudo-version when the version list is empty' do
-    ENV['GO_PROXY_URL'] = 'https://go-status.example'
-    registry = Registry.create!(name: 'Go status', url: 'https://go-status.example', ecosystem: 'Go')
-    package = registry.packages.create!(name: 'example.com/pseudo-only', ecosystem: 'go')
-    package.versions.create!(number: 'v0.0.0-20260810161643-097856497a66', registry: registry)
-    ecosystem = Ecosystem::Go.new(registry)
-    stub_request(:head, 'https://pkg.go.dev/example.com/pseudo-only').to_return(status: 404)
-    stub_request(:get, 'https://go-status.example/example.com/pseudo-only/@v/list').to_return(status: 200, body: '')
-    stub_request(:get, 'https://go-status.example/example.com/pseudo-only/@v/v0.0.0-20260810161643-097856497a66.info')
-      .to_return(status: 200, body: '{}')
+  test 'check_status returns nil when fetch_package_metadata finds the module' do
+    @ecosystem.expects(:fetch_package_metadata).with(@package.name).returns(name: @package.name, module: {})
+    assert_nil @ecosystem.check_status(@package)
+  end
 
-    assert_nil ecosystem.check_status(package)
+  test 'check_status returns removed when fetch_package_metadata returns false' do
+    @ecosystem.expects(:fetch_package_metadata).with(@package.name).returns(false)
+    assert_equal 'removed', @ecosystem.check_status(@package)
+  end
+
+  test 'check_status after a failed sync makes no extra proxy requests' do
+    stub_request(:get, %r{https://pkg\.go\.dev/v1beta/module/example\.com/gone}).to_return(status: 404)
+    stub_request(:get, %r{https://pkg\.go\.dev/v1beta/package/example\.com/gone}).to_return(status: 404)
+    proxy_list = stub_request(:get, "https://proxy.golang.org/cached-only/example.com/gone/@v/list").to_return(status: 404)
+
+    assert_equal false, @ecosystem.fetch_package_metadata('example.com/gone')
+
+    package = Package.new(name: 'example.com/gone', ecosystem: 'go')
+    assert_equal 'removed', @ecosystem.check_status(package)
+    assert_requested proxy_list, times: 1
   end
 
   test 'purl' do


### PR DESCRIPTION
For a module neither pkgsite nor the proxy has, `Package#sync` currently makes four requests: `fetch_package_metadata_uncached` tries pkgsite `/module/{name}` (404) then proxy `@v/list` (404) and returns false, then `Package#sync` calls `check_status` which HEADs `pkg.go.dev` (404) and GETs proxy `@v/list` again (404) before marking the package removed. That is two proxy 404s per dead module per cycle.

`Go#check_status` now calls `fetch_package_metadata`, which is memoized on the ecosystem instance, so after a failed sync it reads the cached `false` and returns `"removed"` with zero further HTTP. Standalone status checks hit pkgsite `/v1beta/module` (the API) with the existing proxy fallback instead of HEADing the `pkg.go.dev` HTML page and re-probing `@v/list` and per-version `.info`.

Behaviour change: pseudo-version-only modules that pkgsite has not indexed and whose proxy `@v/list` is empty will now be marked removed rather than probed via `.info`. They will resync once pkgsite picks them up from the index.