### PR TITLE
Include registry_id in check_statuses_async select

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -138,7 +138,7 @@ class Package < ApplicationRecord
   end
 
   def self.check_statuses_async
-    Package.frequently_synced.active.where('last_synced_at < ?', 5.weeks.ago).limit(1000).select('packages.id').each(&:check_status_async)
+    Package.frequently_synced.active.where('last_synced_at < ?', 5.weeks.ago).limit(1000).select('packages.id, packages.registry_id').each(&:check_status_async)
   end
 
   def self.sync_download_counts_async

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -310,6 +310,12 @@ class PackageTest < ActiveSupport::TestCase
     @package.sync_async
   end
 
+  test 'check_statuses_async selects registry_id for the worker' do
+    @package.update!(last_synced_at: 6.weeks.ago, status: 'active')
+    CheckPackageStatusWorker.expects(:perform_async).with(@registry.id, @package.id)
+    Package.check_statuses_async
+  end
+
   test 'sync_async skips batch ecosystem packages' do
     batch_registry = Registry.create(name: 'nixpkgs-unstable', url: 'https://channels.nixos.org/nixos-unstable', ecosystem: 'nixpkgs', version: 'unstable')
     batch_package = batch_registry.packages.create(name: 'hello', ecosystem: 'nixpkgs', last_synced_at: 2.days.ago)


### PR DESCRIPTION
Regression from #1770: `Package#check_status_async` now needs `registry_id` to enqueue `CheckPackageStatusWorker`, but `Package.check_statuses_async` loaded packages with `select("packages.id")` only, so the hourly `packages:check_statuses` cron raised `ActiveModel::MissingAttributeError` on the first iteration. No data written; the rake lock releases in `ensure`. The other narrow-select callers already include `registry_id`.