### PR TITLE
Cap periodic sync enqueue at each registry's throttle drain rate

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -130,14 +130,17 @@ class Package < ApplicationRecord
   end
 
   def self.sync_least_recent_async
+    return if Sidekiq::Queue.new('critical').size > 10_000
     Package.active.outdated.frequently_synced.order('RANDOM()').limit(4000).select('packages.id, packages.last_synced_at, packages.registry_id').each(&:sync_async)
   end
 
   def self.sync_least_recent_top_async
+    return if Sidekiq::Queue.new('critical').size > 10_000
     Package.active.frequently_synced.order('RANDOM()').top(2).where('packages.last_synced_at < ?', 12.hours.ago).select('packages.id, packages.last_synced_at, packages.registry_id').limit(3_000).each(&:sync_async)
   end
 
   def self.check_statuses_async
+    return if Sidekiq::Queue.new('critical').size > 10_000
     Package.frequently_synced.active.where('last_synced_at < ?', 5.weeks.ago).limit(1000).select('packages.id, packages.registry_id').each(&:check_status_async)
   end
 

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -49,6 +49,10 @@ class Registry < ApplicationRecord
     metadata && metadata['rate_limit']
   end
 
+  def sync_budget(period)
+    rate_limit ? rate_limit * period.to_i : nil
+  end
+
   def rate_limit=(value)
     self.metadata = (metadata || {}).merge('rate_limit' => value).compact
   end
@@ -512,11 +516,13 @@ class Registry < ApplicationRecord
     count
   end
 
-  def sync_one_percent_of_packages
-    packages.active.outdated.order('RANDOM()').limit(one_percent_of_packages_count).each(&:sync_async)
+  def sync_one_percent_of_packages(period: 20.minutes)
+    limit = [one_percent_of_packages_count, sync_budget(period)].compact.min
+    packages.active.outdated.order('RANDOM()').limit(limit).each(&:sync_async)
   end
 
   def self.sync_worst_one_percent
+    return if Sidekiq::Queue.new('critical').size > 10_000
     Registry.frequently_synced.sort_by(&:outdated_percentage).last.sync_one_percent_of_packages
   end
 

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -311,9 +311,23 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   test 'check_statuses_async selects registry_id for the worker' do
+    Sidekiq::Queue.any_instance.stubs(:size).returns(0)
     @package.update!(last_synced_at: 6.weeks.ago, status: 'active')
     CheckPackageStatusWorker.expects(:perform_async).with(@registry.id, @package.id)
     Package.check_statuses_async
+  end
+
+  test 'check_statuses_async skips when critical queue is backed up' do
+    Sidekiq::Queue.any_instance.stubs(:size).returns(20_000)
+    @package.update!(last_synced_at: 6.weeks.ago, status: 'active')
+    CheckPackageStatusWorker.expects(:perform_async).never
+    Package.check_statuses_async
+  end
+
+  test 'sync_least_recent_async skips when critical queue is backed up' do
+    Sidekiq::Queue.any_instance.stubs(:size).returns(20_000)
+    SyncPackageByIdWorker.expects(:perform_async).never
+    Package.sync_least_recent_async
   end
 
   test 'sync_async skips batch ecosystem packages' do

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -402,4 +402,33 @@ class RegistryTest < ActiveSupport::TestCase
     assert_equal 3, stat_2022.packages_count
   end
 
+  test 'sync_budget returns rate_limit times period seconds' do
+    @registry.rate_limit = 2
+    assert_equal 1800, @registry.sync_budget(15.minutes)
+    @registry.rate_limit = nil
+    assert_nil @registry.sync_budget(15.minutes)
+  end
+
+  test 'sync_one_percent_of_packages caps at sync_budget' do
+    @registry.stubs(:one_percent_of_packages_count).returns(4000)
+    @registry.rate_limit = 1
+    scope = mock
+    scope.expects(:limit).with(1200).returns([])
+    @registry.packages.stubs(:active).returns(stub(outdated: stub(order: scope)))
+    @registry.sync_one_percent_of_packages(period: 20.minutes)
+  end
+
+  test 'sync_one_percent_of_packages uses one_percent when unthrottled' do
+    @registry.stubs(:one_percent_of_packages_count).returns(300)
+    scope = mock
+    scope.expects(:limit).with(300).returns([])
+    @registry.packages.stubs(:active).returns(stub(outdated: stub(order: scope)))
+    @registry.sync_one_percent_of_packages
+  end
+
+  test 'sync_worst_one_percent skips when critical queue is backed up' do
+    Sidekiq::Queue.any_instance.stubs(:size).returns(20_000)
+    Registry.any_instance.expects(:sync_one_percent_of_packages).never
+    Registry.sync_worst_one_percent
+  end
 end


### PR DESCRIPTION
The `:critical` queue grows unbounded when crons enqueue more jobs for a rate-limited registry than its `rate_limit` can process before the next cron tick. `sync_worst_one_percent` picking go (2M active packages) enqueues up to 4000 jobs per 20-minute cycle while `rate_limit: 1` drains 1200, netting +2800 per tick.

`Registry#sync_budget(period)` returns `rate_limit * period.to_i` (nil when unthrottled). `sync_one_percent_of_packages` now caps its batch at `[one_percent_of_packages_count, sync_budget(20.minutes)].compact.min`, so a throttled registry never receives more than it can drain by the next tick. Unthrottled registries are unchanged.

`sync_least_recent_async`, `sync_least_recent_top_async`, `check_statuses_async` and `Registry.sync_worst_one_percent` skip the tick when `Sidekiq::Queue.new("critical").size > 10_000`, matching the existing guard on `sync_download_counts_async`, so a backlog from any source stops compounding rather than piling on.