### PR TITLE
Remove UpdatePackageWorker

### DIFF
--- a/app/sidekiq/update_package_worker.rb
+++ b/app/sidekiq/update_package_worker.rb
@@ -1,8 +1,0 @@
-class UpdatePackageWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: :critical, lock: :until_executed, lock_expiration: 1.hour.to_i
-
-  def perform(package_id)
-    Package.find_by_id(package_id).try(:sync)
-  end
-end


### PR DESCRIPTION
Superseded by `SyncPackageByIdWorker` in #1775. Queue and scheduled sets are empty in production; the retry set held a handful of `Faraday::TimeoutError` entries which can be cleared with `Sidekiq::RetrySet.new.each { |j| j.delete if j.klass == "UpdatePackageWorker" }`.