### PR TITLE
Skip batch-sync ecosystems in sync_recent

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -194,7 +194,8 @@ class Registry < ApplicationRecord
   end
 
   def sync_recently_updated_packages_async
-    sync_in_batches? ? sync_recently_updated_packages : sync_packages_async(recently_updated_package_names_excluding_recently_synced)
+    return if sync_in_batches?
+    sync_packages_async(recently_updated_package_names_excluding_recently_synced)
   end
 
   def sync_packages(package_names)

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -124,6 +124,13 @@ class RegistryTest < ActiveSupport::TestCase
     @registry.expects(:sync_packages_async).with(['foo', 'bar', 'baz'])
     @registry.sync_recently_updated_packages_async
   end
+
+  test 'sync_recently_updated_packages_async skips batch-sync ecosystems' do
+    @registry.stubs(:sync_in_batches?).returns(true)
+    @registry.expects(:sync_recently_updated_packages).never
+    @registry.expects(:sync_packages_async).never
+    assert_nil @registry.sync_recently_updated_packages_async
+  end
   
   test 'sync_packages' do
     @registry.expects(:sync_package).with('foo')


### PR DESCRIPTION
`packages:sync_recent` (every 15 min) iterates `Registry.frequently_synced` and, for `sync_in_batches?` ecosystems, runs the sync inline in the rake process rather than enqueuing workers. For nixpkgs that loads the full `packages.json` into `@@packages_cache`, and AppSignal `process_rss` shows the cron container peaking at ~3.8GB on every 15-minute tick (e.g. cron.2311 at 10:30, cron.14311 at 11:15, cron.31416 at 12:48).

Batch-sync ecosystems are already handled by the hourly `packages:sync_batch_registries_outdated`, so `sync_recently_updated_packages_async` now returns early for them instead of running the inline sync.