### PR TITLE
Cache per-version artifacthub response in Helm ecosystem

### DIFF
--- a/app/models/ecosystem/helm.rb
+++ b/app/models/ecosystem/helm.rb
@@ -62,8 +62,8 @@ module Ecosystem
       return [] unless parts.length == 2
 
       repository, package_name = parts
-      data = get_json("https://artifacthub.io/api/v1/packages/helm/#{repository}/#{package_name}/#{version}")
-      deps = data.dig('data', 'dependencies') || []
+      data = fetch_version_details(repository, package_name, version)
+      deps = data.is_a?(Hash) && data.dig('data', 'dependencies') || []
 
       deps.map do |dep|
         dep_name = if dep['artifacthub_repository_name']
@@ -173,10 +173,17 @@ module Ecosystem
     end
 
     def fetch_content_url(repository, name, number)
-      data = get_json("https://artifacthub.io/api/v1/packages/helm/#{repository}/#{name}/#{number}")
+      data = fetch_version_details(repository, name, number)
       data.is_a?(Hash) ? data['content_url'].presence : nil
+    end
+
+    def fetch_version_details(repository, name, number)
+      @version_details ||= {}
+      key = [repository, name, number]
+      return @version_details[key] if @version_details.key?(key)
+      @version_details[key] = get_json("https://artifacthub.io/api/v1/packages/helm/#{repository}/#{name}/#{number}")
     rescue Faraday::Error, Oj::ParseError
-      nil
+      @version_details[key] = nil
     end
 
     def self.purl_type

--- a/test/models/ecosystem/helm_test.rb
+++ b/test/models/ecosystem/helm_test.rb
@@ -226,4 +226,29 @@ class HelmTest < ActiveSupport::TestCase
     status = @ecosystem.check_status(@package)
     assert_nil status
   end
+
+  test 'versions_metadata and dependencies_metadata share one per-version fetch' do
+    version_stub = stub_request(:get, "https://artifacthub.io/api/v1/packages/helm/foo/bar/1.0.0")
+      .to_return(status: 200, body: '{"content_url":"https://example.com/x.tgz","data":{"dependencies":[{"name":"dep","version":"1"}]}}',
+                 headers: { 'Content-Type' => 'application/json' })
+
+    pkg = { name: 'foo/bar', versions: [{ 'version' => '1.0.0', 'ts' => 0 }], licenses: 'MIT' }
+    versions = @ecosystem.versions_metadata(pkg)
+    assert_equal 'https://example.com/x.tgz', versions.first[:metadata]['content_url']
+
+    deps = @ecosystem.dependencies_metadata('foo/bar', '1.0.0', nil)
+    assert_equal 'dep', deps.first[:package_name]
+
+    assert_requested version_stub, times: 1
+  end
+
+  test 'fetch_version_details caches nil on error and does not refetch' do
+    stub_request(:get, "https://artifacthub.io/api/v1/packages/helm/foo/bar/1.0.0")
+      .to_return(status: 500, body: 'not json')
+
+    assert_nil @ecosystem.fetch_version_details('foo', 'bar', '1.0.0')
+    assert_nil @ecosystem.fetch_version_details('foo', 'bar', '1.0.0')
+    assert_equal [], @ecosystem.dependencies_metadata('foo/bar', '1.0.0', nil)
+    assert_requested :get, "https://artifacthub.io/api/v1/packages/helm/foo/bar/1.0.0", times: 1
+  end
 end


### PR DESCRIPTION
`Helm#versions_metadata` and `Helm#dependencies_metadata` both fetched `/api/v1/packages/helm/{repo}/{name}/{version}` for each new version (once for `content_url`, again for `dependencies`), so a package with N new versions made `1 + 2N` artifacthub requests per sync. At `rate_limit: 1` that still produced ~10 429/min because each helm sync was averaging ~25 calls.

`fetch_version_details` memoizes the per-version response on the ecosystem instance so both callers share one fetch, halving the per-version request count to `1 + N`. Errors are cached as `nil` so a failed version fetch is not retried within the same job.