### PR TITLE
Only walk tags for action.yml when default branch has none

### DIFF
--- a/app/models/ecosystem/actions.rb
+++ b/app/models/ecosystem/actions.rb
@@ -81,20 +81,16 @@ module Ecosystem
       if yaml.blank?
         yaml = get_raw_no_exception("https://raw.githubusercontent.com/#{full_name}/#{json['default_branch']}/#{yaml_path}.yaml")
       end
-      
-      # TODO search for action.yml or action.yaml in all tags if not found in default branch
-      tags = tags_json = get_json(json['tags_url']+'?per_page=1000')
-      if tags.present?
-        yaml = nil
-        while yaml.blank? && tags.present?
-          tag = tags.shift
+
+      if yaml.blank?
+        tags = get_json(json['tags_url'] + '?per_page=1000')
+        Array(tags).each do |tag|
           yaml = get_raw_no_exception("https://raw.githubusercontent.com/#{full_name}/#{tag['name']}/#{yaml_path}.yml")
-          if yaml.blank?
-            yaml = get_raw_no_exception("https://raw.githubusercontent.com/#{full_name}/#{tag['name']}/#{yaml_path}.yaml")
-          end
+          yaml = get_raw_no_exception("https://raw.githubusercontent.com/#{full_name}/#{tag['name']}/#{yaml_path}.yaml") if yaml.blank?
+          break if yaml.present?
         end
       end
-      
+
       return nil unless yaml.present?
 
       yaml = YAML.safe_load(yaml)

--- a/test/models/ecosystem/actions_test.rb
+++ b/test/models/ecosystem/actions_test.rb
@@ -174,7 +174,26 @@ class ActionsTest < ActiveSupport::TestCase
       :homepage=>nil, 
       :tags_url=>"http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/getsentry%2Faction-git-diff-suggestions/tags", 
       :namespace=>"getsentry", 
-      :metadata=>{"name"=>"action-git-diff-suggestions", "description"=>"This GitHub Action will take the current git changes and apply them as GitHub code review suggestions", "author"=>"Sentry", "branding"=>{"icon"=>"book-open", "color"=>"purple"}, "inputs"=>{"github-token"=>{"description"=>"github token"}, "message"=>{"description"=>"The message to prepend the review suggestion"}}, "runs"=>{"using"=>"node12", "main"=>"dist/index.js"}, "default_branch"=>"main", "path"=>nil}}
+      :metadata=>{"name"=>"action-git-diff-suggestions", "description"=>"This GitHub Action will take the current git changes and apply them as GitHub code review suggestions", "author"=>"Sentry", "branding"=>{"icon"=>"book-open", "color"=>"purple"}, "inputs"=>{"github-token"=>{"description"=>"github token", "default"=>"${{ github.token }}"}, "message"=>{"description"=>"The message to prepend the review suggestion"}}, "runs"=>{"using"=>"node12", "main"=>"dist/index.js"}, "default_branch"=>"main", "path"=>nil}}
+    assert_not_requested :get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/getsentry%2Faction-git-diff-suggestions/tags?per_page=1000"
+    assert_not_requested :get, "https://raw.githubusercontent.com/getsentry/action-git-diff-suggestions/v1/action.yml"
+  end
+
+  test 'package_metadata falls back to tags when default branch has no action file' do
+    stub_request(:get, "https://repos.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/getsentry/action-git-diff-suggestions")
+      .to_return({ status: 200, body: file_fixture('actions/lookup?url=https:%2F%2Fgithub.com%2Fgetsentry%2Faction-git-diff-suggestions') })
+    stub_request(:get, "https://raw.githubusercontent.com/getsentry/action-git-diff-suggestions/main/action.yml")
+      .to_return({ status: 404 })
+    stub_request(:get, "https://raw.githubusercontent.com/getsentry/action-git-diff-suggestions/main/action.yaml")
+      .to_return({ status: 404 })
+    stub_request(:get, "http://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/getsentry%2Faction-git-diff-suggestions/tags?per_page=1000")
+      .to_return({ status: 200, body: file_fixture('actions/tags') })
+    stub_request(:get, "https://raw.githubusercontent.com/getsentry/action-git-diff-suggestions/v1/action.yml")
+      .to_return({ status: 200, body: file_fixture('actions/action.yml.1') })
+
+    package_metadata = @ecosystem.package_metadata('getsentry/action-git-diff-suggestions')
+    assert_equal 'getsentry/action-git-diff-suggestions', package_metadata[:name]
+    assert_equal 'node12', package_metadata[:metadata]['runs']['using']
   end
 
   test 'versions_metadata' do


### PR DESCRIPTION
`Actions#fetch_package_metadata_uncached` fetched `action.yml` from the default branch, then set `yaml = nil` and walked up to 1000 tags probing `.yml` then `.yaml` on each until one was found. The TODO comment says to search tags only when the default branch does not have the file, but the code discarded the default-branch result and always walked.

The tags fetch and walk now only happen when the default-branch probe came back blank. That saves one `repos.ecosyste.ms` tags call and at least one `raw.githubusercontent.com` fetch per successful actions sync, and skips the tag walk entirely for the common case where `action.yml` is on the default branch.

Behaviour change: package metadata now reflects the default-branch `action.yml` rather than the newest tag's. The existing `package_metadata` test expectation is updated accordingly and now asserts the tags endpoint is not requested; a new test covers the fallback path.