### PR TITLE
Use Google Maven Central mirror

### DIFF
--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -610,15 +610,21 @@ module Ecosystem
       license_urls.map { |url| url_license_map[url.strip] }.compact
     end
 
+    MAVEN_CENTRAL_URLS = [
+      "https://repo.maven.apache.org/maven2",
+      "https://repo1.maven.org/maven2",
+      "https://maven-central.storage-download.googleapis.com/maven2"
+    ].freeze
+
     private
 
     def is_maven_central?
-      @registry_url == "https://repo.maven.apache.org/maven2" || @registry_url == "https://repo1.maven.org/maven2"
+      MAVEN_CENTRAL_URLS.include?(@registry_url)
     end
 
     def supports_archetype_catalog?
       case @registry_url
-      when "https://repo.maven.apache.org/maven2", "https://repo1.maven.org/maven2"
+      when *MAVEN_CENTRAL_URLS
         true
       when "https://repository.jboss.org/nexus/content/repositories/releases"
         true

--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -274,8 +274,9 @@ module Ecosystem
 
     def dependencies_metadata(name, version, mapped_package)
       group_id, artifact_id = *name.split(':', 2)
-      url = "#{@registry_url}/#{group_id.gsub(".", "/")}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom"
-      pom_file = generate_effective_pom(request(url).body)
+      effective = fetch_effective_pom(group_id, artifact_id, version)
+      return [] if effective.nil?
+      pom_file = effective[:body]
       properties = mapped_package&.dig(:properties) || {}
       Bibliothecary::Parsers::Maven.parse_pom_manifest(pom_file, properties).map do |dep|
         {
@@ -525,12 +526,11 @@ module Ecosystem
     end
 
     def fetch_pom(group_id, artifact_id, version)
-      url = "#{@registry_url}/#{group_id.gsub(".", "/")}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom"
-      pom_request = request(url)
-      return nil if pom_request.status == 404
-      xml = Ox.parse(generate_effective_pom(pom_request.body))
+      effective = fetch_effective_pom(group_id, artifact_id, version)
+      return nil if effective.nil?
+      xml = Ox.parse(effective[:body])
       return nil if xml.nil?
-      published_at = pom_request.headers["Last-Modified"]
+      published_at = effective[:last_modified]
       if published_at.present?
         pat = Ox::Element.new("publishedAt")
         pat << published_at
@@ -539,6 +539,18 @@ module Ecosystem
       xml
     rescue URI::InvalidURIError, Ox::Error
       nil
+    end
+
+    def fetch_effective_pom(group_id, artifact_id, version)
+      @effective_pom_cache ||= {}
+      key = "#{group_id}/#{artifact_id}/#{version}"
+      return @effective_pom_cache[key] if @effective_pom_cache.key?(key)
+      url = "#{@registry_url}/#{group_id.gsub(".", "/")}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom"
+      resp = request(url)
+      return @effective_pom_cache[key] = nil if resp.status == 404
+      @effective_pom_cache[key] = { body: generate_effective_pom(resp.body), last_modified: resp.headers["Last-Modified"] }
+    rescue URI::InvalidURIError
+      @effective_pom_cache[key] = nil
     end
 
     def get_pom(group_id, artifact_id, version, seen = [])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ default_registries = [
   {name: 'deno.land', url: 'https://deno.land', ecosystem: 'deno', github: 'denoland', default: true},
   {name: 'clojars.org', url: 'https://repo.clojars.org', ecosystem: 'clojars', github: 'clojars', default: true},
   {name: 'registry.bazel.build', url: 'https://registry.bazel.build', ecosystem: 'bazel', github: 'bazelbuild', default: true},
-  {name: 'repo1.maven.org', url: 'https://maven-central.storage-download.googleapis.com/maven2', ecosystem: 'maven', github: 'maven-central', default: true},
+  {name: 'repo1.maven.org', url: 'https://maven-central.storage-download.googleapis.com/maven2', ecosystem: 'maven', github: 'maven-central', default: true, rate_limit: 2},
   {name: 'repository.jboss.org', url: 'https://repository.jboss.org/nexus/content/repositories/releases', ecosystem: 'maven', github: 'jboss-eap', default: false},
   {name: 'repository.apache.org-releases', url: 'https://repository.apache.org/content/repositories/releases', ecosystem: 'maven', github: 'apache', default: false},
   {name: 'repository.apache.org-snapshots', url: 'https://repository.apache.org/content/repositories/snapshots', ecosystem: 'maven', github: 'apache', default: false},

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ default_registries = [
   {name: 'deno.land', url: 'https://deno.land', ecosystem: 'deno', github: 'denoland', default: true},
   {name: 'clojars.org', url: 'https://repo.clojars.org', ecosystem: 'clojars', github: 'clojars', default: true},
   {name: 'registry.bazel.build', url: 'https://registry.bazel.build', ecosystem: 'bazel', github: 'bazelbuild', default: true},
-  {name: 'repo1.maven.org', url: 'https://repo1.maven.org/maven2', ecosystem: 'maven', github: 'maven-central', default: true},
+  {name: 'repo1.maven.org', url: 'https://maven-central.storage-download.googleapis.com/maven2', ecosystem: 'maven', github: 'maven-central', default: true},
   {name: 'repository.jboss.org', url: 'https://repository.jboss.org/nexus/content/repositories/releases', ecosystem: 'maven', github: 'jboss-eap', default: false},
   {name: 'repository.apache.org-releases', url: 'https://repository.apache.org/content/repositories/releases', ecosystem: 'maven', github: 'apache', default: false},
   {name: 'repository.apache.org-snapshots', url: 'https://repository.apache.org/content/repositories/snapshots', ecosystem: 'maven', github: 'apache', default: false},

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -606,4 +606,28 @@ class MavenTest < ActiveSupport::TestCase
     integrity = @ecosystem.send(:version_integrity, 'com.example:pom-only', '1.0.0')
     assert_nil integrity
   end
+
+  test 'versions_metadata and dependencies_metadata share one .pom fetch per version' do
+    pom = '<project xmlns="http://maven.apache.org/POM/4.0.0"><groupId>com.example</groupId><artifactId>foo</artifactId><version>1.0.0</version><dependencies><dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13</version></dependency></dependencies></project>'
+    pom_stub = stub_request(:get, "https://repo1.maven.org/maven2/com/example/foo/1.0.0/foo-1.0.0.pom")
+      .to_return(status: 200, body: pom, headers: { 'Last-Modified' => 'Wed, 01 Jan 2025 00:00:00 GMT' })
+    @ecosystem.stubs(:generate_effective_pom).with(pom).returns(pom)
+
+    @ecosystem.versions_metadata({ name: 'com.example:foo', versions: ['1.0.0'] })
+    deps = @ecosystem.dependencies_metadata('com.example:foo', '1.0.0', nil)
+
+    assert_equal 'junit:junit', deps.first[:package_name]
+    assert_requested pom_stub, times: 1
+  end
+
+  test 'dependencies_metadata returns [] when pom is 404' do
+    stub_request(:get, "https://repo1.maven.org/maven2/com/example/gone/1.0.0/gone-1.0.0.pom")
+      .to_return(status: 404)
+    assert_equal [], @ecosystem.dependencies_metadata('com.example:gone', '1.0.0', nil)
+  end
+
+  test 'is_maven_central? recognises the Google mirror' do
+    r = Registry.new(url: 'https://maven-central.storage-download.googleapis.com/maven2', name: 'x', ecosystem: 'maven')
+    assert Ecosystem::Maven.new(r).send(:is_maven_central?)
+  end
 end


### PR DESCRIPTION
Sonatype's `repo.maven.apache.org` and `repo1.maven.org` both return 403 from the production server IP regardless of User-Agent, while `maven-central.storage-download.googleapis.com` serves the same artifact tree and returns 200.

- Adds the Google mirror URL to `MAVEN_CENTRAL_URLS` so `is_maven_central?` and `supports_archetype_catalog?` recognise it
- Updates the seed URL for the default maven registry and seeds `rate_limit: 2`
- Caches the effective POM body per version in `fetch_effective_pom` so `dependencies_metadata` reuses what `versions_metadata` already fetched instead of requesting the same `.pom` again, cutting per-version requests from 3 (`.pom`, `.pom`, `.jar.sha1`) to 2

Production needs the registry row updated via console after deploy:

```ruby
Registry.find_by_name!("repo1.maven.org").update!(url: "https://maven-central.storage-download.googleapis.com/maven2", rate_limit: 2)
```