### PR TITLE
Cap sync enqueue rate to registry rate_limit budget

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -131,7 +131,7 @@ class Package < ApplicationRecord
 
   def self.sync_least_recent_async
     return if Sidekiq::Queue.new('critical').size > 10_000
-    Package.active.outdated.frequently_synced.order('RANDOM()').limit(4000).select('packages.id, packages.last_synced_at, packages.registry_id').each(&:sync_async)
+    Package.active.outdated.frequently_synced.where.not(registry_id: Registry.throttled_ids).order('RANDOM()').limit(4000).select('packages.id, packages.last_synced_at, packages.registry_id').each(&:sync_async)
   end
 
   def self.sync_least_recent_top_async

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -45,6 +45,10 @@ class Registry < ApplicationRecord
     throttle_cache.dig(id, :rate_limit)
   end
 
+  def self.throttled_ids
+    throttle_cache.select { |_, v| v[:rate_limit] }.keys
+  end
+
   def rate_limit
     metadata && metadata['rate_limit']
   end
@@ -190,12 +194,12 @@ class Registry < ApplicationRecord
       return ecosystem_instance.sync_missing_packages_async
     end
 
-    sync_in_batches? ? sync_missing_packages : sync_packages_async(missing_package_names)
+    sync_in_batches? ? sync_missing_packages : sync_packages_async(missing_package_names, period: 1.hour)
   end
 
-  def sync_recently_updated_packages_async
+  def sync_recently_updated_packages_async(period: 15.minutes)
     return if sync_in_batches?
-    sync_packages_async(recently_updated_package_names_excluding_recently_synced)
+    sync_packages_async(recently_updated_package_names_excluding_recently_synced, period: period)
   end
 
   def sync_packages(package_names)
@@ -216,7 +220,9 @@ class Registry < ApplicationRecord
     end
   end
 
-  def sync_packages_async(package_names)
+  def sync_packages_async(package_names, period: 15.minutes)
+    budget = sync_budget(period)
+    package_names = package_names.first(budget) if budget
     package_names.each_slice(1_000) do |batch|
       SyncPackageWorker.perform_bulk(batch.map{|name| [id, name]})
     end

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -24,7 +24,7 @@ namespace :packages do
   task sync_recent_npm: :environment do
     with_rake_lock('packages:sync_recent_npm') do
       r = Registry.find_by(ecosystem: 'npm')
-      r.sync_recently_updated_packages_async
+      r.sync_recently_updated_packages_async(period: 5.minutes)
     end
   end
 
@@ -32,7 +32,7 @@ namespace :packages do
   task sync_recent_pypi: :environment do
     with_rake_lock('packages:sync_recent_pypi') do
       r = Registry.find_by(ecosystem: 'pypi')
-      r.sync_recently_updated_packages_async
+      r.sync_recently_updated_packages_async(period: 2.minutes)
     end
   end
 

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -330,6 +330,20 @@ class PackageTest < ActiveSupport::TestCase
     Package.sync_least_recent_async
   end
 
+  test 'sync_least_recent_async excludes throttled registries' do
+    Sidekiq::Queue.any_instance.stubs(:size).returns(0)
+    Registry.reset_throttle_cache
+    throttled = Registry.create!(name: 'npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm', metadata: { 'rate_limit' => 1 })
+    stale_throttled = throttled.packages.create!(name: 'left-pad', ecosystem: 'npm', status: 'active', last_synced_at: 2.months.ago)
+    stale_open = @registry.packages.create!(name: 'stale-gem', ecosystem: 'rubygems', status: 'active', last_synced_at: 2.months.ago)
+
+    SyncPackageByIdWorker.expects(:perform_async).with(@registry.id, stale_open.id).once
+    SyncPackageByIdWorker.expects(:perform_async).with(throttled.id, stale_throttled.id).never
+    Package.sync_least_recent_async
+  ensure
+    Registry.reset_throttle_cache
+  end
+
   test 'sync_async skips batch ecosystem packages' do
     batch_registry = Registry.create(name: 'nixpkgs-unstable', url: 'https://channels.nixos.org/nixos-unstable', ecosystem: 'nixpkgs', version: 'unstable')
     batch_package = batch_registry.packages.create(name: 'hello', ecosystem: 'nixpkgs', last_synced_at: 2.days.ago)

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -107,7 +107,7 @@ class RegistryTest < ActiveSupport::TestCase
   
   test 'sync_missing_packages_async' do
     @registry.expects(:missing_package_names).returns(['foo', 'bar', 'baz'])
-    @registry.expects(:sync_packages_async).with(['foo', 'bar', 'baz'])
+    @registry.expects(:sync_packages_async).with(['foo', 'bar', 'baz'], period: 1.hour)
     @registry.sync_missing_packages_async
   end
 
@@ -121,8 +121,14 @@ class RegistryTest < ActiveSupport::TestCase
   
   test 'sync_recently_updated_packages_async' do
     @registry.expects(:recently_updated_package_names_excluding_recently_synced).returns(['foo', 'bar', 'baz'])
-    @registry.expects(:sync_packages_async).with(['foo', 'bar', 'baz'])
+    @registry.expects(:sync_packages_async).with(['foo', 'bar', 'baz'], period: 15.minutes)
     @registry.sync_recently_updated_packages_async
+  end
+
+  test 'sync_recently_updated_packages_async passes period through' do
+    @registry.expects(:recently_updated_package_names_excluding_recently_synced).returns(['foo'])
+    @registry.expects(:sync_packages_async).with(['foo'], period: 5.minutes)
+    @registry.sync_recently_updated_packages_async(period: 5.minutes)
   end
 
   test 'sync_recently_updated_packages_async skips batch-sync ecosystems' do
@@ -141,6 +147,18 @@ class RegistryTest < ActiveSupport::TestCase
   test 'sync_packages_async' do
     SyncPackageWorker.expects(:perform_bulk).with([[@registry.id, "foo"], [@registry.id, "bar"]])
     @registry.sync_packages_async(['foo', 'bar'])
+  end
+
+  test 'sync_packages_async caps at sync_budget for throttled registries' do
+    @registry.rate_limit = 1
+    SyncPackageWorker.expects(:perform_bulk).with([[@registry.id, "a"], [@registry.id, "b"]])
+    @registry.sync_packages_async(%w[a b c d], period: 2.seconds)
+  end
+
+  test 'sync_packages_async is uncapped when rate_limit is nil' do
+    assert_nil @registry.rate_limit
+    SyncPackageWorker.expects(:perform_bulk).with([[@registry.id, "a"], [@registry.id, "b"], [@registry.id, "c"]])
+    @registry.sync_packages_async(%w[a b c], period: 1.second)
   end
 
   test 'sync_package' do
@@ -407,6 +425,16 @@ class RegistryTest < ActiveSupport::TestCase
     # Should pick up running total from skipped 2021 (2) and add new package
     assert_equal 1, stat_2022.new_packages_count
     assert_equal 3, stat_2022.packages_count
+  end
+
+  test 'throttled_ids returns registries with a rate_limit' do
+    Registry.reset_throttle_cache
+    throttled = Registry.create!(name: 'npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm', metadata: { 'rate_limit' => 1 })
+    ids = Registry.throttled_ids
+    assert_includes ids, throttled.id
+    refute_includes ids, @registry.id
+  ensure
+    Registry.reset_throttle_cache
   end
 
   test 'sync_budget returns rate_limit times period seconds' do


### PR DESCRIPTION
The `:registry_host` sidekiq-throttled strategy caps drain rate per registry, but the cron tasks that fill the `critical` queue were not budget-aware. `sync_least_recent` alone pushed ~16k jobs/h, most of them for npm/nuget/maven/pypi, against a combined drain of ~7/s, so the queue oscillated around 30k with multi-hour latency.

- `Registry#sync_packages_async` now takes a `period:` and truncates the name list to `sync_budget(period)`. `sync_recent`, `sync_recent_npm` (5 min), `sync_recent_pypi` (2 min) and `sync_missing` (1 hour) pass their interval so a tick can never enqueue more than the throttle drains before the next tick.
- `Package.sync_least_recent_async` excludes `Registry.throttled_ids`. Throttled registries still get stale coverage from `sync_worst_one_percent` (already budget-capped) and `sync_least_recent_top`.
- `sync_least_recent_top_async` is unchanged so top-package sync volume is not reduced.
- Unthrottled registries have `sync_budget -> nil` and are unaffected everywhere.

Changing a registry `rate_limit` in the console rescales all of the above with no code change.