### PR TITLE
Drop sync_least_recent_top_async limit and fix check_statuses queue guard

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -136,11 +136,11 @@ class Package < ApplicationRecord
 
   def self.sync_least_recent_top_async
     return if Sidekiq::Queue.new('critical').size > 10_000
-    Package.active.frequently_synced.order('RANDOM()').top(2).where('packages.last_synced_at < ?', 12.hours.ago).select('packages.id, packages.last_synced_at, packages.registry_id').limit(3_000).each(&:sync_async)
+    Package.active.frequently_synced.order('RANDOM()').top(2).where('packages.last_synced_at < ?', 12.hours.ago).select('packages.id, packages.last_synced_at, packages.registry_id').limit(500).each(&:sync_async)
   end
 
   def self.check_statuses_async
-    return if Sidekiq::Queue.new('critical').size > 10_000
+    return if Sidekiq::Queue.new('default').size > 20_000
     Package.frequently_synced.active.where('last_synced_at < ?', 5.weeks.ago).limit(1000).select('packages.id, packages.registry_id').each(&:check_status_async)
   end
 

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -317,8 +317,8 @@ class PackageTest < ActiveSupport::TestCase
     Package.check_statuses_async
   end
 
-  test 'check_statuses_async skips when critical queue is backed up' do
-    Sidekiq::Queue.any_instance.stubs(:size).returns(20_000)
+  test 'check_statuses_async skips when default queue is backed up' do
+    Sidekiq::Queue.expects(:new).with('default').returns(stub(size: 30_000))
     @package.update!(last_synced_at: 6.weeks.ago, status: 'active')
     CheckPackageStatusWorker.expects(:perform_async).never
     Package.check_statuses_async


### PR DESCRIPTION
Post-throttling, the critical queue settles around 10k and oscillates against the `> 10_000` guards rather than draining. AppSignal shows drain at ~15k/h vs inflow ~23k/h with all crons active.

`sync_least_recent_top_async` at `limit(3_000)` twice an hour is the largest remaining uncapped path into throttled registries — `.top(2)` is dominated by npm/pypi/maven/go/nuget packages. Dropping to 500 cuts that from ~6k/h to ~1k/h while keeping 12-hourly refresh coverage on all registries including throttled ones.

`check_statuses_async` was guarding on `Sidekiq::Queue.new('critical')` but `CheckPackageStatusWorker` runs on `default`. Switched to `default` at 20k to match `sync_download_counts_async` and `sync_maintainers_async`.