### PR TITLE
Support fractional rate_limit for registry throttling

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -19,7 +19,7 @@ class Registry < ApplicationRecord
     if @throttle_cache.nil? || Process.clock_gettime(Process::CLOCK_MONOTONIC) > @throttle_cache_expires_at
       @throttle_cache = pluck(:id, :url, :metadata).each_with_object({}) do |(id, url, meta), h|
         limit = meta.is_a?(Hash) ? meta['rate_limit'] : nil
-        h[id] = { host: extract_host(url), rate_limit: (limit.to_i if limit) }
+        h[id] = { host: extract_host(url), rate_limit: (limit.to_f if limit) }
       end
       @throttle_cache_expires_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + THROTTLE_CACHE_TTL
     end
@@ -45,6 +45,18 @@ class Registry < ApplicationRecord
     throttle_cache.dig(id, :rate_limit)
   end
 
+  def self.throttle_limit_for(id)
+    rl = rate_limit_for(id)
+    return nil if rl.nil?
+    rl >= 1 ? rl.round : 1
+  end
+
+  def self.throttle_period_for(id)
+    rl = rate_limit_for(id)
+    return 1 if rl.nil? || rl >= 1
+    (1.0 / rl).ceil
+  end
+
   def self.throttled_ids
     throttle_cache.select { |_, v| v[:rate_limit] }.keys
   end
@@ -54,7 +66,7 @@ class Registry < ApplicationRecord
   end
 
   def sync_budget(period)
-    rate_limit ? rate_limit * period.to_i : nil
+    rate_limit ? (rate_limit * period.to_i).floor : nil
   end
 
   def rate_limit=(value)
@@ -63,7 +75,7 @@ class Registry < ApplicationRecord
 
   def rate_limit_must_be_positive
     return if rate_limit.nil?
-    errors.add(:rate_limit, 'must be a positive integer') unless rate_limit.is_a?(Integer) && rate_limit > 0
+    errors.add(:rate_limit, 'must be a positive number') unless rate_limit.is_a?(Numeric) && rate_limit > 0
   end
 
   def self.find_by_name!(name)

--- a/config/initializers/sidekiq_throttled.rb
+++ b/config/initializers/sidekiq_throttled.rb
@@ -4,8 +4,8 @@ Rails.application.config.to_prepare do
   Sidekiq::Throttled::Registry.add(
     :registry_host,
     threshold: {
-      limit: ->(registry_id, *) { Registry.rate_limit_for(registry_id) },
-      period: 1.second,
+      limit: ->(registry_id, *) { Registry.throttle_limit_for(registry_id) },
+      period: ->(registry_id, *) { Registry.throttle_period_for(registry_id) },
       key_suffix: ->(registry_id, *) { (Registry.host_for(registry_id) || registry_id).to_s }
     }
   )

--- a/test/models/registry_test.rb
+++ b/test/models/registry_test.rb
@@ -444,6 +444,37 @@ class RegistryTest < ActiveSupport::TestCase
     assert_nil @registry.sync_budget(15.minutes)
   end
 
+  test 'sync_budget floors fractional rate_limit' do
+    @registry.rate_limit = 0.5
+    assert_equal 450, @registry.sync_budget(15.minutes)
+  end
+
+  test 'rate_limit accepts positive floats and rejects zero' do
+    @registry.rate_limit = 0.5
+    assert @registry.valid?
+    @registry.rate_limit = 0
+    refute @registry.valid?
+    @registry.rate_limit = -1
+    refute @registry.valid?
+  end
+
+  test 'throttle_limit_for and throttle_period_for handle integer, fractional, and nil rate limits' do
+    Registry.reset_throttle_cache
+    fast = Registry.create!(name: 'npmjs.org', url: 'https://registry.npmjs.org', ecosystem: 'npm', metadata: { 'rate_limit' => 3 })
+    slow = Registry.create!(name: 'artifacthub.io', url: 'https://artifacthub.io', ecosystem: 'helm', metadata: { 'rate_limit' => 0.5 })
+
+    assert_equal 3, Registry.throttle_limit_for(fast.id)
+    assert_equal 1, Registry.throttle_period_for(fast.id)
+
+    assert_equal 1, Registry.throttle_limit_for(slow.id)
+    assert_equal 2, Registry.throttle_period_for(slow.id)
+
+    assert_nil Registry.throttle_limit_for(@registry.id)
+    assert_equal 1, Registry.throttle_period_for(@registry.id)
+  ensure
+    Registry.reset_throttle_cache
+  end
+
   test 'sync_one_percent_of_packages caps at sync_budget' do
     @registry.stubs(:one_percent_of_packages_count).returns(4000)
     @registry.rate_limit = 1


### PR DESCRIPTION
artifacthub.io is returning ~50% 429s at `rate_limit=1` (3,850 429s vs 3,666 200s over 3h), so it needs to drop below 1. sidekiq-throttled's threshold strategy takes limit-per-period, so 0.5/s has to become `limit: 1, period: 2` rather than `limit: 0.5, period: 1` (which behaves as 1/s).

`Registry.throttle_limit_for` and `throttle_period_for` do that translation: `rate_limit >= 1` gives `(rate_limit.round, 1)`, `rate_limit < 1` gives `(1, (1/rate_limit).ceil)`, `nil` stays `(nil, 1)` so unthrottled registries bypass as before.

Also fixed three places that assumed integer: `throttle_cache` was doing `to_i` (0.5 → 0, which sidekiq-throttled treats as always-throttled), the validation rejected non-Integer, and `sync_budget` returned a Float that `Array#first` at `sync_packages_async` can't take.

After deploy, prod values will be set via console:

```ruby
{npm: 2, pypi: 2, nuget: 2, cargo: 2, docker: 2, helm: 0.5}.each { |eco, rl| r = Registry.find_by!(ecosystem: eco.to_s); r.rate_limit = rl; r.save!; puts "#{r.name}: #{r.rate_limit.inspect}" }; Registry.reset_throttle_cache; nil
```

maven stays at 2, go stays at 1.