### PR TITLE
Update throttling and syncing docs

### DIFF
--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -18,12 +18,13 @@ The primary mechanism. Each ecosystem class implements `recently_updated_package
 
 [`Registry#recently_updated_package_names_excluding_recently_synced`](../app/models/registry.rb#L70) filters the results. It drops any package already synced in the last 10 minutes and adds packages that exist in the registry feed but are missing from the database. This prevents redundant work when the same package appears in consecutive poll cycles.
 
-Two cron entries drive this:
+Three cron entries drive this:
 
 | Schedule | Task | What it does |
 |---|---|---|
+| Every 2 min | `packages:sync_recent_pypi` | Polls PyPI only |
 | Every 5 min | `packages:sync_recent_npm` | Polls npm only (by far the highest volume registry) |
-| Every 15 min | `packages:sync_recent` | Polls all non-Docker registries via [`Registry.sync_all_recently_updated_packages_async`](../app/models/registry.rb#L22) |
+| Every 15 min | `packages:sync_recent` | Polls all frequently-synced registries via [`Registry.sync_all_recently_updated_packages_async`](../app/models/registry.rb) |
 
 ## Pings from repos.ecosyste.ms
 
@@ -75,25 +76,25 @@ Polling and pings handle most updates, but packages can still fall behind. Sever
 
 | Schedule | Task | Selection logic |
 |---|---|---|
-| Every 15 min | `packages:sync_least_recent` | [`Package.sync_least_recent_async`](../app/models/package.rb#L81) -- 4000 random active packages not synced in over a month |
-| Every 30 min | `packages:sync_least_recent_top` | [`Package.sync_least_recent_top_async`](../app/models/package.rb#L85) -- 3000 random top-2% packages not synced in over 12 hours |
-| Every 20 min | `packages:sync_worst_one_percent` | [`Registry.sync_worst_one_percent`](../app/models/registry.rb#L423) -- finds the registry with the highest [`outdated_percentage`](../app/models/registry.rb#L395), syncs 1% of its outdated packages at random |
-| Hourly | `packages:sync_batch_registries_outdated` | [`Registry.sync_in_batches_outdated`](../app/models/registry.rb#L46) -- for batch-sync registries (deb, conda, vcpkg, alpine, nixpkgs, bower, julia, adelie, postmarketos), syncs up to 1000 outdated packages each |
-| Hourly | `packages:sync_outdated_docker` | 1000 random [outdated](../app/models/package.rb#L38) Docker packages |
-| Daily (midnight) | `packages:sync_missing` | [`Registry.sync_all_missing_packages_async`](../app/models/registry.rb#L34) -- compares each registry's full package list against the database and syncs anything missing |
+| Every 15 min | `packages:sync_least_recent` | [`Package.sync_least_recent_async`](../app/models/package.rb) -- a random batch of active packages, on unthrottled registries, not synced in over a month |
+| Every 30 min | `packages:sync_least_recent_top` | [`Package.sync_least_recent_top_async`](../app/models/package.rb) -- a random batch of top-2% packages not synced in over 12 hours |
+| Every 20 min | `packages:sync_worst_one_percent` | [`Registry.sync_worst_one_percent`](../app/models/registry.rb) -- finds the registry with the highest [`outdated_percentage`](../app/models/registry.rb) and syncs a batch of its outdated packages at random, capped at that registry's throttle budget |
+| Hourly | `packages:sync_batch_registries_outdated` | [`Registry.sync_in_batches_outdated`](../app/models/registry.rb) -- for batch-sync registries (deb, conda, vcpkg, alpine, nixpkgs, bower, julia, adelie, postmarketos), syncs a batch of outdated packages each |
+| Hourly | `packages:sync_outdated_docker` | a random batch of [outdated](../app/models/package.rb) Docker packages |
+| Daily (midnight) | `packages:sync_missing` | [`Registry.sync_all_missing_packages_async`](../app/models/registry.rb) -- compares each registry's full package list against the database and syncs anything missing, capped per registry |
 
-A package is considered ["outdated"](../app/models/package.rb#L38) when `last_synced_at` is older than one month.
+A package is considered ["outdated"](../app/models/package.rb) when `last_synced_at` is older than one month. Batch sizes for each sweep are set in the linked methods and tuned against the per-registry throttle budgets described in [throttling.md](throttling.md), so they change as rate limits change.
 
 ## Sync throttling
 
-Sync jobs are capped per registry host so we don't overwhelm upstream services. Each registry can have a `rate_limit` (jobs per second) stored in its `metadata`; sidekiq-throttled enforces it at fetch time across all worker processes, and the periodic sweeps above cap their per-registry enqueue at what that limit can drain before the next tick. See [throttling.md](throttling.md) for how it works, which workers are covered, and how to tune a limit.
+Sync jobs are capped per registry host so we don't overwhelm upstream services. Each registry can have a `rate_limit` (jobs per second, fractional values allowed) stored in its `metadata`; sidekiq-throttled enforces it at fetch time across all worker processes, and the periodic sweeps above cap their per-registry enqueue at what that limit can drain before the next tick. See [throttling.md](throttling.md) for how it works, which workers are covered, and how to tune a limit.
 
 Separately, several checks prevent redundant syncing of the same package:
 
 - [`Package#sync_async`](../app/models/package.rb#L310) skips the job entirely if the package was synced in the last 24 hours.
 - [`Registry#sync_package`](../app/models/registry.rb#L145) checks the same 24-hour window. If a recently-synced package is requested again, it schedules the sync to run after the 24 hours expire rather than dropping it.
 - [`recently_updated_package_names_excluding_recently_synced`](../app/models/registry.rb#L70) filters out packages synced in the last 10 minutes.
-- The catch-up sweeps and [`sync_download_counts_async`](../app/models/package.rb#L93) / [`sync_maintainers_async`](../app/models/package.rb#L101) check Sidekiq queue size and skip the tick if the queue is already backed up.
+- The catch-up sweeps and enrichment tasks check their target Sidekiq queue's size and skip the tick if it is already backed up.
 
 ## How packages are prioritised
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -6,9 +6,9 @@ Package syncs make HTTP requests to upstream registries, and several of those re
 
 [`sidekiq-throttled`](https://github.com/ixti/sidekiq-throttled) patches `Sidekiq::BasicFetch`. When a worker process pulls a job from redis, it checks the job's throttle strategy before running it. If the job is over its limit, it is pushed back onto its queue with a raw `redis.lpush` and a different job is fetched instead. The push does not go through `Sidekiq::Client`, so `sidekiq-unique-jobs` client middleware does not run and the job's `until_executed` lock stays intact rather than being deduped. The `:schedule` requeue mode would go through the client and lose the job, so the default `:enqueue` mode is used.
 
-A single shared strategy, `:registry_host`, is registered in [`config/initializers/sidekiq_throttled.rb`](../config/initializers/sidekiq_throttled.rb). Its threshold key is the host part of the registry's URL, so two registries whose URLs point at the same host share one bucket. Its limit is `registry.metadata['rate_limit']`, an integer number of jobs per second. When `rate_limit` is nil `sidekiq-throttled` short-circuits before any redis call and the job runs immediately, so unthrottled registries carry no overhead.
+A single shared strategy, `:registry_host`, is registered in [`config/initializers/sidekiq_throttled.rb`](../config/initializers/sidekiq_throttled.rb). Its threshold key is the host part of the registry's URL, so two registries whose URLs point at the same host share one bucket. Its rate is `registry.metadata['rate_limit']`, jobs per second; `sidekiq-throttled` takes a limit-per-period pair rather than a rate, so [`Registry`](../app/models/registry.rb) exposes helpers that translate one into the other. When `rate_limit` is nil the limit proc returns nil, `sidekiq-throttled` short-circuits before any redis call, and the job runs immediately, so unthrottled registries carry no overhead.
 
-The workers that share `:registry_host` all take `registry_id` as their first argument, which the strategy's `key_suffix` and `limit` procs read at fetch time via [`Registry.host_for`](../app/models/registry.rb) and [`Registry.rate_limit_for`](../app/models/registry.rb):
+The workers that share `:registry_host` all take `registry_id` as their first argument, which the strategy's procs read at fetch time:
 
 | Worker | Enqueued from |
 |---|---|
@@ -31,7 +31,7 @@ Rake tasks that call `Registry#sync_packages` directly (the non-async path used 
 Registry.find_by_name!('npmjs.org').update!(rate_limit: 3)
 ```
 
-`rate_limit` is stored in the registry's `metadata` json and validated as a positive integer, since sidekiq-throttled treats zero or negative as permanently throttled. Default limits for registries that have throttled us are set in [`db/seeds.rb`](../db/seeds.rb). Setting the value back to nil removes the cap:
+`rate_limit` is stored in the registry's `metadata` json and validated as a positive number (integer or float), since sidekiq-throttled treats zero or negative as permanently throttled. A float below 1 gives fewer than one job per second, useful for hosts that 429 even at one job per second. Default limits for registries that have throttled us are set in [`db/seeds.rb`](../db/seeds.rb); production values are tuned via the console and may differ. Setting the value back to nil removes the cap:
 
 ```ruby
 Registry.find_by_name!('npmjs.org').update!(rate_limit: nil)
@@ -39,10 +39,12 @@ Registry.find_by_name!('npmjs.org').update!(rate_limit: nil)
 
 ## Enqueue budget
 
-Throttled jobs go back onto their queue, so if crons enqueue more jobs for a rate-limited registry than that registry can drain before the next cron tick, the queue grows without bound. [`Registry#sync_budget(period)`](../app/models/registry.rb) returns `rate_limit * period` seconds (nil when unthrottled), and [`Registry#sync_one_percent_of_packages`](../app/models/registry.rb) caps its batch at that budget so a tick never adds more than can be processed by the next one. The cross-ecosystem sweeps in [`Package.sync_least_recent_async`](../app/models/package.rb), [`sync_least_recent_top_async`](../app/models/package.rb) and [`check_statuses_async`](../app/models/package.rb) skip the tick when the `:critical` queue is over 10,000 so a backlog from any source stops compounding.
+Throttled jobs go back onto their queue, so if crons enqueue more jobs for a rate-limited registry than that registry can drain before the next cron tick, the queue grows without bound. [`Registry#sync_budget(period)`](../app/models/registry.rb) returns the number of jobs a registry's throttle can drain over `period` (nil when unthrottled), and the per-registry enqueue paths cap their batches at that budget so a tick never adds more than can be processed by the next one.
+
+Throttled registries still receive jobs from more than one cron, and each cron sizes its batch against the throttle independently, so their combined inflow can exceed a single registry's drain rate. To keep that from compounding, the broad stale-package sweep excludes throttled registries entirely, and the remaining sweeps skip a tick when their target queue is already over its guard threshold.
 
 ## Metrics
 
-Every outbound Faraday request emits a `request.faraday` notification, which [`config/initializers/faraday.rb`](../config/initializers/faraday.rb) turns into two AppSignal custom metrics: `registry_http_requests` (counter, tagged `host` and `status`) and `registry_http_duration` (distribution, tagged `host`). The "Registry outbound HTTP" AppSignal dashboard graphs successful requests, 429s, 4xx/5xx errors, connection failures and p95 duration per host.
+Every outbound Faraday request emits a `request.faraday` notification, which [`config/initializers/faraday.rb`](../config/initializers/faraday.rb) turns into two AppSignal custom metrics: `registry_http_requests` (counter, tagged `host` and `status`) and `registry_http_duration` (distribution, tagged `host`). The "Registry outbound HTTP" AppSignal dashboard graphs successful requests, 429s, 4xx/5xx errors, connection failures and p95 duration per host. The 429 series is the signal for whether a `rate_limit` is set correctly: a host serving 429s needs a lower value, and a host that has been 429-free for a while is a candidate for a higher one.
 
-`sidekiq_queue_latency` and `sidekiq_queue_length` for the `:critical` queue show whether throttled jobs are backing up. If `:critical` latency climbs steadily across cron ticks, either a registry's `rate_limit` is set below what its share of the periodic sweeps enqueues, or a cron is enqueueing more than the budget cap accounts for.
+`sidekiq_queue_length` for `:critical` shows whether throttled jobs are backing up. Because `sidekiq-throttled` requeues an over-limit job with its original `enqueued_at` intact, `sidekiq_queue_latency` on that queue reports the age of the oldest requeued job rather than time-to-first-run, so a steady non-zero length with a bouncing latency is the throttle working as intended. A length that climbs across cron ticks without falling back means a cron is enqueueing more than the budget cap accounts for.


### PR DESCRIPTION
Catch the docs up with the recent enqueue-budget and fractional `rate_limit` changes.

`throttling.md`: `rate_limit` now accepts floats, `Registry` translates the stored jobs-per-second value to sidekiq-throttled's limit/period pair, and `sync_budget` caps the per-registry enqueue paths. Removed the hardcoded queue-guard threshold and described the guard generically. Added a note that `sidekiq_queue_latency` on `:critical` now reports oldest-requeued-job age rather than time-to-run, and that the 429 series on the outbound HTTP dashboard is the signal for tuning `rate_limit`.

`syncing.md`: added the `sync_recent_pypi` cron row, dropped hardcoded batch sizes from the catch-up sweep table (they're tuned against throttle budgets and change), dropped stale line-number anchors from the rows being edited, and noted that `rate_limit` accepts fractional values.