### PR TITLE
Append index.html to Maven directory URLs on the Google mirror

### DIFF
--- a/app/models/ecosystem/maven.rb
+++ b/app/models/ecosystem/maven.rb
@@ -17,7 +17,7 @@ module Ecosystem
 
     def check_status_url(package)
       group_id, artifact_id = *package.name.split(':', 2)
-      "#{@registry_url}/#{group_id.gsub(".", "/")}/#{artifact_id}/"
+      directory_listing_url(group_id, artifact_id)
     end
 
     def download_url(package, version)
@@ -191,7 +191,7 @@ module Ecosystem
     end
 
     def fetch_versions_from_html_directory(group_id, artifact_id)
-      directory_url = "#{@registry_url}/#{group_id.gsub(".", "/")}/#{artifact_id}/"
+      directory_url = directory_listing_url(group_id, artifact_id)
       Rails.logger.info "Fetching versions from HTML directory: #{directory_url}"
       html = get_html(directory_url)
 
@@ -627,6 +627,13 @@ module Ecosystem
       "https://repo1.maven.org/maven2",
       "https://maven-central.storage-download.googleapis.com/maven2"
     ].freeze
+
+    MAVEN_CENTRAL_GCS_MIRROR = "https://maven-central.storage-download.googleapis.com/maven2"
+
+    def directory_listing_url(group_id, artifact_id)
+      base = "#{@registry_url}/#{group_id.gsub(".", "/")}/#{artifact_id}/"
+      @registry_url == MAVEN_CENTRAL_GCS_MIRROR ? "#{base}index.html" : base
+    end
 
     private
 

--- a/test/models/ecosystem/maven_test.rb
+++ b/test/models/ecosystem/maven_test.rb
@@ -630,4 +630,32 @@ class MavenTest < ActiveSupport::TestCase
     r = Registry.new(url: 'https://maven-central.storage-download.googleapis.com/maven2', name: 'x', ecosystem: 'maven')
     assert Ecosystem::Maven.new(r).send(:is_maven_central?)
   end
+
+  test 'check_status_url on the Google mirror appends index.html' do
+    r = Registry.new(url: 'https://maven-central.storage-download.googleapis.com/maven2', name: 'x', ecosystem: 'maven')
+    eco = Ecosystem::Maven.new(r)
+    assert_equal "https://maven-central.storage-download.googleapis.com/maven2/dev/zio/zio-aws-autoscaling_3/index.html", eco.check_status_url(@package)
+  end
+
+  test 'check_status_url on a non-mirror registry uses the bare directory url' do
+    r = Registry.new(url: 'https://repository.jboss.org/nexus/content/repositories/releases', name: 'jboss', ecosystem: 'maven')
+    eco = Ecosystem::Maven.new(r)
+    assert_equal "https://repository.jboss.org/nexus/content/repositories/releases/dev/zio/zio-aws-autoscaling_3/", eco.check_status_url(@package)
+  end
+
+  test 'HTML directory listing fallback on the Google mirror fetches index.html' do
+    r = Registry.new(url: 'https://maven-central.storage-download.googleapis.com/maven2', name: 'x', ecosystem: 'maven')
+    eco = Ecosystem::Maven.new(r)
+
+    stub_request(:get, "https://maven-central.storage-download.googleapis.com/maven2/net/jcip/jcip-annotations/maven-metadata.xml")
+      .to_raise(Faraday::ResourceNotFound.new(nil, { status: 404 }))
+    stub_request(:get, "https://maven-central.storage-download.googleapis.com/maven2/net/jcip/jcip-annotations/index.html")
+      .to_return(status: 200, body: '<html><body><pre><a href=../>../</a><a href="1.0/">1.0/</a></pre></body></html>')
+    stub_request(:get, "https://maven-central.storage-download.googleapis.com/maven2/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.pom")
+      .to_return(status: 200, body: file_fixture('maven/jcip-annotations-1.0.pom'), headers: { 'last-modified' => 'Thu, 14 Aug 2008 02:49:00 GMT' })
+
+    package_metadata = eco.package_metadata('net.jcip:jcip-annotations')
+    assert_equal ['1.0'], package_metadata[:versions]
+    assert_not_requested :get, "https://maven-central.storage-download.googleapis.com/maven2/net/jcip/jcip-annotations/"
+  end
 end


### PR DESCRIPTION
The Google Maven Central mirror is a GCS bucket. It returns 404 for bare artifact directory paths because GCS only serves objects, but it does store the same directory-listing HTML repo1 generates as an explicit `index.html` object under each path — verified for both a normal artifact and `net.jcip:jcip-annotations` (which has no `maven-metadata.xml`). A HEAD on `.../index.html` returns 200 for artifacts that exist and 404 for ones that don't.

`check_status_url` and `fetch_versions_from_html_directory` both build directory URLs from `@registry_url`, so after switching Central to the mirror in #1785:

- `Base#check_status` HEADs the directory, gets 404, and returns `'removed'`. `check_status` runs at the end of every `sync_package` and hourly via `check_statuses_async`, so maven packages were being marked removed on sync — 37,837 since the mirror switch.
- The HTML directory-listing fallback for packages without `maven-metadata.xml` always fails, `package_metadata` returns `{}`, and `sync_package` bails without updating `last_synced_at`, so those packages stay in the `outdated` scope and re-enter every sweep.

`directory_listing_url(group_id, artifact_id)` appends `index.html` when `@registry_url` is the GCS mirror and returns the bare directory URL otherwise. `check_status_url` and `fetch_versions_from_html_directory` now use it; all other fetches (maven-metadata.xml, POMs, sha1 sidecars) continue to hit the mirror unchanged. No requests go to `repo1.maven.org`.

Data repair for the incorrectly-removed packages will follow via console once this is deployed.