### PR TITLE
Cap Helm new-version fetches per sync and skip failed versions

### DIFF
--- a/app/models/ecosystem/helm.rb
+++ b/app/models/ecosystem/helm.rb
@@ -148,6 +148,8 @@ module Ecosystem
       }
     end
 
+    NEW_VERSIONS_PER_SYNC = 5
+
     def versions_metadata(pkg_metadata, existing_version_numbers = [])
       return [] unless pkg_metadata[:versions]
       parts = pkg_metadata[:name].to_s.split('/')
@@ -156,8 +158,14 @@ module Ecosystem
       pkg_metadata[:versions]
         .select { |v| v['version'].present? }
         .reject { |v| existing_version_numbers.include?(v['version']) }
-        .map do |version|
-          content_url = fetch_content_url(repository, name, version['version']) if repository && name
+        .sort_by { |v| -v['ts'].to_i }
+        .first(NEW_VERSIONS_PER_SYNC)
+        .filter_map do |version|
+          if repository && name
+            details = fetch_version_details(repository, name, version['version'])
+            next if details.nil?
+            content_url = details['content_url'].presence
+          end
           {
             number: version['version'],
             published_at: version['ts'] ? Time.at(version['ts']).utc : nil,

--- a/test/models/ecosystem/helm_test.rb
+++ b/test/models/ecosystem/helm_test.rb
@@ -251,4 +251,27 @@ class HelmTest < ActiveSupport::TestCase
     assert_equal [], @ecosystem.dependencies_metadata('foo/bar', '1.0.0', nil)
     assert_requested :get, "https://artifacthub.io/api/v1/packages/helm/foo/bar/1.0.0", times: 1
   end
+
+  test 'versions_metadata caps at NEW_VERSIONS_PER_SYNC newest versions' do
+    versions = (1..8).map { |i| { 'version' => "1.#{i}.0", 'ts' => 1_700_000_000 + i } }
+    pkg = { name: 'foo/bar', versions: versions, licenses: 'MIT' }
+    result = @ecosystem.versions_metadata(pkg)
+    assert_equal Ecosystem::Helm::NEW_VERSIONS_PER_SYNC, result.length
+    assert_equal ['1.8.0', '1.7.0', '1.6.0', '1.5.0', '1.4.0'], result.map { |v| v[:number] }
+  end
+
+  test 'versions_metadata applies the cap after excluding existing versions' do
+    versions = (1..8).map { |i| { 'version' => "1.#{i}.0", 'ts' => 1_700_000_000 + i } }
+    pkg = { name: 'foo/bar', versions: versions, licenses: 'MIT' }
+    result = @ecosystem.versions_metadata(pkg, ['1.8.0', '1.7.0', '1.6.0', '1.5.0', '1.4.0'])
+    assert_equal ['1.3.0', '1.2.0', '1.1.0'], result.map { |v| v[:number] }
+  end
+
+  test 'versions_metadata drops versions whose per-version fetch failed' do
+    stub_request(:get, "https://artifacthub.io/api/v1/packages/helm/foo/bar/2.0.0")
+      .to_return(status: 429, body: '')
+    pkg = { name: 'foo/bar', versions: [{ 'version' => '1.0.0', 'ts' => 100 }, { 'version' => '2.0.0', 'ts' => 200 }], licenses: 'MIT' }
+    result = @ecosystem.versions_metadata(pkg)
+    assert_equal ['1.0.0'], result.map { |v| v[:number] }
+  end
 end


### PR DESCRIPTION
artifacthub is still 429ing at `rate_limit=0.5` because the throttle bounds job starts, not requests, and each helm sync fetches `/api/v1/packages/helm/{repo}/{name}/{version}` for every version not already stored. CI-published charts with hundreds of releases (kubeblocks/kb-cloud-bootstrapper 508, openclaw/openclaw 434, kube-prometheus-stack 799 in the fixture) burst hundreds of unpaced requests from a single job.

Because `fetch_version_details` caches a failed fetch as `nil`, `versions_metadata` was still returning those versions with `content_url: nil` and `dependencies_metadata` returned `[]`, so they were inserted and never refetched — 17,625 helm versions are currently stored with nil `content_url`.

`versions_metadata` now sorts new versions by `ts` descending, takes the first `NEW_VERSIONS_PER_SYNC` (5), and drops any whose per-version fetch returned nil so they stay out of `existing_version_numbers` and retry on the next sync. `dependencies_metadata` is only called for versions that `versions_metadata` returned, so it's bounded by the same cap and reuses the cached fetch. Peak requests per job is `1 + NEW_VERSIONS_PER_SYNC` regardless of chart size; older uncaptured versions backfill on subsequent syncs.

The existing 17,625 nil-`content_url` versions and 4,086 orphaned helm `Version` rows (package deleted, versions remain) need separate cleanup.