### PR TITLE
Return false from check_status on error and preserve status when it does

### DIFF
--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -92,7 +92,7 @@ module Ecosystem
         URI.parse(url)
       rescue URI::InvalidURIError => e
         Rails.logger.warn("Invalid URI for package #{package.id} (#{package.name}): #{url} - #{e.message}")
-        return nil
+        return false
       end
 
       connection = Faraday.new(url) do |faraday|
@@ -107,7 +107,7 @@ module Ecosystem
       "removed" if [400, 404, 410].include?(response.status)
     rescue => e
       Rails.logger.warn("Error checking status for package #{package.id} (#{package.name}): #{e.message}")
-      nil
+      false
     end
 
     def ecosystem_name(ecosystem)

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -104,7 +104,10 @@ module Ecosystem
       end
 
       response = connection.head(url)
-      "removed" if [400, 404, 410].include?(response.status)
+      return "removed" if [400, 404, 410].include?(response.status)
+      return nil if response.success?
+
+      false
     rescue => e
       Rails.logger.warn("Error checking status for package #{package.id} (#{package.name}): #{e.message}")
       false

--- a/app/models/ecosystem/pub.rb
+++ b/app/models/ecosystem/pub.rb
@@ -21,12 +21,17 @@ module Ecosystem
 
     def check_status(package)
       json = fetch_package_metadata(package.name)
-      return nil if json.present? && json.is_a?(Hash) && json["name"].present?
+      if json.present? && json.is_a?(Hash) && json["name"].present?
+        return json["isDiscontinued"] ? "discontinued" : nil
+      end
 
       # Fall back to a direct request if not cached
       url = check_status_url(package)
       response = Faraday.get(url)
       return "removed" if [400, 404, 410].include?(response.status)
+    rescue => e
+      Rails.logger.warn("Error checking status for pub package #{package.name}: #{e.message}")
+      false
     end
 
     def all_package_names

--- a/app/models/ecosystem/pub.rb
+++ b/app/models/ecosystem/pub.rb
@@ -29,6 +29,8 @@ module Ecosystem
       url = check_status_url(package)
       response = Faraday.get(url)
       return "removed" if [400, 404, 410].include?(response.status)
+
+      false
     rescue => e
       Rails.logger.warn("Error checking status for pub package #{package.name}: #{e.message}")
       false

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -487,7 +487,11 @@ class Package < ApplicationRecord
 
   def check_status
     result = registry.ecosystem_instance.check_status(self)
-    update(status: result || 'active', last_synced_at: Time.now)
+    if result == false
+      update_columns(last_synced_at: Time.now)
+    else
+      update(status: result || 'active', last_synced_at: Time.now)
+    end
   end
 
   def check_status_async

--- a/test/models/ecosystem/base_test.rb
+++ b/test/models/ecosystem/base_test.rb
@@ -75,6 +75,15 @@ class BaseTest < ActiveSupport::TestCase
     assert_nil status
   end
 
+  test 'check_status returns false for unsuccessful status' do
+    stub_request(:head, "https://example.com/package")
+      .to_return(status: 500)
+
+    @ecosystem.stubs(:check_status_url).returns('https://example.com/package')
+    status = @ecosystem.check_status(@package)
+    assert_equal false, status
+  end
+
   test 'check_status returns false on Faraday errors so status is left untouched' do
     stub_request(:head, "https://example.com/package")
       .to_raise(Faraday::ConnectionFailed.new('Connection failed'))

--- a/test/models/ecosystem/base_test.rb
+++ b/test/models/ecosystem/base_test.rb
@@ -13,7 +13,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_nil status
   end
 
-  test 'check_status returns nil when URL is invalid' do
+  test 'check_status returns false when URL is invalid' do
     # Create a package with an invalid URI in repository_url
     invalid_package = @registry.packages.create(
       ecosystem: 'test',
@@ -24,7 +24,7 @@ class BaseTest < ActiveSupport::TestCase
     # Mock check_status_url to return the invalid URL
     @ecosystem.stubs(:check_status_url).returns('https://MTAnalytics (#11070)')
     status = @ecosystem.check_status(invalid_package)
-    assert_nil status
+    assert_equal false, status
   end
 
   test 'check_status returns removed for 404 status' do
@@ -75,13 +75,13 @@ class BaseTest < ActiveSupport::TestCase
     assert_nil status
   end
 
-  test 'check_status handles Faraday errors gracefully' do
+  test 'check_status returns false on Faraday errors so status is left untouched' do
     stub_request(:head, "https://example.com/package")
       .to_raise(Faraday::ConnectionFailed.new('Connection failed'))
 
     @ecosystem.stubs(:check_status_url).returns('https://example.com/package')
     status = @ecosystem.check_status(@package)
-    assert_nil status
+    assert_equal false, status
   end
 
   test 'download_and_cache returns nil when wget fails to download' do

--- a/test/models/ecosystem/pub_test.rb
+++ b/test/models/ecosystem/pub_test.rb
@@ -130,4 +130,20 @@ class PubTest < ActiveSupport::TestCase
     assert_not_requested(:get, "https://pub.dev/packages/bloc")
     assert_not_requested(:head, "https://pub.dev/packages/bloc")
   end
+
+  test 'check_status returns discontinued when isDiscontinued is set' do
+    @ecosystem.stubs(:fetch_package_metadata).with('bloc').returns({ 'name' => 'bloc', 'isDiscontinued' => true })
+    assert_equal 'discontinued', @ecosystem.check_status(@package)
+  end
+
+  test 'check_status returns nil when isDiscontinued is false' do
+    @ecosystem.stubs(:fetch_package_metadata).with('bloc').returns({ 'name' => 'bloc', 'isDiscontinued' => false })
+    assert_nil @ecosystem.check_status(@package)
+  end
+
+  test 'check_status returns false when the request errors' do
+    @ecosystem.stubs(:fetch_package_metadata).with('bloc').returns(nil)
+    stub_request(:get, "https://pub.dev/packages/bloc").to_raise(Faraday::ConnectionFailed.new('boom'))
+    assert_equal false, @ecosystem.check_status(@package)
+  end
 end

--- a/test/models/ecosystem/pub_test.rb
+++ b/test/models/ecosystem/pub_test.rb
@@ -146,4 +146,16 @@ class PubTest < ActiveSupport::TestCase
     stub_request(:get, "https://pub.dev/packages/bloc").to_raise(Faraday::ConnectionFailed.new('boom'))
     assert_equal false, @ecosystem.check_status(@package)
   end
+
+  test 'check_status returns false when the metadata request errors but the package page exists' do
+    stub_request(:get, "https://pub.dev/api/packages/bloc").to_raise(Faraday::ConnectionFailed.new('boom'))
+    stub_request(:get, "https://pub.dev/packages/bloc").to_return(status: 200)
+    assert_equal false, @ecosystem.check_status(@package)
+  end
+
+  test 'check_status returns false when the package page request is unsuccessful' do
+    @ecosystem.stubs(:fetch_package_metadata).with('bloc').returns(nil)
+    stub_request(:get, "https://pub.dev/packages/bloc").to_return(status: 500)
+    assert_equal false, @ecosystem.check_status(@package)
+  end
 end

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -402,6 +402,14 @@ class PackageTest < ActiveSupport::TestCase
     assert @package.last_synced_at > 1.minute.ago
   end
 
+  test 'check_status leaves status untouched and stamps last_synced_at when ecosystem returns false' do
+    @package.update_columns(status: 'deprecated', last_synced_at: 2.months.ago)
+    @package.registry.ecosystem_instance.expects(:check_status).with(@package).returns(false)
+    @package.check_status
+    assert_equal 'deprecated', @package.reload.read_attribute(:status)
+    assert @package.last_synced_at > 1.minute.ago
+  end
+
   test 'dependent_packages returns packages that depend on this package' do
     dependent = @registry.packages.create(name: 'bar', ecosystem: @registry.ecosystem)
     dep_version = dependent.versions.create(number: '1.0.0')


### PR DESCRIPTION
`Package#check_status` wrote `status: result || 'active'` unconditionally, so when `ecosystem_instance.check_status` returned `nil` the package became `'active'`. `nil` covered both "checked, package exists" and "check failed" (rescue in `Base#check_status` and most overrides), so a transient error during `check_status` flipped a deprecated package to active for one cycle.

`Pub#check_status` also returned `nil` when the package existed, ignoring `isDiscontinued`, so the `discontinued` status set by `map_package_metadata` was overwritten to `active` at the end of every sync.

`Base#check_status` now returns `false` from its error paths (Faraday error and invalid URI); `Package#check_status` treats `false` as "could not determine" and only stamps `last_synced_at`, leaving `status` untouched. `nil` continues to mean "checked, package exists" and still becomes `'active'`, so removed packages that reappear still flip back.

`Pub#check_status` now returns `'discontinued'` when `isDiscontinued` is set, `nil` when it isn't, and `false` on error, so it's the source of truth for `discontinued` the same way npm/nuget/conan/go's `check_status` is for `deprecated`.

The remaining ecosystem overrides that rescue-to-nil keep their current behaviour and can move to `false` individually.