### PR TITLE
Fix repository metadata refresh sweep

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,8 +25,8 @@
       "schedule": "4,24,44 * * * *"
     },
     {
-      "command": "bundle exec rake packages:update_repo_metadata_async",
-      "schedule": "9,39 * * * *"
+      "command": "bundle exec rake packages:update_repo_metadata",
+      "schedule": "4,9,14,19,24,29,34,39,44,49,54,59 * * * *"
     },
     {
       "command": "bundle exec rake packages:check_statuses",

--- a/app/models/concerns/ecosystems_api_client.rb
+++ b/app/models/concerns/ecosystems_api_client.rb
@@ -1,6 +1,17 @@
 module EcosystemsApiClient
   extend ActiveSupport::Concern
 
+  class RequestError < StandardError
+    attr_reader :method, :status, :url
+
+    def initialize(url, status, method: 'GET')
+      @url = url
+      @status = status
+      @method = method
+      super("#{method} #{url} returned HTTP #{status}")
+    end
+  end
+
   class_methods do
     def ecosystems_api_get(url, options = {})
       response = Faraday.get(url) do |req|
@@ -10,7 +21,10 @@ module EcosystemsApiClient
         req.params = options[:params] if options[:params]
       end
       
-      return nil unless response.success?
+      unless response.success?
+        raise RequestError.new(url, response.status) if options[:raise_on_error]
+        return nil
+      end
       
       if options[:raw]
         response.body
@@ -18,6 +32,7 @@ module EcosystemsApiClient
         JSON.parse(response.body)
       end
     rescue JSON::ParserError, Faraday::Error
+      raise if options[:raise_on_error]
       nil
     end
 

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -9,6 +9,10 @@ class Package < ApplicationRecord
     stargazers_count
     forks_count
   ].freeze
+  REPO_METADATA_REFRESH_CURSOR_KEY = 'packages:update_repo_metadata:cursor'.freeze
+  REPO_METADATA_REFRESH_BATCH_SIZE = 400
+  REPO_METADATA_REFRESH_SCAN_SIZE = 100_000
+  REPO_METADATA_REFRESH_MAX_AGE = 1.month
   
   # Matches a name where any /-delimited segment is exactly "." or "..".
   # Such names generate URLs that CDNs and browsers normalise into other
@@ -503,7 +507,29 @@ class Package < ApplicationRecord
   end
 
   def self.update_repo_metadata_async
-    Package.with_repository_or_homepage_url.order('repo_metadata_updated_at DESC nulls first').limit(400).select('packages.id, packages.repository_url, packages.homepage').each(&:update_repo_metadata_async)
+    cursor = REDIS.get(REPO_METADATA_REFRESH_CURSOR_KEY).to_i
+    packages, next_cursor = repo_metadata_refresh_batch(after_id: cursor)
+    packages.each(&:update_repo_metadata_async)
+    REDIS.set(REPO_METADATA_REFRESH_CURSOR_KEY, next_cursor)
+  end
+
+  def self.repo_metadata_refresh_batch(after_id:, batch_size: REPO_METADATA_REFRESH_BATCH_SIZE, scan_size: REPO_METADATA_REFRESH_SCAN_SIZE)
+    max_id = maximum(:id)
+    return [[], 0] unless max_id
+
+    after_id = 0 if after_id >= max_id
+    scan_end = [after_id + scan_size, max_id].min
+    packages = with_repository_or_homepage_url
+      .where(id: (after_id + 1)..scan_end)
+      .where('repo_metadata_updated_at IS NULL OR repo_metadata_updated_at < ?', REPO_METADATA_REFRESH_MAX_AGE.ago)
+      .order(:id)
+      .limit(batch_size)
+      .select('packages.id, packages.repository_url, packages.homepage')
+      .to_a
+
+    next_cursor = packages.length == batch_size ? packages.last.id : scan_end
+    next_cursor = 0 if next_cursor >= max_id
+    [packages, next_cursor]
   end
 
   def update_repo_metadata_async
@@ -558,19 +584,27 @@ class Package < ApplicationRecord
   def fetch_repo_metadata
     return if repository_or_homepage_url.blank?
 
-    json = ecosystems_api_get('https://repos.ecosyste.ms/api/v1/repositories/lookup', params: { url: repository_or_homepage_url })
+    json = fetch_repo_metadata_lookup(repository_or_homepage_url)
+    return json if json
     
-    if json.nil?
-      # check for renamed repos
-      resp = Faraday.head(repository_or_homepage_url)
-      if resp.status == 301
-        json = ecosystems_api_get('https://repos.ecosyste.ms/api/v1/repositories/lookup', params: { url: resp.headers['location'] })
-      end
+    response = Faraday.head(repository_or_homepage_url)
+    if [301, 302, 307, 308].include?(response.status) && response.headers['location'].present?
+      return fetch_repo_metadata_lookup(response.headers['location']) || {}
     end
-    
-    json || {}
-  rescue
-    {}
+    return {} if response.success? || [400, 404, 405, 410, 422].include?(response.status)
+
+    raise EcosystemsApiClient::RequestError.new(repository_or_homepage_url, response.status, method: 'HEAD')
+  end
+
+  def fetch_repo_metadata_lookup(url)
+    ecosystems_api_get(
+      'https://repos.ecosyste.ms/api/v1/repositories/lookup',
+      params: { url: url },
+      raise_on_error: true
+    )
+  rescue EcosystemsApiClient::RequestError => error
+    raise unless [400, 404, 410, 422].include?(error.status)
+    nil
   end
 
   def fetch_tags

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -110,7 +110,7 @@ Beyond core package sync, several jobs enrich packages with data from other sour
 
 | Schedule | Task | What it does |
 |---|---|---|
-| Every 30 min | `packages:update_repo_metadata_async` | [`Package.update_repo_metadata_async`](../app/models/package.rb#L363) -- updates repo metadata for 400 packages (ordered by least recently updated) |
+| Every 5 min | `packages:update_repo_metadata` | [`Package.update_repo_metadata_async`](../app/models/package.rb#L505) scans a bounded ID range, queues up to 400 packages whose repo metadata is missing or over a month old, and stores its cursor in Redis |
 | Every 30 min | `packages:sync_maintainers` | [`Package.sync_maintainers_async`](../app/models/package.rb#L101) -- syncs maintainer data for up to 1000 packages in supported ecosystems |
 | Every 30 min | `packages:update_rankings` | [`Package.update_rankings_async`](../app/models/package.rb#L110) -- calculates ranking percentiles for up to 1000 unranked packages |
 | Hourly | `packages:update_advisories` | [`Package.update_advisories`](../app/models/package.rb#L754) -- fetches recently changed advisories and updates affected packages |

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -236,6 +236,129 @@ class PackageTest < ActiveSupport::TestCase
     ], @package.repo_funding_links
   end
 
+  test 'update_repo_metadata preserves its timestamp when the repository lookup is temporarily unavailable' do
+    repository_url = 'https://github.com/example/example'
+    previous_update = 2.days.ago
+    @package.update!(repository_url: repository_url, repo_metadata_updated_at: previous_update)
+
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+      .with(query: { url: repository_url })
+      .to_return(status: 500)
+
+    error = assert_raises(EcosystemsApiClient::RequestError) do
+      @package.update_repo_metadata
+    end
+
+    assert_equal 500, error.status
+    assert_in_delta previous_update, @package.reload.repo_metadata_updated_at, 1.second
+  end
+
+  test 'update_repo_metadata retries when redirect discovery is temporarily unavailable' do
+    repository_url = 'https://github.com/example/example'
+    previous_update = 2.days.ago
+    @package.update!(repository_url: repository_url, repo_metadata_updated_at: previous_update)
+
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+      .with(query: { url: repository_url })
+      .to_return(status: 404)
+    stub_request(:head, repository_url).to_return(status: 503)
+
+    error = assert_raises(EcosystemsApiClient::RequestError) do
+      @package.update_repo_metadata
+    end
+
+    assert_equal 503, error.status
+    assert_equal 'HEAD', error.method
+    assert_in_delta previous_update, @package.reload.repo_metadata_updated_at, 1.second
+  end
+
+  test 'update_repo_metadata stores a successful repository lookup and advances its timestamp' do
+    previous_update = 2.days.ago
+    metadata = {
+      'full_name' => 'example/example',
+      'host' => { 'name' => 'GitHub' }
+    }
+    @package.update!(repository_url: 'https://github.com/example/example', repo_metadata_updated_at: previous_update)
+    @package.stubs(:fetch_repo_metadata).returns(metadata)
+    @package.stubs(:fetch_tags).returns([])
+    @package.stubs(:fetch_owner).returns(nil)
+    @package.stubs(:ping_issues)
+    @package.stubs(:ping_commits)
+    @package.stubs(:update_issue_metadata)
+
+    @package.update_repo_metadata
+
+    assert_equal metadata.merge('tags' => []), @package.reload.repo_metadata
+    assert_operator @package.repo_metadata_updated_at, :>, previous_update
+  end
+
+  test 'repo_metadata_refresh_batch selects old and never-refreshed packages within a bounded id range' do
+    old_package = @registry.packages.create!(
+      name: 'old-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      repository_url: 'https://github.com/example/old',
+      repo_metadata_updated_at: 2.months.ago
+    )
+    never_refreshed_package = @registry.packages.create!(
+      name: 'missing-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      homepage: 'https://github.com/example/missing'
+    )
+    @registry.packages.create!(
+      name: 'fresh-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      repository_url: 'https://github.com/example/fresh',
+      repo_metadata_updated_at: Time.current
+    )
+
+    packages, next_cursor = Package.repo_metadata_refresh_batch(
+      after_id: @package.id,
+      batch_size: 400,
+      scan_size: 100_000
+    )
+
+    assert_equal [old_package.id, never_refreshed_package.id], packages.map(&:id)
+    assert_equal 0, next_cursor
+  end
+
+  test 'repo_metadata_refresh_batch resumes after the last selected package when the batch is full' do
+    first_package = @registry.packages.create!(
+      name: 'first-old-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      repository_url: 'https://github.com/example/first',
+      repo_metadata_updated_at: 2.months.ago
+    )
+    @registry.packages.create!(
+      name: 'second-old-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      repository_url: 'https://github.com/example/second',
+      repo_metadata_updated_at: 2.months.ago
+    )
+
+    packages, next_cursor = Package.repo_metadata_refresh_batch(
+      after_id: @package.id,
+      batch_size: 1,
+      scan_size: 100_000
+    )
+
+    assert_equal [first_package.id], packages.map(&:id)
+    assert_equal first_package.id, next_cursor
+  end
+
+  test 'update_repo_metadata_async persists its scan cursor after enqueueing the batch' do
+    package = @registry.packages.create!(
+      name: 'queued-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      repository_url: 'https://github.com/example/queued'
+    )
+    Package.stubs(:repo_metadata_refresh_batch).with(after_id: 123).returns([[package], 456])
+    REDIS.expects(:get).with(Package::REPO_METADATA_REFRESH_CURSOR_KEY).returns('123')
+    REDIS.expects(:set).with(Package::REPO_METADATA_REFRESH_CURSOR_KEY, 456)
+    package.expects(:update_repo_metadata_async)
+
+    Package.update_repo_metadata_async
+  end
+
   test 'registry_url' do
     assert_equal @package.registry_url, 'https://rubygems.org/gems/foo'
   end

--- a/test/tasks/packages_rake_test.rb
+++ b/test/tasks/packages_rake_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'rake'
+require 'json'
 
 class PackagesRakeTest < ActiveSupport::TestCase
   setup do
@@ -25,6 +26,22 @@ class PackagesRakeTest < ActiveSupport::TestCase
   test "should sync least recently synced packages" do
     Package.expects(:sync_least_recent_async).returns(:true)
     Rake::Task["packages:sync_least_recent"].invoke
+  end
+
+  test "scheduled rake tasks exist" do
+    app_config = JSON.parse(Rails.root.join('app.json').read)
+    scheduled_tasks = app_config.fetch('cron')
+    task_names = scheduled_tasks.filter_map do |entry|
+      entry.fetch('command')[/bundle exec rake ([^ ]+)/, 1]
+    end
+
+    missing_tasks = task_names.reject { |task_name| Rake::Task.task_defined?(task_name) }
+    repo_metadata_task = scheduled_tasks.find do |entry|
+      entry.fetch('command') == 'bundle exec rake packages:update_repo_metadata'
+    end
+
+    assert_empty missing_tasks
+    assert_equal '4,9,14,19,24,29,34,39,44,49,54,59 * * * *', repo_metadata_task.fetch('schedule')
   end
 
   test "backfills NuGet packages without verified metadata" do


### PR DESCRIPTION
Fixes #1793.

The scheduled repository metadata refresh referenced a nonexistent rake task and selected the newest timestamps after null rows. This changes the job to use a Redis-backed primary-key cursor over bounded ID ranges, retries transient repository lookup failures without advancing the timestamp, and runs the sweep every five minutes.

Production samples of the bounded selector took 4 to 189 ms without a new index.