### PR TITLE
Prevent permanent Sidekiq unique locks

### DIFF
--- a/app.json
+++ b/app.json
@@ -77,7 +77,7 @@
       "schedule": "0 0 */6 * *"
     },
     {
-      "command": "bundle exec rake packages:clean_up_sidekiq_unique_jobs",
+      "command": "bundle exec rake sidekiq:unique_jobs:audit_locks",
       "schedule": "0 0 * * 0"
     }
   ]

--- a/app/services/legacy_unique_job_locks.rb
+++ b/app/services/legacy_unique_job_locks.rb
@@ -1,0 +1,160 @@
+require "sidekiq/api"
+require "set"
+
+class LegacyUniqueJobLocks
+  AUDIT_CURSOR_KEY = "packages:legacy_unique_job_locks:audit_cursor".freeze
+  CLEANUP_CURSOR_KEY = "packages:legacy_unique_job_locks:cleanup_cursor".freeze
+  PRIMARY_LOCK_PATTERN = "uniquejobs:#{'?' * 32}".freeze
+  PRIMARY_LOCK_REGEX = /\Auniquejobs:[0-9a-f]{32}\z/.freeze
+  AUDIT_SCAN_COUNT = 5_000
+  DEFAULT_SCAN_COUNT = 1_000
+  MAX_SCAN_COUNT = 10_000
+  MAX_LIVE_JOBS = 10_000
+
+  class TooManyLiveJobs < StandardError
+  end
+
+  def self.audit(
+    redis: nil,
+    digests: SidekiqUniqueJobs::Digests.new,
+    expiring_digests: SidekiqUniqueJobs::ExpiringDigests.new
+  )
+    unless redis
+      return Sidekiq.redis do |connection|
+        audit(redis: connection, digests: digests, expiring_digests: expiring_digests)
+      end
+    end
+
+    primary = redis.scan("MATCH", PRIMARY_LOCK_PATTERN, "COUNT", AUDIT_SCAN_COUNT).count
+    indexed = digests.page(page_size: 1).first + expiring_digests.page(page_size: 1).first
+
+    {
+      primary: primary,
+      indexed: indexed,
+      unindexed_estimate: [primary - indexed, 0].max
+    }
+  end
+
+  def self.live_digests(max_jobs: MAX_LIVE_JOBS)
+    digests = Set.new
+    jobs_seen = 0
+    add_job = lambda do |job|
+      jobs_seen += 1
+      if jobs_seen > max_jobs
+        raise TooManyLiveJobs, "Live job scan exceeded the limit of #{max_jobs}"
+      end
+
+      add_job_digest(digests, job)
+    end
+
+    Sidekiq::ScheduledSet.new.each { |job| add_job.call(job) }
+    Sidekiq::RetrySet.new.each { |job| add_job.call(job) }
+    Sidekiq::Queue.all.each do |queue|
+      queue.each { |job| add_job.call(job) }
+    end
+    Sidekiq::WorkSet.new.each do |_process_id, _thread_id, work|
+      add_job.call(work.job)
+    end
+    # Cover jobs that moved from active execution into the retry set during the scan.
+    Sidekiq::RetrySet.new.each { |job| add_job.call(job) }
+
+    digests
+  end
+
+  def self.add_job_digest(digests, job)
+    digest = job.item["lock_digest"] || job.item["unique_digest"]
+    digest = digest.delete_suffix(":RUN") if digest
+    digests << digest if digest.present?
+  end
+
+  def initialize(redis: nil, live_digests: nil, deleter: SidekiqUniqueJobs::BatchDelete, apply: false, scan_count: DEFAULT_SCAN_COUNT)
+    @redis = redis
+    @provided_live_digests = live_digests
+    @deleter = deleter
+    @apply = apply
+    @scan_count = [[scan_count.to_i, 1].max, MAX_SCAN_COUNT].min
+  end
+
+  def call
+    return call_with_redis(@redis) if @redis
+
+    batch = Sidekiq.redis { |redis| scan_batch(redis) }
+    live_digests = live_digests_for(batch[:candidates])
+    Sidekiq.redis { |redis| finish_batch(redis, batch, live_digests) }
+  end
+
+  def call_with_redis(redis)
+    batch = scan_batch(redis)
+    live_digests = live_digests_for(batch[:candidates])
+    finish_batch(redis, batch, live_digests)
+  end
+
+  def scan_batch(redis)
+    cursor_key = @apply ? CLEANUP_CURSOR_KEY : AUDIT_CURSOR_KEY
+    cursor = redis.get(cursor_key).presence || "0"
+    next_cursor, keys = redis.call(
+      "SCAN",
+      cursor,
+      "MATCH",
+      PRIMARY_LOCK_PATTERN,
+      "COUNT",
+      @scan_count
+    )
+    keys.select! { |key| PRIMARY_LOCK_REGEX.match?(key) }
+    matched = keys.length
+    keys = keys.first(@scan_count)
+
+    {
+      cursor_key: cursor_key,
+      cursor: cursor,
+      next_cursor: next_cursor.to_s,
+      keys: keys,
+      matched: matched,
+      candidates: unindexed_permanent_keys(redis, keys)
+    }
+  end
+
+  def finish_batch(redis, batch, live_digests)
+    candidates = batch[:candidates].reject { |digest| live_digests.include?(digest) }
+    deleted = @apply && candidates.any? ? @deleter.call(candidates, redis) : 0
+    redis.set(batch[:cursor_key], batch[:next_cursor])
+    overflow = [batch[:matched] - batch[:keys].length, 0].max
+
+    {
+      cursor: batch[:cursor],
+      next_cursor: batch[:next_cursor],
+      scanned: batch[:keys].length,
+      matched: batch[:matched],
+      overflow: overflow,
+      complete: batch[:next_cursor] == "0" && overflow.zero?,
+      candidates: candidates.length,
+      deleted: deleted,
+      sample: candidates.first(10)
+    }
+  end
+
+  def live_digests_for(candidates)
+    return Set.new if candidates.empty?
+    return @provided_live_digests if @provided_live_digests
+
+    self.class.live_digests
+  end
+
+  def unindexed_permanent_keys(redis, keys)
+    statuses = redis.pipelined do |pipeline|
+      keys.each do |digest|
+        pipeline.pttl(digest)
+        pipeline.zscore(SidekiqUniqueJobs::DIGESTS, digest)
+        pipeline.zscore(SidekiqUniqueJobs::EXPIRING_DIGESTS, digest)
+      end
+    end
+
+    keys.each_with_index.filter_map do |digest, index|
+      ttl = statuses[index * 3]
+      digest_index_score = statuses[(index * 3) + 1]
+      expiring_index_score = statuses[(index * 3) + 2]
+      indexed = digest_index_score.present? || expiring_index_score.present?
+      digest if ttl == -1 && !indexed
+    end
+  end
+end

--- a/app/sidekiq/check_package_status_worker.rb
+++ b/app/sidekiq/check_package_status_worker.rb
@@ -1,7 +1,7 @@
 class CheckPackageStatusWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Job
-  sidekiq_options lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, package_id)

--- a/app/sidekiq/sync_maintainers_worker.rb
+++ b/app/sidekiq/sync_maintainers_worker.rb
@@ -1,6 +1,6 @@
 class SyncMaintainersWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     Package.find_by_id(package_id).try(:sync_maintainers)

--- a/app/sidekiq/sync_package_by_id_worker.rb
+++ b/app/sidekiq/sync_package_by_id_worker.rb
@@ -1,7 +1,7 @@
 class SyncPackageByIdWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Job
-  sidekiq_options queue: :critical, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :critical, lock: :until_executed, lock_ttl: 1.hour.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, package_id)

--- a/app/sidekiq/sync_package_version_worker.rb
+++ b/app/sidekiq/sync_package_version_worker.rb
@@ -3,7 +3,7 @@ class SyncPackageVersionWorker
   include Sidekiq::Throttled::Job
   sidekiq_options queue: :low,
                   lock: :until_executed,
-                  lock_expiration: 1.hour.to_i
+                  lock_ttl: 1.hour.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, name, version)

--- a/app/sidekiq/sync_package_worker.rb
+++ b/app/sidekiq/sync_package_worker.rb
@@ -1,7 +1,7 @@
 class SyncPackageWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Job
-  sidekiq_options queue: :critical, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :critical, lock: :until_executed, lock_ttl: 1.hour.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, name, force = false)

--- a/app/sidekiq/update_advisories_worker.rb
+++ b/app/sidekiq/update_advisories_worker.rb
@@ -1,6 +1,6 @@
 class UpdateAdvisoriesWorker
   include Sidekiq::Worker
-  sidekiq_options lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     Package.find_by_id(package_id).try(:update_advisories)

--- a/app/sidekiq/update_dependent_packages_count_worker.rb
+++ b/app/sidekiq/update_dependent_packages_count_worker.rb
@@ -1,6 +1,6 @@
 class UpdateDependentPackagesCountWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     # TODO noop empty whilst emptying the queue

--- a/app/sidekiq/update_dependent_repos_count_worker.rb
+++ b/app/sidekiq/update_dependent_repos_count_worker.rb
@@ -1,6 +1,6 @@
 class UpdateDependentReposCountWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     # TODO noop empty whilst emptying the queue

--- a/app/sidekiq/update_integrity_worker.rb
+++ b/app/sidekiq/update_integrity_worker.rb
@@ -1,6 +1,6 @@
 class UpdateIntegrityWorker
   include Sidekiq::Worker
-  sidekiq_options lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(version_id)
     Version.find_by_id(version_id).try(:update_integrity)

--- a/app/sidekiq/update_rankings_worker.rb
+++ b/app/sidekiq/update_rankings_worker.rb
@@ -1,6 +1,6 @@
 class UpdateRankingsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     Package.find_by_id(package_id).try(:update_rankings)

--- a/app/sidekiq/update_repo_metadata_worker.rb
+++ b/app/sidekiq/update_repo_metadata_worker.rb
@@ -1,6 +1,6 @@
 class UpdateRepoMetadataWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low, lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     Package.find_by_id(package_id).try(:update_repo_metadata)

--- a/app/sidekiq/update_versions_worker.rb
+++ b/app/sidekiq/update_versions_worker.rb
@@ -1,6 +1,6 @@
 class UpdateVersionsWorker
   include Sidekiq::Worker
-  sidekiq_options lock: :until_executed, lock_expiration: 1.hour.to_i
+  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(package_id)
     Package.find_by_id(package_id).try(:update_versions)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 SidekiqUniqueJobs.configure do |config|
+  config.lock_ttl        = 1.hour.to_i
   config.reaper          = :ruby
   config.reaper_count    = 2_000
   config.reaper_interval = 60

--- a/lib/tasks/packages.rake
+++ b/lib/tasks/packages.rake
@@ -219,14 +219,6 @@ namespace :packages do
     end
   end
 
-  desc 'clean up sidekiq unique jobs'
-  task clean_up_sidekiq_unique_jobs: :environment do
-    with_rake_lock('packages:clean_up_sidekiq_unique_jobs') do
-      SidekiqUniqueJobs::Digests.new.delete_by_pattern("*", count: 10_000)
-      SidekiqUniqueJobs::ExpiringDigests.new.delete_by_pattern("*", count: 10_000)
-    end
-  end
-
   desc 'report upstream ecosystem groupings for nixpkgs packages'
   task nixpkgs_upstream_ecosystems: :environment do
     registry = Registry.where(ecosystem: 'nixpkgs').order(packages_count: :desc).first

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -49,5 +49,19 @@ namespace :sidekiq do
         puts "Done."
       end
     end
+
+    desc "Report indexed and legacy unindexed unique job locks"
+    task audit_locks: :environment do
+      puts LegacyUniqueJobLocks.audit.to_json
+    end
+
+    desc "Inspect or delete one bounded batch of legacy unindexed locks"
+    task clean_legacy_locks: :environment do
+      apply = ENV["APPLY"] == "true"
+      scan_count = ENV.fetch("COUNT", LegacyUniqueJobLocks::DEFAULT_SCAN_COUNT).to_i
+      result = LegacyUniqueJobLocks.new(apply: apply, scan_count: scan_count).call
+
+      puts result.to_json
+    end
   end
 end

--- a/test/services/legacy_unique_job_locks_test.rb
+++ b/test/services/legacy_unique_job_locks_test.rb
@@ -1,0 +1,196 @@
+require "test_helper"
+
+class LegacyUniqueJobLocksTest < ActiveSupport::TestCase
+  setup do
+    @redis = mock
+    @digests = mock
+    @expiring_digests = mock
+    @deleter = mock
+  end
+
+  test "audit compares primary lock keys with the digest index" do
+    scan = mock
+    scan.expects(:count).returns(120)
+    @redis.expects(:scan).with(
+      "MATCH",
+      LegacyUniqueJobLocks::PRIMARY_LOCK_PATTERN,
+      "COUNT",
+      LegacyUniqueJobLocks::AUDIT_SCAN_COUNT
+    ).returns(scan)
+    @digests.expects(:page).with(page_size: 1).returns([5, 0, []])
+    @expiring_digests.expects(:page).with(page_size: 1).returns([2, 0, []])
+
+    result = LegacyUniqueJobLocks.audit(
+      redis: @redis,
+      digests: @digests,
+      expiring_digests: @expiring_digests
+    )
+
+    assert_equal({ primary: 120, indexed: 7, unindexed_estimate: 113 }, result)
+  end
+
+  test "dry run reports only unindexed permanent locks without live jobs" do
+    orphan = "uniquejobs:#{'a' * 32}"
+    expiring = "uniquejobs:#{'b' * 32}"
+    indexed = "uniquejobs:#{'c' * 32}"
+    live = "uniquejobs:#{'d' * 32}"
+    expiring_indexed = "uniquejobs:#{'e' * 32}"
+    pipeline = mock
+
+    @redis.expects(:get).with(LegacyUniqueJobLocks::AUDIT_CURSOR_KEY).returns("12")
+    @redis.expects(:call).with(
+      "SCAN",
+      "12",
+      "MATCH",
+      LegacyUniqueJobLocks::PRIMARY_LOCK_PATTERN,
+      "COUNT",
+      1_000
+    ).returns(["42", [orphan, expiring, indexed, live, expiring_indexed]])
+    [orphan, expiring, indexed, live, expiring_indexed].each do |digest|
+      pipeline.expects(:pttl).with(digest)
+      pipeline.expects(:zscore).with(SidekiqUniqueJobs::DIGESTS, digest)
+      pipeline.expects(:zscore).with(SidekiqUniqueJobs::EXPIRING_DIGESTS, digest)
+    end
+    @redis.expects(:pipelined).yields(pipeline).returns([
+      -1, nil, nil,
+      5_000, nil, nil,
+      -1, "123", nil,
+      -1, nil, nil,
+      -1, nil, "456"
+    ])
+    @redis.expects(:set).with(LegacyUniqueJobLocks::AUDIT_CURSOR_KEY, "42")
+    @deleter.expects(:call).never
+
+    result = LegacyUniqueJobLocks.new(
+      redis: @redis,
+      live_digests: Set[live],
+      deleter: @deleter,
+      scan_count: 1_000
+    ).call
+
+    assert_equal 5, result[:scanned]
+    assert_equal 1, result[:candidates]
+    assert_equal 0, result[:deleted]
+    assert_equal [orphan], result[:sample]
+    assert_equal "42", result[:next_cursor]
+    assert_not result[:complete]
+  end
+
+  test "apply deletes a bounded batch and uses a separate cursor" do
+    orphan = "uniquejobs:#{'a' * 32}"
+    pipeline = mock
+
+    @redis.expects(:get).with(LegacyUniqueJobLocks::CLEANUP_CURSOR_KEY).returns(nil)
+    @redis.expects(:call).with(
+      "SCAN",
+      "0",
+      "MATCH",
+      LegacyUniqueJobLocks::PRIMARY_LOCK_PATTERN,
+      "COUNT",
+      LegacyUniqueJobLocks::DEFAULT_SCAN_COUNT
+    ).returns(["8", [orphan]])
+    pipeline.expects(:pttl).with(orphan)
+    pipeline.expects(:zscore).with(SidekiqUniqueJobs::DIGESTS, orphan)
+    pipeline.expects(:zscore).with(SidekiqUniqueJobs::EXPIRING_DIGESTS, orphan)
+    @redis.expects(:pipelined).yields(pipeline).returns([-1, nil, nil])
+    @deleter.expects(:call).with([orphan], @redis).returns(1)
+    @redis.expects(:set).with(LegacyUniqueJobLocks::CLEANUP_CURSOR_KEY, "8")
+
+    result = LegacyUniqueJobLocks.new(
+      redis: @redis,
+      live_digests: Set.new,
+      deleter: @deleter,
+      apply: true
+    ).call
+
+    assert_equal 1, result[:deleted]
+    assert_equal [orphan], result[:sample]
+  end
+
+  test "live digests include queued scheduled retry and active jobs" do
+    queue = [stub(item: { "lock_digest" => "queued" })]
+    scheduled = [stub(item: { "unique_digest" => "scheduled" })]
+    retried = [stub(item: { "lock_digest" => "retried" })]
+    active_job = stub(item: { "lock_digest" => "active:RUN" })
+    work = stub(job: active_job)
+
+    Sidekiq::Queue.stubs(:all).returns([queue])
+    Sidekiq::ScheduledSet.stubs(:new).returns(scheduled)
+    Sidekiq::RetrySet.stubs(:new).returns(retried)
+    Sidekiq::WorkSet.stubs(:new).returns([["process", "thread", work]])
+
+    assert_equal Set["queued", "scheduled", "retried", "active"], LegacyUniqueJobLocks.live_digests
+  end
+
+  test "live digest scan stops at its safety limit" do
+    queue = [stub(item: {}), stub(item: {})]
+
+    Sidekiq::ScheduledSet.stubs(:new).returns([])
+    Sidekiq::RetrySet.stubs(:new).returns([])
+    Sidekiq::Queue.stubs(:all).returns([queue])
+    Sidekiq::WorkSet.stubs(:new).returns([])
+
+    assert_raises(LegacyUniqueJobLocks::TooManyLiveJobs) do
+      LegacyUniqueJobLocks.live_digests(max_jobs: 1)
+    end
+  end
+
+  test "batch without permanent unindexed locks skips the live job scan" do
+    expiring = "uniquejobs:#{'a' * 32}"
+    pipeline = mock
+
+    @redis.expects(:get).with(LegacyUniqueJobLocks::AUDIT_CURSOR_KEY).returns(nil)
+    @redis.expects(:call).with(
+      "SCAN",
+      "0",
+      "MATCH",
+      LegacyUniqueJobLocks::PRIMARY_LOCK_PATTERN,
+      "COUNT",
+      LegacyUniqueJobLocks::DEFAULT_SCAN_COUNT
+    ).returns(["0", [expiring]])
+    pipeline.expects(:pttl).with(expiring)
+    pipeline.expects(:zscore).with(SidekiqUniqueJobs::DIGESTS, expiring)
+    pipeline.expects(:zscore).with(SidekiqUniqueJobs::EXPIRING_DIGESTS, expiring)
+    @redis.expects(:pipelined).yields(pipeline).returns([5_000, nil, nil])
+    @redis.expects(:set).with(LegacyUniqueJobLocks::AUDIT_CURSOR_KEY, "0")
+    LegacyUniqueJobLocks.expects(:live_digests).never
+
+    result = LegacyUniqueJobLocks.new(redis: @redis).call
+
+    assert_equal 0, result[:candidates]
+    assert result[:complete]
+  end
+
+  test "scan results are capped even when Redis returns more than COUNT" do
+    keys = %w[a b c].map { |letter| "uniquejobs:#{letter * 32}" }
+    pipeline = mock
+
+    @redis.expects(:get).with(LegacyUniqueJobLocks::AUDIT_CURSOR_KEY).returns(nil)
+    @redis.expects(:call).with(
+      "SCAN",
+      "0",
+      "MATCH",
+      LegacyUniqueJobLocks::PRIMARY_LOCK_PATTERN,
+      "COUNT",
+      2
+    ).returns(["0", keys])
+    keys.first(2).each do |digest|
+      pipeline.expects(:pttl).with(digest)
+      pipeline.expects(:zscore).with(SidekiqUniqueJobs::DIGESTS, digest)
+      pipeline.expects(:zscore).with(SidekiqUniqueJobs::EXPIRING_DIGESTS, digest)
+    end
+    @redis.expects(:pipelined).yields(pipeline).returns([-1, nil, nil, -1, nil, nil])
+    @redis.expects(:set).with(LegacyUniqueJobLocks::AUDIT_CURSOR_KEY, "0")
+
+    result = LegacyUniqueJobLocks.new(
+      redis: @redis,
+      live_digests: Set.new,
+      scan_count: 2
+    ).call
+
+    assert_equal 2, result[:scanned]
+    assert_equal 3, result[:matched]
+    assert_equal 1, result[:overflow]
+    assert_not result[:complete]
+  end
+end

--- a/test/sidekiq/unique_job_options_test.rb
+++ b/test/sidekiq/unique_job_options_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class UniqueJobOptionsTest < ActiveSupport::TestCase
+  def unique_workers
+    Rails.root.glob("app/sidekiq/*_worker.rb").filter_map do |path|
+      worker = path.basename(".rb").to_s.camelize.constantize
+      worker if worker.get_sidekiq_options["lock"]
+    end
+  end
+
+  test "unique jobs have a global lock ttl" do
+    assert_equal 1.hour.to_i, SidekiqUniqueJobs.config.lock_ttl
+  end
+
+  test "unique workers use the current lock ttl option" do
+    assert_predicate unique_workers, :any?
+
+    unique_workers.each do |worker|
+      options = worker.get_sidekiq_options
+
+      assert_equal 1.hour.to_i, options["lock_ttl"], worker.name
+      assert_not options.key?("lock_expiration"), worker.name
+    end
+  end
+
+  test "prepared unique jobs retain a positive lock ttl" do
+    unique_workers.each do |worker|
+      options = worker.get_sidekiq_options
+      item = {
+        "class" => worker.name,
+        "queue" => options["queue"],
+        "args" => [1]
+      }
+
+      SidekiqUniqueJobs::Job.prepare(item)
+
+      assert_equal 1.hour.to_i, item["lock_ttl"], worker.name
+    end
+  end
+end

--- a/test/tasks/sidekiq_unique_jobs_rake_test.rb
+++ b/test/tasks/sidekiq_unique_jobs_rake_test.rb
@@ -33,4 +33,43 @@ class SidekiqUniqueJobsRakeTest < ActiveSupport::TestCase
   ensure
     ENV.delete("PATTERN")
   end
+
+  test "audit_locks reports indexed and unindexed lock counts" do
+    result = { primary: 120, indexed: 5, unindexed_estimate: 115 }
+    LegacyUniqueJobLocks.expects(:audit).returns(result)
+
+    output, = capture_io { Rake::Task["sidekiq:unique_jobs:audit_locks"].execute }
+
+    assert_equal result.stringify_keys, JSON.parse(output)
+  end
+
+  test "clean_legacy_locks is a bounded dry run by default" do
+    cleanup = mock
+    result = { cursor: "0", next_cursor: "42", scanned: 1_000, candidates: 900, deleted: 0 }
+    LegacyUniqueJobLocks.expects(:new).with(
+      apply: false,
+      scan_count: LegacyUniqueJobLocks::DEFAULT_SCAN_COUNT
+    ).returns(cleanup)
+    cleanup.expects(:call).returns(result)
+
+    output, = capture_io { Rake::Task["sidekiq:unique_jobs:clean_legacy_locks"].execute }
+
+    assert_equal result.stringify_keys, JSON.parse(output)
+  end
+
+  test "clean_legacy_locks applies an explicit batch size" do
+    ENV["APPLY"] = "true"
+    ENV["COUNT"] = "2500"
+    cleanup = mock
+    result = { cursor: "42", next_cursor: "81", scanned: 2_500, candidates: 2_000, deleted: 2_000 }
+    LegacyUniqueJobLocks.expects(:new).with(apply: true, scan_count: 2_500).returns(cleanup)
+    cleanup.expects(:call).returns(result)
+
+    output, = capture_io { Rake::Task["sidekiq:unique_jobs:clean_legacy_locks"].execute }
+
+    assert_equal result.stringify_keys, JSON.parse(output)
+  ensure
+    ENV.delete("APPLY")
+    ENV.delete("COUNT")
+  end
 end


### PR DESCRIPTION
Adds a global one-hour unique lock TTL and updates workers to use `lock_ttl`. Replaces the weekly blanket lock deletion with a read-only audit, and adds a cursor-based cleanup for legacy permanent locks that dry-runs unless `APPLY=true` and refuses unbounded live-job scans. Follow-up to #1793.