### PR TITLE
Keep unique locks for throttled jobs

### DIFF
--- a/app/sidekiq/check_package_status_worker.rb
+++ b/app/sidekiq/check_package_status_worker.rb
@@ -1,7 +1,7 @@
 class CheckPackageStatusWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Job
-  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
+  sidekiq_options lock: :until_executed, lock_ttl: 1.day.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, package_id)

--- a/app/sidekiq/sync_package_by_id_worker.rb
+++ b/app/sidekiq/sync_package_by_id_worker.rb
@@ -1,7 +1,7 @@
 class SyncPackageByIdWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Job
-  sidekiq_options queue: :critical, lock: :until_executed, lock_ttl: 1.hour.to_i
+  sidekiq_options queue: :critical, lock: :until_executed, lock_ttl: 1.day.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, package_id)

--- a/app/sidekiq/sync_package_version_worker.rb
+++ b/app/sidekiq/sync_package_version_worker.rb
@@ -3,7 +3,7 @@ class SyncPackageVersionWorker
   include Sidekiq::Throttled::Job
   sidekiq_options queue: :low,
                   lock: :until_executed,
-                  lock_ttl: 1.hour.to_i
+                  lock_ttl: 1.day.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, name, version)

--- a/app/sidekiq/sync_package_worker.rb
+++ b/app/sidekiq/sync_package_worker.rb
@@ -1,7 +1,7 @@
 class SyncPackageWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Job
-  sidekiq_options queue: :critical, lock: :until_executed, lock_ttl: 1.hour.to_i
+  sidekiq_options queue: :critical, lock: :until_executed, lock_ttl: 1.day.to_i
   sidekiq_throttle_as :registry_host
 
   def perform(registry_id, name, force = false)

--- a/test/sidekiq/unique_job_options_test.rb
+++ b/test/sidekiq/unique_job_options_test.rb
@@ -8,6 +8,10 @@ class UniqueJobOptionsTest < ActiveSupport::TestCase
     end
   end
 
+  def throttled_unique_workers
+    unique_workers.select { |worker| worker.ancestors.include?(Sidekiq::Throttled::Job) }
+  end
+
   test "unique jobs have a global lock ttl" do
     assert_equal 1.hour.to_i, SidekiqUniqueJobs.config.lock_ttl
   end
@@ -18,8 +22,21 @@ class UniqueJobOptionsTest < ActiveSupport::TestCase
     unique_workers.each do |worker|
       options = worker.get_sidekiq_options
 
-      assert_equal 1.hour.to_i, options["lock_ttl"], worker.name
       assert_not options.key?("lock_expiration"), worker.name
+    end
+  end
+
+  test "throttled unique workers keep their locks while requeued" do
+    assert_predicate throttled_unique_workers, :any?
+
+    throttled_unique_workers.each do |worker|
+      assert_equal 1.day.to_i, worker.get_sidekiq_options["lock_ttl"], worker.name
+    end
+  end
+
+  test "other unique workers use the global lock ttl" do
+    (unique_workers - throttled_unique_workers).each do |worker|
+      assert_equal SidekiqUniqueJobs.config.lock_ttl, worker.get_sidekiq_options["lock_ttl"], worker.name
     end
   end
 
@@ -34,7 +51,7 @@ class UniqueJobOptionsTest < ActiveSupport::TestCase
 
       SidekiqUniqueJobs::Job.prepare(item)
 
-      assert_equal 1.hour.to_i, item["lock_ttl"], worker.name
+      assert_equal options["lock_ttl"], item["lock_ttl"], worker.name
     end
   end
 end


### PR DESCRIPTION
Registry-throttled jobs are requeued with their original enqueue time. Production sampling found one-hour unique locks expiring while those jobs were still queued, allowing duplicates to add more load. This gives the four throttled workers a one-day `lock_ttl` while retaining the one-hour default for other unique workers.