### PR TITLE
Spread repository metadata refresh jobs

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -11,6 +11,7 @@ class Package < ApplicationRecord
   ].freeze
   REPO_METADATA_REFRESH_CURSOR_KEY = 'packages:update_repo_metadata:cursor'.freeze
   REPO_METADATA_REFRESH_BATCH_SIZE = 400
+  REPO_METADATA_REFRESH_INTERVAL = 5.minutes.to_f / REPO_METADATA_REFRESH_BATCH_SIZE
   REPO_METADATA_REFRESH_SCAN_SIZE = 100_000
   REPO_METADATA_REFRESH_MAX_AGE = 1.month
   
@@ -509,7 +510,9 @@ class Package < ApplicationRecord
   def self.update_repo_metadata_async
     cursor = REDIS.get(REPO_METADATA_REFRESH_CURSOR_KEY).to_i
     packages, next_cursor = repo_metadata_refresh_batch(after_id: cursor)
-    packages.each(&:update_repo_metadata_async)
+    packages.each_with_index do |package, index|
+      package.update_repo_metadata_async(wait: index * REPO_METADATA_REFRESH_INTERVAL)
+    end
     REDIS.set(REPO_METADATA_REFRESH_CURSOR_KEY, next_cursor)
   end
 
@@ -532,9 +535,13 @@ class Package < ApplicationRecord
     [packages, next_cursor]
   end
 
-  def update_repo_metadata_async
+  def update_repo_metadata_async(wait: nil)
     return if repository_or_homepage_url.blank?
-    UpdateRepoMetadataWorker.perform_async(id)
+    if wait
+      UpdateRepoMetadataWorker.perform_in(wait, id)
+    else
+      UpdateRepoMetadataWorker.perform_async(id)
+    end
   end
 
   def update_repo_metadata

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -354,9 +354,41 @@ class PackageTest < ActiveSupport::TestCase
     Package.stubs(:repo_metadata_refresh_batch).with(after_id: 123).returns([[package], 456])
     REDIS.expects(:get).with(Package::REPO_METADATA_REFRESH_CURSOR_KEY).returns('123')
     REDIS.expects(:set).with(Package::REPO_METADATA_REFRESH_CURSOR_KEY, 456)
-    package.expects(:update_repo_metadata_async)
+    package.expects(:update_repo_metadata_async).with(wait: 0)
 
     Package.update_repo_metadata_async
+  end
+
+  test 'update_repo_metadata_async spreads the batch across the cron interval' do
+    packages = 3.times.map do |index|
+      @registry.packages.create!(
+        name: "spread-repo-metadata-#{index}",
+        ecosystem: @registry.ecosystem,
+        repository_url: "https://github.com/example/spread-#{index}"
+      )
+    end
+    Package.stubs(:repo_metadata_refresh_batch).returns([packages, 456])
+    REDIS.stubs(:get).returns('123')
+    REDIS.stubs(:set)
+
+    packages.each_with_index do |package, index|
+      package.expects(:update_repo_metadata_async).with(
+        wait: index * Package::REPO_METADATA_REFRESH_INTERVAL
+      )
+    end
+
+    Package.update_repo_metadata_async
+  end
+
+  test 'update_repo_metadata_async schedules a delayed worker when wait is given' do
+    package = @registry.packages.create!(
+      name: 'delayed-repo-metadata',
+      ecosystem: @registry.ecosystem,
+      repository_url: 'https://github.com/example/delayed'
+    )
+    UpdateRepoMetadataWorker.expects(:perform_in).with(2.5, package.id)
+
+    package.update_repo_metadata_async(wait: 2.5)
   end
 
   test 'registry_url' do


### PR DESCRIPTION
The scheduled repository metadata refresh enqueues 400 jobs at once every five minutes. Spread those jobs evenly across the interval while leaving individual refresh requests immediate.