### PR TITLE
Prevent caching internal server errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -19,6 +19,9 @@ class ErrorsController < ApplicationController
   end
 
   def internal
+    response.cache_control.replace({ no_store: true })
+    response.headers.delete('CDN-Cache-Control')
+
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json { render json: { error: "internal server error" }, status: :internal_server_error }

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -19,11 +19,10 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     assert_template 'errors/internal'
   end
 
-  test '500 is not publicly cacheable' do
+  test '500 is not cacheable' do
     get '/500'
-    cache_control = response.headers['Cache-Control'].to_s
-    refute_includes cache_control, 'public', "got: #{cache_control}"
-    refute_includes cache_control, 's-maxage', "got: #{cache_control}"
+    assert_equal 'no-store', response.headers['Cache-Control']
+    assert_nil response.headers['CDN-Cache-Control']
   end
 
   test '404 is not publicly cacheable' do
@@ -40,11 +39,10 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     refute_includes cache_control, 's-maxage', "got: #{cache_control}"
   end
 
-  test 'json 500 is not publicly cacheable' do
+  test 'json 500 is not cacheable' do
     get '/500', as: :json
-    cache_control = response.headers['Cache-Control'].to_s
-    refute_includes cache_control, 'public', "got: #{cache_control}"
-    refute_includes cache_control, 's-maxage', "got: #{cache_control}"
+    assert_equal 'no-store', response.headers['Cache-Control']
+    assert_nil response.headers['CDN-Cache-Control']
   end
 
   test 'path traversal renders 404 through exceptions_app' do


### PR DESCRIPTION
Packages error responses skip the normal cache callback but can still receive a one-day cache lifetime and be stored by the CDN. Return internal server errors with `Cache-Control: no-store`, remove `CDN-Cache-Control`, and assert the behavior for HTML and JSON responses.