### PR TITLE
Limit repository metadata refresh concurrency

### DIFF
--- a/app/sidekiq/update_repo_metadata_worker.rb
+++ b/app/sidekiq/update_repo_metadata_worker.rb
@@ -1,6 +1,8 @@
 class UpdateRepoMetadataWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.hour.to_i
+  include Sidekiq::Throttled::Job
+  sidekiq_options queue: :low, lock: :until_executed, lock_ttl: 1.day.to_i
+  sidekiq_throttle concurrency: { limit: 5 }, requeue: { with: :enqueue }
 
   def perform(package_id)
     Package.find_by_id(package_id).try(:update_repo_metadata)

--- a/test/sidekiq/update_repo_metadata_worker_test.rb
+++ b/test/sidekiq/update_repo_metadata_worker_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class UpdateRepoMetadataWorkerTest < ActiveSupport::TestCase
+  setup do
+    @strategy = Sidekiq::Throttled::Registry.get(UpdateRepoMetadataWorker)
+    @strategy.reset!
+  end
+
+  teardown do
+    @strategy.reset!
+  end
+
+  test "limits concurrent repository metadata updates" do
+    jids = 5.times.map { SecureRandom.hex }
+
+    jids.each do |jid|
+      refute @strategy.throttled?(jid, 1)
+    end
+    assert @strategy.throttled?(SecureRandom.hex, 1)
+
+    @strategy.finalize!(jids.first, 1)
+    refute @strategy.throttled?(SecureRandom.hex, 1)
+  end
+
+  test "requeues the existing unique job when throttled" do
+    assert_equal :enqueue, @strategy.requeue_with
+  end
+end


### PR DESCRIPTION
Cap `UpdateRepoMetadataWorker` at five concurrent jobs so slow Repos responses cannot consume the full Sidekiq pool. Keep throttled unique jobs on the existing enqueue path and extend their lock TTL while they wait.