### PR TITLE
Prevent lower Sidekiq queue starvation

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
 :queues:
-  - critical
-  - default
-  - low
+  - [critical, 10]
+  - [default, 3]
+  - [low, 1]

--- a/test/config/sidekiq_config_test.rb
+++ b/test/config/sidekiq_config_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "yaml"
+
+class SidekiqConfigTest < ActiveSupport::TestCase
+  test "polls every queue with weighted priority" do
+    config = YAML.load_file(Rails.root.join("config/sidekiq.yml"))
+
+    assert_equal [["critical", 10], ["default", 3], ["low", 1]], config.fetch(:queues)
+  end
+end


### PR DESCRIPTION
Use weighted queue polling so sustained critical work cannot prevent default and low jobs from running. Keep critical work dominant with a `10:3:1` polling ratio.