### PR TITLE
Avoid retrying invalid repository URLs

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -589,18 +589,16 @@ class Package < ApplicationRecord
   end
 
   def fetch_repo_metadata
-    return if repository_or_homepage_url.blank?
+    url = repository_or_homepage_url
+    return if url.blank?
 
-    json = fetch_repo_metadata_lookup(repository_or_homepage_url)
+    json = fetch_repo_metadata_lookup(url)
     return json if json
-    
-    response = Faraday.head(repository_or_homepage_url)
-    if [301, 302, 307, 308].include?(response.status) && response.headers['location'].present?
-      return fetch_repo_metadata_lookup(response.headers['location']) || {}
-    end
-    return {} if response.success? || [400, 404, 405, 410, 422].include?(response.status)
 
-    raise EcosystemsApiClient::RequestError.new(repository_or_homepage_url, response.status, method: 'HEAD')
+    redirect_url = repo_metadata_redirect_url(url)
+    return {} unless redirect_url
+
+    fetch_repo_metadata_lookup(redirect_url) || {}
   end
 
   def fetch_repo_metadata_lookup(url)
@@ -612,6 +610,23 @@ class Package < ApplicationRecord
   rescue EcosystemsApiClient::RequestError => error
     raise unless [400, 404, 410, 422].include?(error.status)
     nil
+  end
+
+  def repo_metadata_redirect_url(url)
+    return unless repo_metadata_fallback_url?(url)
+
+    response = Faraday.head(url)
+    return unless [301, 302, 307, 308].include?(response.status)
+    response.headers['location'].presence
+  rescue Faraday::Error, URI::InvalidURIError
+    nil
+  end
+
+  def repo_metadata_fallback_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) && uri.host.present?
+  rescue URI::InvalidURIError
+    false
   end
 
   def fetch_tags

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -253,7 +253,7 @@ class PackageTest < ActiveSupport::TestCase
     assert_in_delta previous_update, @package.reload.repo_metadata_updated_at, 1.second
   end
 
-  test 'update_repo_metadata retries when redirect discovery is temporarily unavailable' do
+  test 'update_repo_metadata treats an unsuccessful fallback request as no metadata' do
     repository_url = 'https://github.com/example/example'
     previous_update = 2.days.ago
     @package.update!(repository_url: repository_url, repo_metadata_updated_at: previous_update)
@@ -263,12 +263,80 @@ class PackageTest < ActiveSupport::TestCase
       .to_return(status: 404)
     stub_request(:head, repository_url).to_return(status: 503)
 
+    @package.update_repo_metadata
+
+    assert_operator @package.reload.repo_metadata_updated_at, :>, previous_update
+  end
+
+  test 'update_repo_metadata treats a fallback connection failure as no metadata' do
+    repository_url = 'https://retired.example.org/project'
+    previous_update = 2.days.ago
+    @package.update!(repository_url: repository_url, repo_metadata_updated_at: previous_update)
+
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+      .with(query: { url: repository_url })
+      .to_return(status: 404)
+    stub_request(:head, repository_url)
+      .to_raise(Faraday::ConnectionFailed.new('Could not resolve hostname'))
+
+    @package.update_repo_metadata
+
+    assert_operator @package.reload.repo_metadata_updated_at, :>, previous_update
+  end
+
+  test 'fetch_repo_metadata does not request invalid fallback urls' do
+    invalid_urls = [
+      'git://git.coding.net/example/project.git',
+      'git@example.org:example/project.git'
+    ]
+    Faraday.expects(:head).never
+
+    invalid_urls.each do |url|
+      @package.repository_url = url
+      stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+        .with(query: { url: url })
+        .to_return(status: 404)
+
+      assert_equal({}, @package.fetch_repo_metadata)
+    end
+  end
+
+  test 'update_repo_metadata retries when the repository lookup cannot connect' do
+    repository_url = 'https://github.com/example/example'
+    previous_update = 2.days.ago
+    @package.update!(repository_url: repository_url, repo_metadata_updated_at: previous_update)
+
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+      .with(query: { url: repository_url })
+      .to_raise(Faraday::ConnectionFailed.new('Could not resolve hostname'))
+
+    assert_raises(Faraday::ConnectionFailed) do
+      @package.update_repo_metadata
+    end
+
+    assert_in_delta previous_update, @package.reload.repo_metadata_updated_at, 1.second
+  end
+
+  test 'update_repo_metadata retries when a redirected repository lookup is unavailable' do
+    repository_url = 'https://example.org/renamed'
+    redirected_url = 'https://github.com/example/renamed'
+    previous_update = 2.days.ago
+    @package.update!(repository_url: repository_url, repo_metadata_updated_at: previous_update)
+
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+      .with(query: { url: repository_url })
+      .to_return(status: 404)
+    stub_request(:head, repository_url)
+      .to_return(status: 301, headers: { 'Location' => redirected_url })
+    stub_request(:get, 'https://repos.ecosyste.ms/api/v1/repositories/lookup')
+      .with(query: { url: redirected_url })
+      .to_return(status: 500)
+
     error = assert_raises(EcosystemsApiClient::RequestError) do
       @package.update_repo_metadata
     end
 
-    assert_equal 503, error.status
-    assert_equal 'HEAD', error.method
+    assert_equal 500, error.status
     assert_in_delta previous_update, @package.reload.repo_metadata_updated_at, 1.second
   end
 


### PR DESCRIPTION
Validate fallback repository URLs before making a `HEAD` request. Treat fallback network and status failures as no metadata while keeping Repos lookup failures retryable.