### PR TITLE
Add Hugging Face model ecosystem

### DIFF
--- a/app/models/ecosystem/huggingface.rb
+++ b/app/models/ecosystem/huggingface.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module Ecosystem
+  class Huggingface < Base
+    API_URL = "https://huggingface.co/api/models"
+    PAGE_SIZE = 1_000
+    SYNC_MISSING_CURSOR_KEY = "sync_missing_packages_cursor"
+
+    def has_dependent_repos?
+      false
+    end
+
+    def sync_missing_packages_incrementally?
+      true
+    end
+
+    def sync_missing_packages_async
+      response = request(sync_missing_packages_cursor)
+      raise "Hugging Face models API returned #{response.status}" unless response.success?
+
+      names = Oj.load(response.body).filter_map { |model| model["id"].presence || model["modelId"].presence }.uniq
+      existing_names = @registry.packages.where(name: names).pluck(:name).to_set
+      jobs = names.reject { |name| existing_names.include?(name) }.map { |name| [@registry.id, name] }
+      jobs.each_slice(1_000) { |batch| SyncPackageWorker.perform_bulk(batch) }
+
+      save_sync_missing_packages_cursor(next_page_url(response.headers["link"]))
+      jobs.length
+    rescue => e
+      Rails.logger.error("Error syncing missing Hugging Face models for registry #{@registry.id}: #{e.message}")
+      0
+    end
+
+    def purl_params(package, version = nil)
+      namespace, name = package.name.split("/", 2)
+      {
+        type: purl_type,
+        namespace: name.present? ? namespace : nil,
+        name: (name || namespace).encode("iso-8859-1"),
+        version: version.try(:number).try(:encode, "iso-8859-1")
+      }
+    end
+
+    def registry_url(package, version = nil)
+      url = "#{@registry_url}/#{package.name}"
+      version.present? ? "#{url}/tree/#{version}" : url
+    end
+
+    def download_url(_package, _version = nil)
+      nil
+    end
+
+    def documentation_url(package, version = nil)
+      registry_url(package, version)
+    end
+
+    def install_command(package, version = nil)
+      command = "hf download #{package.name}"
+      version.present? ? "#{command} --revision #{version}" : command
+    end
+
+    def check_status(package)
+      return "removed" if fetch_package_metadata(package.name) == false
+
+      nil
+    end
+
+    def all_package_names
+      names = []
+      url = "#{API_URL}?limit=#{PAGE_SIZE}"
+
+      while url.present?
+        response = request(url)
+        raise "Hugging Face models API returned #{response.status}" unless response.success?
+
+        names.concat(Oj.load(response.body).filter_map { |model| model["id"].presence || model["modelId"].presence })
+        url = next_page_url(response.headers["link"])
+      end
+
+      names.uniq
+    rescue => e
+      Rails.logger.warn("Error listing Hugging Face models: #{e.message}")
+      []
+    end
+
+    def recently_updated_package_names
+      get_json_array("#{API_URL}?limit=100&sort=lastModified&direction=-1")
+        .filter_map { |model| model["id"].presence || model["modelId"].presence }
+    rescue => e
+      Rails.logger.warn("Error listing recently updated Hugging Face models: #{e.message}")
+      []
+    end
+
+    def fetch_package_metadata_uncached(name)
+      response = request("#{API_URL}/#{encoded_model_name(name)}")
+      return false if [400, 404, 410].include?(response.status)
+      return nil unless response.success?
+
+      Oj.load(response.body)
+    rescue => e
+      Rails.logger.warn("Error fetching Hugging Face model #{name}: #{e.message}")
+      nil
+    end
+
+    def map_package_metadata(model)
+      return false unless model.is_a?(Hash)
+
+      name = model["id"].presence || model["modelId"].presence
+      return false if name.blank?
+
+      namespace = name.split("/", 2).first if name.include?("/")
+
+      {
+        name: name,
+        namespace: namespace,
+        homepage: "#{@registry_url}/#{name}",
+        licenses: license_for(model),
+        keywords_array: Array(model["tags"]).reject(&:blank?),
+        downloads: model["downloads"],
+        downloads_period: "last-month",
+        versions: [model],
+        metadata: {
+          author: model["author"],
+          created_at: model["createdAt"],
+          last_modified: model["lastModified"],
+          likes: model["likes"],
+          pipeline_tag: model["pipeline_tag"],
+          library_name: model["library_name"],
+          gated: model["gated"],
+          private: model["private"],
+          disabled: model["disabled"]
+        }.compact
+      }
+    end
+
+    def versions_metadata(pkg_metadata, existing_version_numbers = [])
+      Array(pkg_metadata[:versions]).filter_map do |model|
+        revision = model["sha"].presence
+        next if revision.blank? || existing_version_numbers.include?(revision)
+
+        {
+          number: revision,
+          published_at: model["lastModified"],
+          metadata: {
+            revision: revision,
+            created_at: model["createdAt"],
+            last_modified: model["lastModified"]
+          }.compact
+        }
+      end.uniq { |version| version[:number] }
+    end
+
+    def next_page_url(link_header)
+      link_header.to_s.split(",").each do |link|
+        next unless link.match?(/rel=[\"']?next[\"']?/)
+
+        url = link.match(/<([^>]+)>/)&.captures&.first
+        return URI.join(API_URL, url).to_s if url.present?
+      end
+
+      nil
+    end
+
+    def sync_missing_packages_cursor
+      @registry.metadata.to_h[SYNC_MISSING_CURSOR_KEY].presence || "#{API_URL}?limit=#{PAGE_SIZE}"
+    end
+
+    def save_sync_missing_packages_cursor(cursor)
+      metadata = @registry.metadata.to_h
+      if cursor.present?
+        metadata[SYNC_MISSING_CURSOR_KEY] = cursor
+      else
+        metadata.delete(SYNC_MISSING_CURSOR_KEY)
+      end
+      @registry.update!(metadata: metadata)
+    end
+
+    def license_for(model)
+      card_data = model["cardData"]
+      return card_data["license"] if card_data.is_a?(Hash) && card_data["license"].present?
+
+      Array(model["tags"]).find { |tag| tag.start_with?("license:") }&.delete_prefix("license:")
+    end
+
+    def encoded_model_name(name)
+      name.to_s.split("/").map { |segment| CGI.escape(segment) }.join("/")
+    end
+  end
+end

--- a/app/models/ecosystem/huggingface.rb
+++ b/app/models/ecosystem/huggingface.rb
@@ -66,7 +66,7 @@ module Ecosystem
 
     def all_package_names
       names = []
-      url = "#{API_URL}?limit=#{PAGE_SIZE}"
+      url = catalogue_url
 
       while url.present?
         response = request(url)
@@ -161,7 +161,7 @@ module Ecosystem
     end
 
     def sync_missing_packages_cursor
-      @registry.metadata.to_h[SYNC_MISSING_CURSOR_KEY].presence || "#{API_URL}?limit=#{PAGE_SIZE}"
+      @registry.metadata.to_h[SYNC_MISSING_CURSOR_KEY].presence || catalogue_url
     end
 
     def save_sync_missing_packages_cursor(cursor)
@@ -183,6 +183,10 @@ module Ecosystem
 
     def encoded_model_name(name)
       name.to_s.split("/").map { |segment| CGI.escape(segment) }.join("/")
+    end
+
+    def catalogue_url
+      "#{API_URL}?limit=#{PAGE_SIZE}&sort=createdAt&direction=1"
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,6 +40,7 @@ default_registries = [
   {name: 'conan.io', url: 'https://conan.io/center', ecosystem: 'conan', github: 'conan-io', default: true},
   {name: "carthage", url: "https://github.com/Carthage/Carthage", ecosystem: "carthage", github: "Carthage", default: true},
   {name: 'github actions', url: 'https://github.com/marketplace/actions/', ecosystem: 'actions', github: 'actions', default: true},
+  {name: 'huggingface.co', url: 'https://huggingface.co', ecosystem: 'huggingface', github: 'huggingface', default: true, rate_limit: 1},
   {name: 'pkg.adelielinux.org', url: "https://pkg.adelielinux.org/current", ecosystem: "adelie", github: "AdelieLinux", default: true, metadata: {repos: ['system', 'user']}},
   {name: 'bioconductor.org', url: 'https://bioconductor.org', ecosystem: 'bioconductor', github: 'Bioconductor', default: true},
   {name: 'open-vsx.org', url: 'https://open-vsx.org', ecosystem: 'openvsx', default: true, github: 'open-vsx'},

--- a/test/fixtures/files/huggingface/models-page-1.json
+++ b/test/fixtures/files/huggingface/models-page-1.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "openai-community/gpt2",
+    "sha": "0123456789abcdef0123456789abcdef01234567"
+  },
+  {
+    "modelId": "stabilityai/sdxl-turbo",
+    "sha": "abcdef0123456789abcdef0123456789abcdef01"
+  }
+]

--- a/test/fixtures/files/huggingface/models-page-2.json
+++ b/test/fixtures/files/huggingface/models-page-2.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "sentence-transformers/all-MiniLM-L6-v2",
+    "sha": "fedcba9876543210fedcba9876543210fedcba98"
+  }
+]

--- a/test/fixtures/files/huggingface/openai-community-gpt2.json
+++ b/test/fixtures/files/huggingface/openai-community-gpt2.json
@@ -1,0 +1,21 @@
+{
+  "id": "openai-community/gpt2",
+  "author": "openai-community",
+  "sha": "0123456789abcdef0123456789abcdef01234567",
+  "createdAt": "2022-11-23T17:29:44.000Z",
+  "lastModified": "2026-08-19T12:34:56.000Z",
+  "downloads": 123456,
+  "likes": 420,
+  "gated": false,
+  "private": false,
+  "disabled": false,
+  "pipeline_tag": "text-generation",
+  "library_name": "transformers",
+  "tags": ["transformers", "pytorch", "license:mit", "text-generation"],
+  "cardData": {
+    "license": "mit"
+  },
+  "siblings": [
+    { "rfilename": "pytorch_model.bin" }
+  ]
+}

--- a/test/models/ecosystem/huggingface_test.rb
+++ b/test/models/ecosystem/huggingface_test.rb
@@ -1,0 +1,174 @@
+require "test_helper"
+
+class HuggingfaceTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: "huggingface.co", url: "https://huggingface.co", ecosystem: "huggingface")
+    @ecosystem = Ecosystem::Huggingface.new(@registry)
+    @package = Package.new(ecosystem: "huggingface", name: "openai-community/gpt2")
+    @version = @package.versions.build(number: "0123456789abcdef0123456789abcdef01234567")
+  end
+
+  test "registry_url" do
+    assert_equal "https://huggingface.co/openai-community/gpt2", @ecosystem.registry_url(@package)
+  end
+
+  test "registry_url with version" do
+    assert_equal "https://huggingface.co/openai-community/gpt2/tree/0123456789abcdef0123456789abcdef01234567", @ecosystem.registry_url(@package, @version)
+  end
+
+  test "download_url is nil because models have no universal archive" do
+    assert_nil @ecosystem.download_url(@package, @version)
+  end
+
+  test "documentation_url" do
+    assert_equal "https://huggingface.co/openai-community/gpt2", @ecosystem.documentation_url(@package)
+  end
+
+  test "documentation_url with version" do
+    assert_equal "https://huggingface.co/openai-community/gpt2/tree/0123456789abcdef0123456789abcdef01234567", @ecosystem.documentation_url(@package, @version)
+  end
+
+  test "install_command" do
+    assert_equal "hf download openai-community/gpt2", @ecosystem.install_command(@package)
+  end
+
+  test "install_command with version" do
+    assert_equal "hf download openai-community/gpt2 --revision 0123456789abcdef0123456789abcdef01234567", @ecosystem.install_command(@package, @version)
+  end
+
+  test "purl" do
+    assert_equal "pkg:huggingface/openai-community/gpt2", @ecosystem.purl(@package)
+    assert Purl.parse(@ecosystem.purl(@package))
+  end
+
+  test "purl with version" do
+    assert_equal "pkg:huggingface/openai-community/gpt2@0123456789abcdef0123456789abcdef01234567", @ecosystem.purl(@package, @version)
+    assert Purl.parse(@ecosystem.purl(@package, @version))
+  end
+
+  test "all_package_names follows cursor pagination" do
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000")
+      .to_return(
+        status: 200,
+        headers: { "Link" => "<https://huggingface.co/api/models?limit=1000&cursor=next-page>; rel=\"next\"" },
+        body: file_fixture("huggingface/models-page-1.json")
+      )
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&cursor=next-page")
+      .to_return(status: 200, body: file_fixture("huggingface/models-page-2.json"))
+
+    assert_equal ["openai-community/gpt2", "stabilityai/sdxl-turbo", "sentence-transformers/all-MiniLM-L6-v2"], @ecosystem.all_package_names
+  end
+
+  test "sync_missing_packages_async enqueues missing models and saves the next cursor" do
+    registry = Registry.create!(default: true, name: "Hugging Face discovery", url: "https://huggingface-discovery.example", ecosystem: "huggingface")
+    registry.packages.create!(name: "openai-community/gpt2", ecosystem: "huggingface")
+    ecosystem = Ecosystem::Huggingface.new(registry)
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000")
+      .to_return(
+        status: 200,
+        headers: { "Link" => "<https://huggingface.co/api/models?limit=1000&cursor=next-page>; rel=\"next\"" },
+        body: file_fixture("huggingface/models-page-1.json")
+      )
+    SyncPackageWorker.expects(:perform_bulk).with([
+      [registry.id, "stabilityai/sdxl-turbo"]
+    ])
+
+    assert_equal 1, ecosystem.sync_missing_packages_async
+    assert_equal "https://huggingface.co/api/models?limit=1000&cursor=next-page", registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
+  end
+
+  test "sync_missing_packages_async clears its cursor at the end of the catalogue" do
+    registry = Registry.create!(
+      default: true,
+      name: "Hugging Face discovery end",
+      url: "https://huggingface-discovery-end.example",
+      ecosystem: "huggingface",
+      metadata: { Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY => "https://huggingface.co/api/models?limit=1000&cursor=last-page" }
+    )
+    ecosystem = Ecosystem::Huggingface.new(registry)
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&cursor=last-page")
+      .to_return(status: 200, body: file_fixture("huggingface/models-page-2.json"))
+    SyncPackageWorker.expects(:perform_bulk).with([
+      [registry.id, "sentence-transformers/all-MiniLM-L6-v2"]
+    ])
+
+    assert_equal 1, ecosystem.sync_missing_packages_async
+    assert_nil registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
+  end
+
+  test "sync_missing_packages_async keeps its cursor when the API fails" do
+    registry = Registry.create!(
+      default: true,
+      name: "Hugging Face discovery failure",
+      url: "https://huggingface-discovery-failure.example",
+      ecosystem: "huggingface",
+      metadata: { Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY => "https://huggingface.co/api/models?limit=1000&cursor=retry" }
+    )
+    ecosystem = Ecosystem::Huggingface.new(registry)
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&cursor=retry").to_return(status: 503)
+
+    assert_equal 0, ecosystem.sync_missing_packages_async
+    assert_equal "https://huggingface.co/api/models?limit=1000&cursor=retry", registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
+  end
+
+  test "recently_updated_package_names" do
+    stub_request(:get, "https://huggingface.co/api/models?limit=100&sort=lastModified&direction=-1")
+      .to_return(status: 200, body: file_fixture("huggingface/models-page-1.json"))
+
+    assert_equal ["openai-community/gpt2", "stabilityai/sdxl-turbo"], @ecosystem.recently_updated_package_names
+  end
+
+  test "package_metadata" do
+    stub_model_request
+
+    metadata = @ecosystem.package_metadata(@package.name)
+
+    assert_equal "openai-community/gpt2", metadata[:name]
+    assert_equal "openai-community", metadata[:namespace]
+    assert_equal "https://huggingface.co/openai-community/gpt2", metadata[:homepage]
+    assert_nil metadata[:repository_url]
+    assert_nil metadata[:description]
+    assert_equal "mit", metadata[:licenses]
+    assert_equal ["transformers", "pytorch", "license:mit", "text-generation"], metadata[:keywords_array]
+    assert_equal 123456, metadata[:downloads]
+    assert_equal "last-month", metadata[:downloads_period]
+    assert_equal 420, metadata[:metadata][:likes]
+    assert_equal false, metadata[:metadata][:gated]
+  end
+
+  test "versions_metadata uses the model revision without treating it as an integrity hash" do
+    stub_model_request
+
+    metadata = @ecosystem.package_metadata(@package.name)
+    versions = @ecosystem.versions_metadata(metadata)
+
+    assert_equal [{
+      number: "0123456789abcdef0123456789abcdef01234567",
+      published_at: "2026-08-19T12:34:56.000Z",
+      metadata: {
+        revision: "0123456789abcdef0123456789abcdef01234567",
+        created_at: "2022-11-23T17:29:44.000Z",
+        last_modified: "2026-08-19T12:34:56.000Z"
+      }
+    }], versions
+  end
+
+  test "check_status returns removed for a missing model" do
+    stub_request(:get, "https://huggingface.co/api/models/openai-community/gpt2").to_return(status: 404)
+
+    assert_equal "removed", @ecosystem.check_status(@package)
+  end
+
+  test "check_status does not mark a model removed when the API errors" do
+    stub_request(:get, "https://huggingface.co/api/models/openai-community/gpt2").to_return(status: 503)
+
+    assert_nil @ecosystem.check_status(@package)
+  end
+
+  private
+
+  def stub_model_request
+    stub_request(:get, "https://huggingface.co/api/models/openai-community/gpt2")
+      .to_return(status: 200, body: file_fixture("huggingface/openai-community-gpt2.json"))
+  end
+end

--- a/test/models/ecosystem/huggingface_test.rb
+++ b/test/models/ecosystem/huggingface_test.rb
@@ -47,13 +47,13 @@ class HuggingfaceTest < ActiveSupport::TestCase
   end
 
   test "all_package_names follows cursor pagination" do
-    stub_request(:get, "https://huggingface.co/api/models?limit=1000")
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1")
       .to_return(
         status: 200,
-        headers: { "Link" => "<https://huggingface.co/api/models?limit=1000&cursor=next-page>; rel=\"next\"" },
+        headers: { "Link" => "<https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=next-page>; rel=\"next\"" },
         body: file_fixture("huggingface/models-page-1.json")
       )
-    stub_request(:get, "https://huggingface.co/api/models?limit=1000&cursor=next-page")
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=next-page")
       .to_return(status: 200, body: file_fixture("huggingface/models-page-2.json"))
 
     assert_equal ["openai-community/gpt2", "stabilityai/sdxl-turbo", "sentence-transformers/all-MiniLM-L6-v2"], @ecosystem.all_package_names
@@ -63,10 +63,10 @@ class HuggingfaceTest < ActiveSupport::TestCase
     registry = Registry.create!(default: true, name: "Hugging Face discovery", url: "https://huggingface-discovery.example", ecosystem: "huggingface")
     registry.packages.create!(name: "openai-community/gpt2", ecosystem: "huggingface")
     ecosystem = Ecosystem::Huggingface.new(registry)
-    stub_request(:get, "https://huggingface.co/api/models?limit=1000")
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1")
       .to_return(
         status: 200,
-        headers: { "Link" => "<https://huggingface.co/api/models?limit=1000&cursor=next-page>; rel=\"next\"" },
+        headers: { "Link" => "<https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=next-page>; rel=\"next\"" },
         body: file_fixture("huggingface/models-page-1.json")
       )
     SyncPackageWorker.expects(:perform_bulk).with([
@@ -74,7 +74,7 @@ class HuggingfaceTest < ActiveSupport::TestCase
     ])
 
     assert_equal 1, ecosystem.sync_missing_packages_async
-    assert_equal "https://huggingface.co/api/models?limit=1000&cursor=next-page", registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
+    assert_equal "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=next-page", registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
   end
 
   test "sync_missing_packages_async clears its cursor at the end of the catalogue" do
@@ -83,10 +83,10 @@ class HuggingfaceTest < ActiveSupport::TestCase
       name: "Hugging Face discovery end",
       url: "https://huggingface-discovery-end.example",
       ecosystem: "huggingface",
-      metadata: { Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY => "https://huggingface.co/api/models?limit=1000&cursor=last-page" }
+      metadata: { Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY => "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=last-page" }
     )
     ecosystem = Ecosystem::Huggingface.new(registry)
-    stub_request(:get, "https://huggingface.co/api/models?limit=1000&cursor=last-page")
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=last-page")
       .to_return(status: 200, body: file_fixture("huggingface/models-page-2.json"))
     SyncPackageWorker.expects(:perform_bulk).with([
       [registry.id, "sentence-transformers/all-MiniLM-L6-v2"]
@@ -102,13 +102,13 @@ class HuggingfaceTest < ActiveSupport::TestCase
       name: "Hugging Face discovery failure",
       url: "https://huggingface-discovery-failure.example",
       ecosystem: "huggingface",
-      metadata: { Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY => "https://huggingface.co/api/models?limit=1000&cursor=retry" }
+      metadata: { Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY => "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=retry" }
     )
     ecosystem = Ecosystem::Huggingface.new(registry)
-    stub_request(:get, "https://huggingface.co/api/models?limit=1000&cursor=retry").to_return(status: 503)
+    stub_request(:get, "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=retry").to_return(status: 503)
 
     assert_equal 0, ecosystem.sync_missing_packages_async
-    assert_equal "https://huggingface.co/api/models?limit=1000&cursor=retry", registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
+    assert_equal "https://huggingface.co/api/models?limit=1000&sort=createdAt&direction=1&cursor=retry", registry.reload.metadata[Ecosystem::Huggingface::SYNC_MISSING_CURSOR_KEY]
   end
 
   test "recently_updated_package_names" do


### PR DESCRIPTION
Closes #1232

## Summary

Adds Hugging Face model support backed by the Models API.

- Adds the `huggingface` ecosystem and default `huggingface.co` registry.
- Preserves namespaced model IDs in PURLs.
- Maps model metadata, license, monthly downloads, tags and current revision.
- Records the current Git revision as a version without treating it as an artifact integrity hash.
- Returns no download URL because Hugging Face models do not share a universal artifact such as `config.json`.
- Avoids treating model pages as source repository URLs.
- Uses cursor-based, incremental missing-package discovery to avoid materializing the 2M+ model catalogue during normal syncs.

## Tests

- Added pagination, incremental discovery, metadata, PURL, revision and error-handling coverage.
- `bin/rails test` passes: 1604 runs, 33495 assertions, 0 failures, 0 errors.
