### PR TITLE
Add PURL version lookup API endpoints

### DIFF
--- a/app/controllers/api/v1/purls_controller.rb
+++ b/app/controllers/api/v1/purls_controller.rb
@@ -1,0 +1,25 @@
+class Api::V1::PurlsController < Api::V1::ApplicationController
+  MAX_PURLS = 100
+
+  def lookup
+    if params[:purl].blank?
+      return render json: { error: "Missing purl parameter" }, status: :bad_request
+    end
+
+    @result = PurlVersionLookup.new(params[:purl]).call
+  end
+
+  def bulk_lookup
+    purls = Array(params[:purls])
+
+    if purls.empty?
+      return render json: { error: "Missing purls parameter" }, status: :bad_request
+    end
+
+    if purls.length > MAX_PURLS
+      return render json: { error: "Maximum 100 PURLs allowed per request" }, status: :bad_request
+    end
+
+    @results = purls.map { |purl| PurlVersionLookup.new(purl).call }
+  end
+end

--- a/app/services/purl_version_lookup.rb
+++ b/app/services/purl_version_lookup.rb
@@ -54,11 +54,27 @@ class PurlVersionLookup
     versions = if @purl.version.present?
       Version.where(package: packages).where("LOWER(versions.number) = ?", @purl.version.downcase)
     else
-      version_ids = packages.filter_map { |package| package.latest_version&.id }
-      Version.where(id: version_ids)
+      latest_versions_for(packages)
     end
 
     versions.includes(:dependencies, package: :registry).order(:id).to_a
+  end
+
+  def latest_versions_for(packages)
+    marked_versions = Version.where(package: packages, latest: true).active
+    missing_package_ids = packages.where.not(id: marked_versions.select(:package_id)).pluck(:id)
+    return marked_versions if missing_package_ids.empty?
+
+    fallback_version_ids = Package.where(id: missing_package_ids).preload(:versions).filter_map do |package|
+      latest_version_id_for(package.versions.to_a)
+    end
+
+    Version.where(id: marked_versions.select(:id)).or(Version.where(id: fallback_version_ids))
+  end
+
+  def latest_version_id_for(versions)
+    active_versions = versions.select { |version| version.status.nil? }
+    (active_versions.select(&:stable?).sort.first || active_versions.sort.first)&.id
   end
 
   def normalize_url(url)

--- a/app/services/purl_version_lookup.rb
+++ b/app/services/purl_version_lookup.rb
@@ -1,0 +1,71 @@
+class PurlVersionLookup
+  Result = Data.define(:purl, :match_status, :version)
+
+  def initialize(purl_string)
+    @purl_string = purl_string.to_s
+  end
+
+  def call
+    @purl = Purl.parse(@purl_string.gsub("npm/@", "npm/%40"))
+    versions = matching_versions(package_scope)
+
+    if versions.empty?
+      result("missing")
+    elsif versions.one?
+      result("matched", versions.first)
+    else
+      result("ambiguous")
+    end
+  rescue ArgumentError, Purl::Error
+    result("missing")
+  end
+
+  private
+
+  def package_scope
+    namespace = @purl.type == "docker" && @purl.namespace.nil? ? "library" : @purl.namespace
+
+    if @purl.type == "github"
+      return Package.repository_url("https://github.com/#{@purl.namespace}/#{@purl.name}")
+    end
+
+    ecosystem = Ecosystem::Base.purl_type_to_ecosystem(@purl.type)
+    separator = Ecosystem::Base.purl_type_to_namespace_separator(@purl.type)
+    return Package.none if ecosystem.blank? || separator.nil?
+
+    name = [namespace, @purl.name].compact.join(separator)
+    registry_ids = matching_registry_ids(ecosystem)
+    Package.where(name: name, registry_id: registry_ids)
+  end
+
+  def matching_registry_ids(ecosystem)
+    repository_url = @purl.qualifiers&.fetch("repository_url", nil)
+    registries = Registry.where(ecosystem: ecosystem)
+
+    if repository_url.present?
+      target_url = normalize_url(repository_url)
+      registries.select { |registry| normalize_url(registry.url) == target_url }.map(&:id)
+    else
+      registries.pluck(:id)
+    end
+  end
+
+  def matching_versions(packages)
+    versions = if @purl.version.present?
+      Version.where(package: packages).where("LOWER(versions.number) = ?", @purl.version.downcase)
+    else
+      version_ids = packages.filter_map { |package| package.latest_version&.id }
+      Version.where(id: version_ids)
+    end
+
+    versions.includes(:dependencies, package: :registry).order(:id).to_a
+  end
+
+  def normalize_url(url)
+    url.to_s.downcase.sub(%r{/+$}, "")
+  end
+
+  def result(match_status, version = nil)
+    Result.new(purl: @purl_string, match_status: match_status, version: version)
+  end
+end

--- a/app/views/api/v1/purls/_result.json.jbuilder
+++ b/app/views/api/v1/purls/_result.json.jbuilder
@@ -1,0 +1,20 @@
+json.purl result.purl
+json.match_status result.match_status
+
+if result.version
+  version = result.version
+  package = version.package
+  artifact = { download_url: version.download_url, integrity: version.integrity }.compact
+
+  json.version do
+    json.name package.name
+    json.version version.number
+    json.purl version.purl
+    json.license_expression version.licenses.presence || package.licenses
+    json.identifiers({ purl: version.purl, integrity: version.integrity }.compact)
+    json.artifacts artifact.present? ? [artifact] : []
+    json.dependencies version.dependencies do |dependency|
+      json.partial! "api/v1/dependencies/dependency", dependency: dependency
+    end
+  end
+end

--- a/app/views/api/v1/purls/bulk_lookup.json.jbuilder
+++ b/app/views/api/v1/purls/bulk_lookup.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @results do |result|
+  json.partial! "api/v1/purls/result", result: result
+end

--- a/app/views/api/v1/purls/lookup.json.jbuilder
+++ b/app/views/api/v1/purls/lookup.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/v1/purls/result", result: @result

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,13 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :purls, only: [] do
+        collection do
+          get :lookup
+          post :bulk_lookup
+        end
+      end
+
       resources :keywords, only: [:index, :show], constraints: { id: /.*/ }, defaults: { format: :json }
 
       resources :critical, only: [:index] do

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -254,6 +254,63 @@ paths:
         '400':
           description: missing integrity parameter
 
+  /purls/lookup:
+    get:
+      summary: lookup a package version by PURL
+      operationId: lookupPurl
+      tags:
+        - packages
+      parameters:
+        - name: purl
+          in: query
+          description: package URL, with an optional version
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurlLookupResult'
+        '400':
+          description: missing PURL parameter
+
+  /purls/bulk_lookup:
+    post:
+      summary: lookup package versions by PURL
+      operationId: bulkLookupPurls
+      tags:
+        - packages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - purls
+              properties:
+                purls:
+                  type: array
+                  description: package URLs to lookup (maximum 100)
+                  maxItems: 100
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                description: results in the same order as the requested PURLs
+                items:
+                  $ref: '#/components/schemas/PurlLookupResult'
+        '400':
+          description: missing PURLs parameter or too many PURLs
+
   /packages/lookup:
     get:
       summary: lookup a package by repository URL, purl or ecosystem+name
@@ -2158,6 +2215,62 @@ components:
           properties:
             package:
               $ref: '#/components/schemas/PackageWithRegistry'
+    PurlLookupResult:
+      required:
+        - purl
+        - match_status
+      type: object
+      properties:
+        purl:
+          type: string
+        match_status:
+          type: string
+          enum:
+            - matched
+            - missing
+            - ambiguous
+        version:
+          $ref: '#/components/schemas/PurlVersion'
+          nullable: true
+    PurlVersion:
+      required:
+        - name
+        - version
+        - purl
+        - identifiers
+        - artifacts
+        - dependencies
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        purl:
+          type: string
+        license_expression:
+          type: string
+          nullable: true
+        identifiers:
+          type: object
+          properties:
+            purl:
+              type: string
+            integrity:
+              type: string
+        artifacts:
+          type: array
+          items:
+            type: object
+            properties:
+              download_url:
+                type: string
+              integrity:
+                type: string
+        dependencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Dependency'
     VersionWithPackage:
       required:
         - id

--- a/test/controllers/api/v1/purls_controller_test.rb
+++ b/test/controllers/api/v1/purls_controller_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+
+class ApiV1PurlsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @registry = Registry.create!(name: "crates.io", url: "https://crates.io", ecosystem: "cargo")
+    @package = @registry.packages.create!(ecosystem: "cargo", name: "rand", licenses: "MIT")
+    @old_version = @package.versions.create!(number: "0.7.0", integrity: "sha256-old")
+    @latest_version = @package.versions.create!(number: "0.8.0", integrity: "sha256-latest", latest: true)
+    @latest_version.dependencies.create!(ecosystem: "cargo", package_name: "serde", requirements: "^1.0", kind: "runtime")
+  end
+
+  test "looks up the version specified by a PURL" do
+    get lookup_api_v1_purls_path, params: { purl: "pkg:cargo/rand@0.7.0" }
+
+    assert_response :success
+    assert_template "purls/lookup", file: "purls/lookup.json.jbuilder"
+
+    response = Oj.load(@response.body)
+    assert_equal "pkg:cargo/rand@0.7.0", response["purl"]
+    assert_equal "matched", response["match_status"]
+    assert_equal "rand", response.dig("version", "name")
+    assert_equal "0.7.0", response.dig("version", "version")
+    assert_equal "pkg:cargo/rand@0.7.0?repository_url=https://crates.io", response.dig("version", "purl")
+    assert_equal "MIT", response.dig("version", "license_expression")
+    assert_equal "sha256-old", response.dig("version", "identifiers", "integrity")
+    assert_equal "sha256-old", response.dig("version", "artifacts", 0, "integrity")
+  end
+
+  test "looks up the latest version when the PURL has no version" do
+    get lookup_api_v1_purls_path, params: { purl: "pkg:cargo/rand" }
+
+    assert_response :success
+
+    response = Oj.load(@response.body)
+    assert_equal "matched", response["match_status"]
+    assert_equal "0.8.0", response.dig("version", "version")
+    assert_equal "serde", response.dig("version", "dependencies", 0, "package_name")
+  end
+
+  test "returns missing when the PURL does not match a version" do
+    get lookup_api_v1_purls_path, params: { purl: "pkg:cargo/rand@9.9.9" }
+
+    assert_response :success
+
+    response = Oj.load(@response.body)
+    assert_equal "missing", response["match_status"]
+    assert_nil response["version"]
+  end
+
+  test "returns missing for an invalid PURL" do
+    get lookup_api_v1_purls_path, params: { purl: "not-a-purl" }
+
+    assert_response :success
+
+    response = Oj.load(@response.body)
+    assert_equal "missing", response["match_status"]
+  end
+
+  test "returns ambiguous when the PURL identifies versions in multiple registries" do
+    alternate_registry = Registry.create!(name: "alternate crates", url: "https://alternate.example", ecosystem: "cargo")
+    alternate_package = alternate_registry.packages.create!(ecosystem: "cargo", name: "rand")
+    alternate_package.versions.create!(number: "0.8.0")
+
+    get lookup_api_v1_purls_path, params: { purl: "pkg:cargo/rand@0.8.0" }
+
+    assert_response :success
+
+    response = Oj.load(@response.body)
+    assert_equal "ambiguous", response["match_status"]
+    assert_nil response["version"]
+  end
+
+  test "uses the repository_url qualifier to select a registry" do
+    central = Registry.create!(name: "maven central", url: "https://repo1.maven.org/maven2", ecosystem: "maven")
+    google = Registry.create!(name: "maven google", url: "https://maven.google.com/", ecosystem: "maven")
+    central.packages.create!(ecosystem: "maven", name: "com.example:library").versions.create!(number: "1.0.0")
+    google_package = google.packages.create!(ecosystem: "maven", name: "com.example:library")
+    google_package.versions.create!(number: "1.0.0")
+
+    get lookup_api_v1_purls_path, params: { purl: "pkg:maven/com.example/library@1.0.0?repository_url=https://maven.google.com" }
+
+    assert_response :success
+
+    response = Oj.load(@response.body)
+    assert_equal "matched", response["match_status"]
+    assert_equal "com.example:library", response.dig("version", "name")
+  end
+
+  test "returns bulk results in the order of the input PURLs" do
+    alternate_registry = Registry.create!(name: "alternate crates", url: "https://alternate.example", ecosystem: "cargo")
+    alternate_package = alternate_registry.packages.create!(ecosystem: "cargo", name: "rand")
+    alternate_package.versions.create!(number: "0.8.0")
+
+    post bulk_lookup_api_v1_purls_path, params: {
+      purls: ["pkg:cargo/rand@0.7.0", "pkg:cargo/missing@1.0.0", "pkg:cargo/rand@0.8.0"]
+    }
+
+    assert_response :success
+    assert_template "purls/bulk_lookup", file: "purls/bulk_lookup.json.jbuilder"
+
+    response = Oj.load(@response.body)
+    assert_equal ["pkg:cargo/rand@0.7.0", "pkg:cargo/missing@1.0.0", "pkg:cargo/rand@0.8.0"], response.pluck("purl")
+    assert_equal ["matched", "missing", "ambiguous"], response.pluck("match_status")
+  end
+
+  test "returns bad request when the PURL parameter is missing" do
+    get lookup_api_v1_purls_path
+
+    assert_response :bad_request
+    assert_equal "Missing purl parameter", Oj.load(@response.body)["error"]
+  end
+
+  test "returns bad request when the PURLs parameter is missing" do
+    post bulk_lookup_api_v1_purls_path
+
+    assert_response :bad_request
+    assert_equal "Missing purls parameter", Oj.load(@response.body)["error"]
+  end
+
+  test "returns bad request when more than 100 PURLs are requested" do
+    post bulk_lookup_api_v1_purls_path, params: { purls: (1..101).map { |i| "pkg:cargo/package#{i}" } }
+
+    assert_response :bad_request
+    assert_equal "Maximum 100 PURLs allowed per request", Oj.load(@response.body)["error"]
+  end
+end

--- a/test/controllers/api/v1/purls_controller_test.rb
+++ b/test/controllers/api/v1/purls_controller_test.rb
@@ -27,6 +27,8 @@ class ApiV1PurlsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "looks up the latest version when the PURL has no version" do
+    Package.any_instance.expects(:latest_version).never
+
     get lookup_api_v1_purls_path, params: { purl: "pkg:cargo/rand" }
 
     assert_response :success
@@ -35,6 +37,18 @@ class ApiV1PurlsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "matched", response["match_status"]
     assert_equal "0.8.0", response.dig("version", "version")
     assert_equal "serde", response.dig("version", "dependencies", 0, "package_name")
+  end
+
+  test "falls back when a package has no persisted latest version" do
+    package = @registry.packages.create!(ecosystem: "cargo", name: "fallback")
+    package.versions.create!(number: "0.7.0")
+    package.versions.create!(number: "0.8.0")
+
+    get lookup_api_v1_purls_path, params: { purl: "pkg:cargo/fallback" }
+
+    assert_response :success
+    assert_equal "matched", Oj.load(@response.body)["match_status"]
+    assert_equal "0.8.0", Oj.load(@response.body).dig("version", "version")
   end
 
   test "returns missing when the PURL does not match a version" do


### PR DESCRIPTION
Closes #1184

## Summary

Adds dedicated PURL lookup endpoints that resolve package versions without changing the existing package lookup API:

- `GET /api/v1/purls/lookup?purl=...`
- `POST /api/v1/purls/bulk_lookup`

The single endpoint returns a compact version projection. The batch endpoint returns one result for each input PURL in the original order.

Each lookup result reports a `match_status`:

- `matched` when exactly one version resolves
- `missing` when no version resolves
- `ambiguous` when multiple registries provide the requested version

Versionless PURLs resolve to the package's latest version. Lookups preserve `repository_url` qualifiers, and matched results include the package name, version, canonical PURL, license expression, identifiers, available artifact URL/hash and declared dependencies.

## Tests

- Added request coverage for explicit-version and latest-version lookups.
- Added coverage for missing, invalid, and ambiguous PURLs.
- Added coverage for `repository_url` qualifiers.
- Added ordered batch results and invalid request validation.

## Verification

- `bin/rails test test/controllers/api/v1/purls_controller_test.rb`
- `bin/rails test`
- Ruby syntax checks, OpenAPI YAML parsing, and `git diff --check`