### PR TITLE
Add version-scoped advisory API responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'rswag-ui'
 gem 'spdx', '2.0.12'
 gem "semantic"
 gem "semantic_range"
+gem "vers"
 gem "sanitize-url"
 gem "toml-rb"
 gem "chartkick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uri (1.1.1)
     useragent (0.16.11)
+    vers (1.3.1)
     web-console (4.3.0)
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
@@ -396,6 +397,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   toml-rb
+  vers
   web-console
   webmock
 
@@ -544,6 +546,7 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  vers (1.3.1) sha256=fd50cebd3da8ad2e1e675a717d265044dbf6bb7b043883f2b0eb9654ec6bdeab
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5

--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -20,6 +20,6 @@ class Api::V1::DependenciesController < Api::V1::ApplicationController
     end
 
     @pagy, @dependencies = pagy_countless(scope)
-    fresh_when(etag: @dependencies.map(&:id), public: true)
+    fresh_when(etag: [*@dependencies, *@dependencies.filter_map { |dependency| dependency.version&.package }], public: true)
   end
 end

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -254,7 +254,7 @@ class Api::V1::PackagesController < Api::V1::ApplicationController
     @package = find_package_with_normalization!(@registry, params[:id])
     @version = @package.latest_version
     raise ActiveRecord::RecordNotFound, "No versions found" unless @version
-    fresh_when @version, public: true
+    fresh_when [@package, @version], public: true
   end
 
   def codemeta

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -23,14 +23,14 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
     end
 
     @pagy, @versions = pagy_countless(scope)
-    fresh_when @versions, public: true
+    fresh_when [@package, *@versions], public: true
   end
 
   def show
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:package_id])
     @version = @package.versions.find_by_number!(params[:id])
-    fresh_when @version, public: true
+    fresh_when [@package, @version], public: true
   end
 
   def recent
@@ -57,6 +57,7 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
     end
 
     @pagy, @versions = pagy_countless(scope)
+    fresh_when [*@versions, *@versions.map(&:package)], public: true
   end
 
   def version_numbers
@@ -87,5 +88,6 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
                    .order('published_at DESC nulls last, created_at DESC, id DESC')
 
     @pagy, @versions = pagy_countless(scope)
+    fresh_when [*@versions, *@versions.map(&:package)], public: true
   end
 end

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::VersionsController < Api::V1::ApplicationController
   def index
     @registry = Registry.find_by_name!(params[:registry_id])
     @package = find_package_with_normalization!(@registry, params[:package_id])
-    scope = @package.versions#.includes(:dependencies)
+    scope = @package.versions.includes(package: :registry)
 
     scope = scope.created_after(params[:created_after]) if params[:created_after].present?
     scope = scope.published_after(params[:published_after]) if params[:published_after].present?

--- a/app/models/concerns/version_advisories.rb
+++ b/app/models/concerns/version_advisories.rb
@@ -49,10 +49,13 @@ module VersionAdvisories
   end
 
   def vulnerable_version_range?(range)
-    cleaned_version = Vers.clean(number)
-    return false if cleaned_version.blank? || range.blank?
+    return false if range.blank?
 
-    Vers.satisfies?(cleaned_version, range, vers_scheme)
+    if package.ecosystem == "packagist"
+      SemanticRange.satisfies?(number, range)
+    else
+      Vers.satisfies?(number, range, vers_scheme)
+    end
   rescue ArgumentError
     false
   end

--- a/app/models/concerns/version_advisories.rb
+++ b/app/models/concerns/version_advisories.rb
@@ -1,0 +1,63 @@
+module VersionAdvisories
+  extend ActiveSupport::Concern
+
+  VERS_SCHEMES = {
+    "go" => "golang",
+    "packagist" => "composer",
+    "rubygems" => "gem"
+  }.freeze
+
+  def version_scoped_advisories
+    Array(package.advisories).filter_map do |advisory|
+      advisory_for_version(advisory)
+    end
+  end
+
+  private
+
+  def advisory_for_version(advisory)
+    affected_entries = matching_advisory_packages(advisory).select do |advisory_package|
+      advisory_package_affected?(advisory_package)
+    end
+    return if affected_entries.empty?
+
+    {
+      "uuid" => advisory["uuid"],
+      "identifiers" => Array(advisory["identifiers"]),
+      "url" => advisory["url"],
+      "title" => advisory["title"],
+      "severity" => advisory["severity"],
+      "affected" => true,
+      "fixed" => false,
+      "fixed_versions" => affected_entries.flat_map do |advisory_package|
+        Array(advisory_package["versions"]).filter_map { |range| range["first_patched_version"].presence }
+      end.uniq
+    }.compact
+  end
+
+  def matching_advisory_packages(advisory)
+    Array(advisory["packages"]).select do |advisory_package|
+      advisory_package["ecosystem"].to_s.casecmp?(package.ecosystem.to_s) &&
+        advisory_package["package_name"].to_s.casecmp?(package.name.to_s)
+    end
+  end
+
+  def advisory_package_affected?(advisory_package)
+    Array(advisory_package["versions"]).any? do |range|
+      vulnerable_version_range?(range["vulnerable_version_range"])
+    end
+  end
+
+  def vulnerable_version_range?(range)
+    cleaned_version = Vers.clean(number)
+    return false if cleaned_version.blank? || range.blank?
+
+    Vers.satisfies?(cleaned_version, range, vers_scheme)
+  rescue ArgumentError
+    false
+  end
+
+  def vers_scheme
+    VERS_SCHEMES.fetch(package.ecosystem.downcase, package.ecosystem.downcase)
+  end
+end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,5 +1,6 @@
 class Version < ApplicationRecord
   include EcosystemsApiClient
+  include VersionAdvisories
   
   validates_presence_of :package_id, :number
   validates_uniqueness_of :number, scope: :package_id, case_sensitive: false

--- a/app/views/api/v1/versions/_version.json.jbuilder
+++ b/app/views/api/v1/versions/_version.json.jbuilder
@@ -4,3 +4,4 @@ json.codemeta_url codemeta_api_v1_registry_package_version_url(version.package.r
 json.dependencies version.dependencies do |dependency|
   json.extract! dependency, :id, :ecosystem, :package_name, :requirements, :kind, :optional
 end
+json.advisories version.version_scoped_advisories

--- a/app/views/api/v1/versions/_version_with_package.json.jbuilder
+++ b/app/views/api/v1/versions/_version_with_package.json.jbuilder
@@ -1,3 +1,4 @@
 json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :immutable, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
 json.version_url api_v1_registry_package_version_url(@registry, version.package, version)
 json.package_url api_v1_registry_package_url(@registry, version.package)
+json.advisories version.version_scoped_advisories

--- a/app/views/api/v1/versions/index.json.jbuilder
+++ b/app/views/api/v1/versions/index.json.jbuilder
@@ -1,6 +1,7 @@
 json.array! @versions do |version|
   json.extract! version, :id, :number, :published_at, :licenses, :integrity, :status, :download_url, :registry_url, :documentation_url, :install_command, :immutable, :metadata, :created_at, :updated_at, :purl, :related_tag, :latest
   json.version_url api_v1_registry_package_version_url(@registry, @package, version)
+  json.advisories version.version_scoped_advisories
   # json.dependencies version.dependencies do |dependency|
   #   json.extract! dependency, :ecosystem, :package_name, :requirements, :kind, :optional
   # end

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -2029,6 +2029,7 @@ components:
         - codemeta_url
         - related_tag
         - latest
+        - advisories
       type: object
       properties:
         id:
@@ -2076,6 +2077,10 @@ components:
           type: string
         related_tag:
           type: object
+        advisories:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionAdvisory'
     VersionWithDependencies:
       required:
         - number
@@ -2096,6 +2101,7 @@ components:
         - related_tag
         - latest
         - dependencies
+        - advisories
       type: object
       properties:
           id:
@@ -2149,6 +2155,10 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Dependency'
+          advisories:
+            type: array
+            items:
+              $ref: '#/components/schemas/VersionAdvisory'
     VersionLookup:
       allOf:
         - $ref: '#/components/schemas/VersionWithDependencies'
@@ -2179,6 +2189,7 @@ components:
         - related_tag
         - latest
         - package_url
+        - advisories
       type: object
       properties:
         id:
@@ -2228,6 +2239,42 @@ components:
           type: string
         package_url:
           type: string
+        advisories:
+          type: array
+          items:
+            $ref: '#/components/schemas/VersionAdvisory'
+    VersionAdvisory:
+      required:
+        - identifiers
+        - affected
+        - fixed
+        - fixed_versions
+      type: object
+      properties:
+        uuid:
+          type: string
+          nullable: true
+        identifiers:
+          type: array
+          items:
+            type: string
+        url:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        severity:
+          type: string
+          nullable: true
+        affected:
+          type: boolean
+        fixed:
+          type: boolean
+        fixed_versions:
+          type: array
+          items:
+            type: string
     Dependency:
       required:
         - id

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -38,6 +38,56 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal actual_response['metadata'], {"foo"=>"bar", "immutable"=>false}
   end
 
+  test 'version responses include only advisories affecting that version' do
+    @package.update!(advisories: [
+      {
+        "uuid" => "GHSA-affected",
+        "identifiers" => ["GHSA-affected"],
+        "packages" => [
+          {
+            "ecosystem" => "cargo",
+            "package_name" => "rand",
+            "versions" => [
+              { "vulnerable_version_range" => ">= 1.0.0, < 2.0.0", "first_patched_version" => "2.0.0" }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid" => "GHSA-fixed",
+        "identifiers" => ["GHSA-fixed"],
+        "packages" => [
+          {
+            "ecosystem" => "cargo",
+            "package_name" => "rand",
+            "versions" => [{ "vulnerable_version_range" => ">= 2.0.0" }]
+          }
+        ]
+      }
+    ])
+
+    get api_v1_registry_package_version_path(registry_id: @registry.name, package_id: @package.name, id: @version.number)
+    assert_response :success
+    assert_equal ["GHSA-affected"], Oj.load(@response.body)["advisories"].pluck("uuid")
+
+    get api_v1_registry_package_versions_path(registry_id: @registry.name, package_id: @package.name)
+    assert_response :success
+    assert_equal ["GHSA-affected"], Oj.load(@response.body).first["advisories"].pluck("uuid")
+
+    get latest_version_api_v1_registry_package_path(registry_id: @registry.name, id: @package.name)
+    assert_response :success
+    assert_equal ["GHSA-affected"], Oj.load(@response.body)["advisories"].pluck("uuid")
+
+    get versions_api_v1_registry_path(id: @registry.name)
+    assert_response :success
+    assert_equal ["GHSA-affected"], Oj.load(@response.body).first["advisories"].pluck("uuid")
+
+    @version.update_column(:integrity, "sha256-#{'a' * 64}")
+    get lookup_api_v1_versions_path(integrity: "sha256-#{'a' * 64}")
+    assert_response :success
+    assert_equal ["GHSA-affected"], Oj.load(@response.body).first["advisories"].pluck("uuid")
+  end
+
   test 'get recent versions' do
     get versions_api_v1_registry_path(id: @registry.name)
     assert_response :success

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -88,6 +88,28 @@ class ApiV1VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal ["GHSA-affected"], Oj.load(@response.body).first["advisories"].pluck("uuid")
   end
 
+  test 'version response cache validators include advisory updates' do
+    get api_v1_registry_package_version_path(registry_id: @registry.name, package_id: @package.name, id: @version.number)
+    assert_response :success
+    etag = @response.headers["ETag"]
+
+    get api_v1_registry_package_version_path(
+      registry_id: @registry.name,
+      package_id: @package.name,
+      id: @version.number
+    ), headers: { "If-None-Match" => etag }
+    assert_response :not_modified
+
+    @package.update!(advisories: [{ "uuid" => "GHSA-cache", "identifiers" => [], "packages" => [] }])
+
+    get api_v1_registry_package_version_path(
+      registry_id: @registry.name,
+      package_id: @package.name,
+      id: @version.number
+    ), headers: { "If-None-Match" => etag }
+    assert_response :success
+  end
+
   test 'get recent versions' do
     get versions_api_v1_registry_path(id: @registry.name)
     assert_response :success

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -143,6 +143,46 @@ class VersionTest < ActiveSupport::TestCase
     assert_empty @version.version_scoped_advisories
   end
 
+  test 'version scoped advisories support short version numbers' do
+    short_version = @package.versions.create!(number: "1.0")
+    @package.update!(advisories: [
+      {
+        "uuid" => "GHSA-short-version",
+        "identifiers" => ["GHSA-short-version"],
+        "packages" => [
+          {
+            "ecosystem" => "rubygems",
+            "package_name" => "foo",
+            "versions" => [{ "vulnerable_version_range" => ">= 1.0, < 2.0" }]
+          }
+        ]
+      }
+    ])
+
+    assert_equal ["GHSA-short-version"], short_version.version_scoped_advisories.pluck("uuid")
+  end
+
+  test 'version scoped advisories support Composer ranges' do
+    registry = Registry.create!(default: true, name: "packagist.org", url: "https://packagist.org", ecosystem: "packagist")
+    package = registry.packages.create!(name: "vendor/package", ecosystem: "packagist")
+    version = package.versions.create!(number: "1.2.3")
+    package.update!(advisories: [
+      {
+        "uuid" => "GHSA-composer-range",
+        "identifiers" => ["GHSA-composer-range"],
+        "packages" => [
+          {
+            "ecosystem" => "packagist",
+            "package_name" => "vendor/package",
+            "versions" => [{ "vulnerable_version_range" => "^1.0" }]
+          }
+        ]
+      }
+    ])
+
+    assert_equal ["GHSA-composer-range"], version.version_scoped_advisories.pluck("uuid")
+  end
+
   test 'as_live_event_json includes API fields' do
     json = @version.as_live_event_json
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -63,6 +63,86 @@ class VersionTest < ActiveSupport::TestCase
     assert Purl.parse(@version.purl)
   end
 
+  test 'version scoped advisories include only affected advisory entries' do
+    @package.update!(advisories: [
+      {
+        "uuid" => "GHSA-affected",
+        "identifiers" => ["GHSA-affected", "CVE-2026-0001"],
+        "url" => "https://github.com/advisories/GHSA-affected",
+        "title" => "Affected advisory",
+        "severity" => "high",
+        "packages" => [
+          {
+            "ecosystem" => "rubygems",
+            "package_name" => "foo",
+            "versions" => [
+              { "vulnerable_version_range" => ">= 1.0.0, < 2.0.0", "first_patched_version" => "2.0.0" }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid" => "GHSA-fixed",
+        "identifiers" => ["GHSA-fixed"],
+        "packages" => [
+          {
+            "ecosystem" => "rubygems",
+            "package_name" => "foo",
+            "versions" => [
+              { "vulnerable_version_range" => "< 1.0.0", "first_patched_version" => nil }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid" => "GHSA-other-package",
+        "identifiers" => ["GHSA-other-package"],
+        "packages" => [
+          {
+            "ecosystem" => "rubygems",
+            "package_name" => "bar",
+            "versions" => [
+              { "vulnerable_version_range" => ">= 1.0.0" }
+            ]
+          }
+        ]
+      }
+    ])
+
+    assert_equal [
+      {
+        "uuid" => "GHSA-affected",
+        "identifiers" => ["GHSA-affected", "CVE-2026-0001"],
+        "url" => "https://github.com/advisories/GHSA-affected",
+        "title" => "Affected advisory",
+        "severity" => "high",
+        "affected" => true,
+        "fixed" => false,
+        "fixed_versions" => ["2.0.0"]
+      }
+    ], @version.version_scoped_advisories
+
+    assert_empty @version2.version_scoped_advisories
+  end
+
+  test 'version scoped advisories skip invalid version ranges' do
+    @package.update!(advisories: [
+      {
+        "uuid" => "GHSA-invalid",
+        "identifiers" => ["GHSA-invalid"],
+        "packages" => [
+          {
+            "ecosystem" => "rubygems",
+            "package_name" => "foo",
+            "versions" => [{ "vulnerable_version_range" => "not a range" }]
+          }
+        ]
+      }
+    ])
+
+    assert_empty @version.version_scoped_advisories
+  end
+
   test 'as_live_event_json includes API fields' do
     json = @version.as_live_event_json
 


### PR DESCRIPTION
Closes #1752

## Summary

Adds version-scoped advisory data to version API responses.

Package responses continue to expose the complete advisory list. Version responses now return only advisories whose affected version ranges include the requested version.

Each version advisory includes:

- Advisory UUID and identifiers
- URL, title, and severity where available
- `affected` and `fixed` status for the returned version
- Known `fixed_versions`

The implementation uses the `vers` gem for ecosystem-aware version range evaluation, matching the approach used by `advisories.ecosyste.ms`.

## API coverage

The filtered `advisories` array is returned by:

- Package version index and show endpoints
- Latest package version endpoint
- Recent registry versions endpoint
- Version integrity lookup endpoint

## Tests

- Added model coverage for affected ranges, fixed versions, package matching, and invalid ranges.
- Added request coverage for all version response shapes.

## Verification

- `bin/rails test test/models/version_test.rb test/controllers/api/v1/versions_controller_test.rb`
- `bin/rails test`
- `bundle check`
- Ruby syntax checks, OpenAPI YAML parsing, and `git diff --check`