### PR TITLE
Add version artifacts and integrity lookup

### DIFF
--- a/app/controllers/api/v1/artifacts_controller.rb
+++ b/app/controllers/api/v1/artifacts_controller.rb
@@ -18,11 +18,12 @@ class Api::V1::ArtifactsController < Api::V1::ApplicationController
     scope = Artifact.lookup(params)
 
     if scope.nil?
-      return render json: { error: 'Missing integrity parameter' }, status: :bad_request
+      return render json: { error: 'Missing integrity, sha256, sha1, or sha512 parameter' }, status: :bad_request
     end
 
-    scope = scope.includes(version: [:dependencies, { package: :registry }])
-                 .order('artifacts.published_at DESC nulls last, artifacts.id DESC')
+    scope = scope.includes(
+      version: [:dependencies, { package: [:registry, { maintainerships: :maintainer }] }]
+    ).order('artifacts.published_at DESC nulls last, artifacts.id DESC')
     @pagy, @artifacts = pagy_countless(scope)
   end
 end

--- a/app/controllers/api/v1/artifacts_controller.rb
+++ b/app/controllers/api/v1/artifacts_controller.rb
@@ -1,0 +1,28 @@
+class Api::V1::ArtifactsController < Api::V1::ApplicationController
+  def index
+    @registry = Registry.find_by_name!(params[:registry_id])
+    @package = find_package_with_normalization!(@registry, params[:package_id])
+    @version = @package.versions.find_by_number!(params[:version_id])
+    scope = @version.artifacts.order('published_at DESC nulls last, id DESC')
+
+    @pagy, @artifacts = pagy_countless(scope)
+    fresh_when @artifacts, public: true
+  end
+
+  def show
+    @artifact = Artifact.includes(version: { package: :registry }).find(params[:id])
+    fresh_when @artifact, public: true
+  end
+
+  def lookup
+    scope = Artifact.lookup(params)
+
+    if scope.nil?
+      return render json: { error: 'Missing integrity parameter' }, status: :bad_request
+    end
+
+    scope = scope.includes(version: [:dependencies, { package: :registry }])
+                 .order('artifacts.published_at DESC nulls last, artifacts.id DESC')
+    @pagy, @artifacts = pagy_countless(scope)
+  end
+end

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -1,0 +1,31 @@
+class Artifact < ApplicationRecord
+  SYNC_ATTRIBUTES = %i[
+    identifier
+    filename
+    kind
+    download_url
+    size
+    published_at
+    status
+    integrity
+    metadata
+  ].freeze
+
+  validates_presence_of :version_id, :identifier
+  validates_uniqueness_of :identifier, scope: :version_id
+
+  belongs_to :version
+
+  def self.lookup(params)
+    exact_integrity = params[:integrity].presence&.to_s
+    normalized_integrity = Version.normalize_integrity(params)
+    return if exact_integrity.blank? && normalized_integrity.blank?
+
+    if exact_integrity.present?
+      exact_matches = where(integrity: exact_integrity)
+      return exact_matches if exact_matches.exists?
+    end
+
+    where(integrity: normalized_integrity)
+  end
+end

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -20,6 +20,7 @@ class Artifact < ApplicationRecord
     exact_integrity = params[:integrity].presence&.to_s
     normalized_integrity = Version.normalize_integrity(params)
     return if exact_integrity.blank? && normalized_integrity.blank?
+    return where(integrity: normalized_integrity) if exact_integrity == normalized_integrity
 
     if exact_integrity.present?
       exact_matches = where(integrity: exact_integrity)

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -121,7 +121,7 @@ module Ecosystem
       []
     end
 
-    def artifacts_metadata(_package_metadata, _version_metadata)
+    def artifacts_metadata(_package_metadata)
       nil
     end
 

--- a/app/models/ecosystem/base.rb
+++ b/app/models/ecosystem/base.rb
@@ -121,6 +121,10 @@ module Ecosystem
       []
     end
 
+    def artifacts_metadata(_package_metadata, _version_metadata)
+      nil
+    end
+
     def fetch_package_metadata(name, version: nil)
       cache_key = [name, version]
       return @last_fetched_metadata if @last_fetched_key == cache_key

--- a/app/models/ecosystem/pypi.rb
+++ b/app/models/ecosystem/pypi.rb
@@ -187,10 +187,11 @@ module Ecosystem
       end
     end
 
-    def artifacts_metadata(package_metadata, version_metadata)
-      number = version_metadata[:number] || version_metadata['number']
+    def artifacts_metadata(package_metadata)
       releases = package_metadata[:releases] || package_metadata['releases'] || {}
-      Array(releases[number]).map { |file| artifact_metadata(file) }
+      releases.to_h do |number, files|
+        [number.to_s, Array(files).map { |file| artifact_metadata(file) }]
+      end
     end
 
     def artifact_metadata(file)
@@ -201,7 +202,8 @@ module Ecosystem
         python_version: file['python_version'],
         has_sig: file['has_sig']
       }
-      metadata[:wheel_tags] = wheel_tags(file['filename']) if file['packagetype'] == 'bdist_wheel'
+      tags = wheel_tags(file['filename']) if file['packagetype'] == 'bdist_wheel'
+      metadata[:wheel_tags] = tags if tags
 
       {
         identifier: file['filename'],
@@ -218,6 +220,8 @@ module Ecosystem
 
     def wheel_tags(filename)
       parts = File.basename(filename, '.whl').split('-')
+      return if parts.length < 5
+
       {
         python: parts[-3],
         abi: parts[-2],

--- a/app/models/ecosystem/pypi.rb
+++ b/app/models/ecosystem/pypi.rb
@@ -187,6 +187,44 @@ module Ecosystem
       end
     end
 
+    def artifacts_metadata(package_metadata, version_metadata)
+      number = version_metadata[:number] || version_metadata['number']
+      releases = package_metadata[:releases] || package_metadata['releases'] || {}
+      Array(releases[number]).map { |file| artifact_metadata(file) }
+    end
+
+    def artifact_metadata(file)
+      metadata = {
+        digests: file['digests'],
+        requires_python: file['requires_python'],
+        yanked_reason: file['yanked_reason'],
+        python_version: file['python_version'],
+        has_sig: file['has_sig']
+      }
+      metadata[:wheel_tags] = wheel_tags(file['filename']) if file['packagetype'] == 'bdist_wheel'
+
+      {
+        identifier: file['filename'],
+        filename: file['filename'],
+        kind: file['packagetype'] == 'bdist_wheel' ? 'wheel' : file['packagetype'],
+        download_url: file['url'],
+        size: file['size'],
+        published_at: file['upload_time_iso_8601'] || file['upload_time'],
+        status: file['yanked'] ? 'yanked' : nil,
+        integrity: file.dig('digests', 'sha256').presence&.then { |digest| "sha256-#{digest}" },
+        metadata: metadata
+      }
+    end
+
+    def wheel_tags(filename)
+      parts = File.basename(filename, '.whl').split('-')
+      {
+        python: parts[-3],
+        abi: parts[-2],
+        platform: parts[-1]
+      }
+    end
+
     def parse_pep_508_dep_spec(dep)
       name, requirement = dep.split(PEP_508_NAME_WITH_EXTRAS_REGEX, 2).last(2)
       version, environment_markers = requirement.split(";").map(&:strip)

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -442,7 +442,6 @@ class Package < ApplicationRecord
 
     created_versions = []
     versions_metadata.each do |version|
-      artifacts_metadata = ecosystem.artifacts_metadata(package_metadata, version)
       if version[:integrity].present?
         v = versions.find{|ver| ver.integrity == version[:integrity] }
       else
@@ -462,13 +461,23 @@ class Package < ApplicationRecord
           created_versions << created if created.persisted?
           v = created
         end
-        v.sync_artifacts(artifacts_metadata) if v&.persisted? && !artifacts_metadata.nil?
       rescue ActiveRecord::RecordNotUnique
         Rails.logger.warn("Version not unique: #{version[:number]}")
       end
     end
+    sync_artifacts(package_metadata, ecosystem)
     update_columns(versions_count: versions.count, versions_updated_at: Time.now)
     emit_new_version_events(created_versions)
+  end
+
+  def sync_artifacts(package_metadata, ecosystem = registry.ecosystem_instance)
+    artifacts_by_version = ecosystem.artifacts_metadata(package_metadata)
+    return if artifacts_by_version.nil?
+
+    versions_by_number = versions.where(number: artifacts_by_version.keys).index_by(&:number)
+    artifacts_by_version.each do |number, artifacts_metadata|
+      versions_by_number[number.to_s]&.sync_artifacts(artifacts_metadata)
+    end
   end
 
   def update_versions_async

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -442,6 +442,7 @@ class Package < ApplicationRecord
 
     created_versions = []
     versions_metadata.each do |version|
+      artifacts_metadata = ecosystem.artifacts_metadata(package_metadata, version)
       if version[:integrity].present?
         v = versions.find{|ver| ver.integrity == version[:integrity] }
       else
@@ -459,7 +460,9 @@ class Package < ApplicationRecord
         else
           created = versions.create(version)
           created_versions << created if created.persisted?
+          v = created
         end
+        v.sync_artifacts(artifacts_metadata) if v&.persisted? && !artifacts_metadata.nil?
       rescue ActiveRecord::RecordNotUnique
         Rails.logger.warn("Version not unique: #{version[:number]}")
       end

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -340,6 +340,8 @@ class Registry < ApplicationRecord
       end
     end
 
+    package.sync_artifacts(package_metadata, ecosystem_instance)
+
     package.update(versions_count: package.versions.count, last_synced_at: Time.zone.now)
     package.update_details
     package.update_dependent_repos_count_async if ecosystem_instance.has_dependent_repos?

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -9,6 +9,7 @@ class Version < ApplicationRecord
   counter_culture :package
   has_many :dependencies, dependent: :delete_all
   has_many :runtime_dependencies, -> { where kind: %w[runtime normal] }, class_name: "Dependency"
+  has_many :artifacts, dependent: :delete_all
 
   def self.sortable_columns
     {
@@ -62,11 +63,39 @@ class Version < ApplicationRecord
         integrity
       end
     else
-      integrity.sub(/\A(sha256|sha1|sha512)-(.+)\z/i) do
+      integrity.sub(/\A(sha256|sha1|sha512)[-:=](.+)\z/i) do
         digest = Regexp.last_match(2)
         digest = digest.downcase if digest.match?(/\A[a-fA-F0-9]+\z/)
 
         "#{Regexp.last_match(1).downcase}-#{digest}"
+      end
+    end
+  end
+
+  def sync_artifacts(artifacts_metadata)
+    return if artifacts_metadata.nil?
+
+    now = Time.current
+    rows = artifacts_metadata.map do |artifact_metadata|
+      artifact_metadata = artifact_metadata.with_indifferent_access
+      attributes = Artifact::SYNC_ATTRIBUTES.index_with { |attribute| artifact_metadata[attribute] }
+      raise ArgumentError, 'Artifact identifier is required' if attributes[:identifier].blank?
+
+      attributes.merge(version_id: id, created_at: now, updated_at: now)
+    end
+
+    Artifact.transaction do
+      identifiers = rows.pluck(:identifier)
+      missing_artifacts = artifacts.where.not(status: 'removed').or(artifacts.where(status: nil))
+      missing_artifacts = missing_artifacts.where.not(identifier: identifiers) if identifiers.any?
+      missing_artifacts.update_all(status: 'removed', updated_at: now)
+
+      if rows.any?
+        Artifact.upsert_all(
+          rows,
+          unique_by: [:version_id, :identifier],
+          update_only: Artifact::SYNC_ATTRIBUTES - [:identifier]
+        )
       end
     end
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -83,6 +83,7 @@ class Version < ApplicationRecord
 
       attributes.merge(version_id: id, created_at: now, updated_at: now)
     end
+    rows = rows.index_by { |row| row[:identifier] }.values
 
     Artifact.transaction do
       identifiers = rows.pluck(:identifier)

--- a/app/views/api/v1/artifacts/_artifact.json.jbuilder
+++ b/app/views/api/v1/artifacts/_artifact.json.jbuilder
@@ -1,0 +1,3 @@
+json.extract! artifact, :id, :identifier, :filename, :kind, :download_url, :size, :published_at, :status, :integrity, :metadata, :created_at, :updated_at
+json.artifact_url api_v1_artifact_url(artifact)
+json.version_url api_v1_registry_package_version_url(artifact.version.package.registry, artifact.version.package, artifact.version)

--- a/app/views/api/v1/artifacts/index.json.jbuilder
+++ b/app/views/api/v1/artifacts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @artifacts, partial: 'api/v1/artifacts/artifact', as: :artifact

--- a/app/views/api/v1/artifacts/lookup.json.jbuilder
+++ b/app/views/api/v1/artifacts/lookup.json.jbuilder
@@ -1,0 +1,16 @@
+json.array! @artifacts do |artifact|
+  version = artifact.version
+
+  json.partial! 'api/v1/artifacts/artifact', artifact: artifact
+  json.version do
+    json.partial! 'api/v1/versions/version', version: version
+
+    json.package do
+      json.partial! 'api/v1/packages/package', package: version.package
+
+      json.registry do
+        json.partial! 'api/v1/registries/registry', registry: version.package.registry
+      end
+    end
+  end
+end

--- a/app/views/api/v1/artifacts/show.json.jbuilder
+++ b/app/views/api/v1/artifacts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/artifacts/artifact', artifact: @artifact

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :artifacts, only: [:show] do
+        collection do
+          get :lookup
+        end
+      end
+
       resources :keywords, only: [:index, :show], constraints: { id: /.*/ }, defaults: { format: :json }
 
       resources :critical, only: [:index] do
@@ -57,6 +63,7 @@ Rails.application.routes.draw do
 
         resources :packages, constraints: { id: /.*/ }, only: [:index, :show] do
           resources :versions, only: [:index, :show], constraints: { id: /.*/ } do
+            resources :artifacts, only: [:index]
             member do
               get :codemeta, to: 'versions#codemeta'
             end

--- a/db/migrate/20260824090000_create_artifacts.rb
+++ b/db/migrate/20260824090000_create_artifacts.rb
@@ -1,0 +1,22 @@
+class CreateArtifacts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :artifacts do |t|
+      t.references :version, null: false, type: :bigint,
+                             foreign_key: { on_delete: :cascade }, index: false
+      t.string :identifier, null: false
+      t.string :filename
+      t.string :kind
+      t.text :download_url
+      t.bigint :size
+      t.datetime :published_at
+      t.string :status
+      t.string :integrity
+      t.jsonb :metadata
+      t.timestamps
+    end
+
+    add_index :artifacts, :version_id
+    add_index :artifacts, [:version_id, :identifier], unique: true
+    add_index :artifacts, :integrity, using: :hash, where: "integrity IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_22_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -35,6 +35,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_22_190000) do
     t.string "uuid"
     t.datetime "withdrawn_at"
     t.index ["source_id"], name: "index_advisories_on_source_id"
+  end
+
+  create_table "artifacts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "download_url"
+    t.string "filename"
+    t.string "identifier", null: false
+    t.string "integrity"
+    t.string "kind"
+    t.jsonb "metadata"
+    t.datetime "published_at"
+    t.bigint "size"
+    t.string "status"
+    t.datetime "updated_at", null: false
+    t.bigint "version_id", null: false
+    t.index ["integrity"], name: "index_artifacts_on_integrity", where: "(integrity IS NOT NULL)", using: :hash
+    t.index ["version_id", "identifier"], name: "index_artifacts_on_version_id_and_identifier", unique: true
+    t.index ["version_id"], name: "index_artifacts_on_version_id"
   end
 
   create_table "dependencies", force: :cascade do |t|
@@ -250,5 +268,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_22_190000) do
   end
 
   add_foreign_key "advisories", "sources"
+  add_foreign_key "artifacts", "versions", on_delete: :cascade
   add_foreign_key "registry_growth_stats", "registries"
 end

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -254,6 +254,83 @@ paths:
         '400':
           description: missing integrity parameter
 
+  /artifacts/lookup:
+    get:
+      summary: lookup artifacts by integrity value
+      operationId: lookupArtifacts
+      tags:
+        - artifacts
+      parameters:
+        - name: integrity
+          in: query
+          description: integrity value from a lockfile or registry
+          required: false
+          schema:
+            type: string
+        - name: sha256
+          in: query
+          description: sha256 hash in hex
+          required: false
+          schema:
+            type: string
+        - name: sha1
+          in: query
+          description: sha1 hash in hex
+          required: false
+          schema:
+            type: string
+        - name: sha512
+          in: query
+          description: sha512 hash in hex
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: page number
+          required: false
+          schema:
+            type: integer
+        - name: per_page
+          in: query
+          description: number of records to return
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ArtifactLookup'
+        '400':
+          description: missing integrity parameter
+  /artifacts/{artifactId}:
+    get:
+      summary: get an artifact
+      operationId: getArtifact
+      tags:
+        - artifacts
+      parameters:
+        - in: path
+          name: artifactId
+          schema:
+            type: integer
+          required: true
+          description: artifact id
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Artifact'
+        '404':
+          description: artifact not found
+
   /packages/lookup:
     get:
       summary: lookup a package by repository URL, purl or ecosystem+name
@@ -1636,6 +1713,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionWithDependencies'
+  /registries/{registryName}/packages/{packageName}/versions/{versionNumber}/artifacts:
+    get:
+      summary: get artifacts for a package version
+      operationId: getRegistryPackageVersionArtifacts
+      tags:
+        - artifacts
+      parameters:
+        - in: path
+          name: registryName
+          schema:
+            type: string
+          required: true
+          description: name of registry
+        - in: path
+          name: packageName
+          schema:
+            type: string
+          required: true
+          description: name of package
+        - in: path
+          name: versionNumber
+          schema:
+            type: string
+          required: true
+          description: number of version
+        - name: page
+          in: query
+          description: page number
+          required: false
+          schema:
+            type: integer
+        - name: per_page
+          in: query
+          description: number of records to return
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Artifact'
+        404:
+          description: registry, package, or version not found
   /registries/{registryName}/packages/{packageName}/versions/{versionNumber}/codemeta:
     get:
       summary: get CodeMeta metadata for a version
@@ -2009,6 +2134,64 @@ components:
               $ref: '#/components/schemas/Registry'
           required:
             - registry
+    Artifact:
+      required:
+        - id
+        - identifier
+        - filename
+        - kind
+        - download_url
+        - size
+        - published_at
+        - status
+        - integrity
+        - metadata
+        - created_at
+        - updated_at
+        - artifact_url
+        - version_url
+      type: object
+      properties:
+        id:
+          type: integer
+        identifier:
+          type: string
+        filename:
+          type: string
+          nullable: true
+        kind:
+          type: string
+          nullable: true
+        download_url:
+          type: string
+          nullable: true
+        size:
+          type: integer
+          format: int64
+          nullable: true
+        published_at:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        integrity:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        artifact_url:
+          type: string
+        version_url:
+          type: string
     Version:
       required:
         - id
@@ -2158,6 +2341,15 @@ components:
           properties:
             package:
               $ref: '#/components/schemas/PackageWithRegistry'
+    ArtifactLookup:
+      allOf:
+        - $ref: '#/components/schemas/Artifact'
+        - type: object
+          required:
+            - version
+          properties:
+            version:
+              $ref: '#/components/schemas/VersionLookup'
     VersionWithPackage:
       required:
         - id

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -257,6 +257,7 @@ paths:
   /artifacts/lookup:
     get:
       summary: lookup artifacts by integrity value
+      description: provide integrity, sha256, sha1, or sha512; exact integrity matching runs before known SHA wrapper normalization
       operationId: lookupArtifacts
       tags:
         - artifacts
@@ -307,7 +308,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ArtifactLookup'
         '400':
-          description: missing integrity parameter
+          description: missing integrity, sha256, sha1, or sha512 parameter
   /artifacts/{artifactId}:
     get:
       summary: get an artifact
@@ -1751,7 +1752,7 @@ paths:
           schema:
             type: integer
       responses:
-        200:
+        '200':
           description: OK
           content:
             application/json:
@@ -1759,7 +1760,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Artifact'
-        404:
+        '404':
           description: registry, package, or version not found
   /registries/{registryName}/packages/{packageName}/versions/{versionNumber}/codemeta:
     get:

--- a/test/controllers/api/v1/artifacts_controller_test.rb
+++ b/test/controllers/api/v1/artifacts_controller_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class ApiV1ArtifactsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @registry = Registry.create!(name: 'crates.io', url: 'https://crates.io', ecosystem: 'cargo')
+    @package = @registry.packages.create!(ecosystem: 'cargo', name: 'rand')
+    @version = @package.versions.create!(number: '1.0.0', registry: @registry)
+    @artifact = @version.artifacts.create!(
+      identifier: 'rand-1.0.0.crate',
+      filename: 'rand-1.0.0.crate',
+      kind: 'crate',
+      download_url: 'https://static.crates.io/crates/rand/rand-1.0.0.crate',
+      size: 123,
+      published_at: 1.day.ago,
+      integrity: "sha256-#{'a' * 64}",
+      metadata: { 'source' => 'registry' }
+    )
+  end
+
+  test 'lists artifacts for a version with pagination' do
+    @version.artifacts.create!(identifier: 'rand-1.0.0.asc')
+    @version.artifacts.create!(identifier: 'rand-1.0.0.sig')
+
+    get api_v1_registry_package_version_artifacts_path(
+      registry_id: @registry.name,
+      package_id: @package.name,
+      version_id: @version.number,
+      per_page: 2
+    )
+
+    assert_response :success
+    assert_template 'artifacts/index', file: 'artifacts/index.json.jbuilder'
+    assert_equal 2, Oj.load(@response.body).length
+  end
+
+  test 'gets an artifact' do
+    get api_v1_artifact_path(@artifact)
+
+    assert_response :success
+    assert_template 'artifacts/show', file: 'artifacts/show.json.jbuilder'
+    response = Oj.load(@response.body)
+    assert_equal @artifact.identifier, response['identifier']
+    assert_equal @artifact.metadata, response['metadata']
+    assert_equal api_v1_registry_package_version_url(@registry, @package, @version), response['version_url']
+  end
+
+  test 'lookup prefers an exact integrity value' do
+    digest = 'b' * 64
+    exact = @version.artifacts.create!(identifier: 'exact', integrity: "sha256:#{digest}")
+    @version.artifacts.create!(identifier: 'normalized', integrity: "sha256-#{digest}")
+
+    get lookup_api_v1_artifacts_path(integrity: "sha256:#{digest}")
+
+    assert_response :success
+    response = Oj.load(@response.body)
+    assert_equal [exact.id], response.pluck('id')
+    assert_equal @package.name, response.first.dig('version', 'package', 'name')
+    assert_equal @registry.name, response.first.dig('version', 'package', 'registry', 'name')
+  end
+
+  test 'lookup normalizes a known integrity wrapper after exact lookup misses' do
+    digest = 'c' * 64
+    artifact = @version.artifacts.create!(identifier: 'normalized', integrity: "sha256-#{digest}")
+
+    get lookup_api_v1_artifacts_path(integrity: "SHA256:#{digest.upcase}")
+
+    assert_response :success
+    assert_equal [artifact.id], Oj.load(@response.body).pluck('id')
+  end
+
+  test 'lookup accepts an opaque integrity value' do
+    artifact = @version.artifacts.create!(identifier: 'go-module', integrity: 'h1:AbCdEf==')
+
+    get lookup_api_v1_artifacts_path(integrity: 'h1:AbCdEf==')
+
+    assert_response :success
+    assert_equal [artifact.id], Oj.load(@response.body).pluck('id')
+  end
+
+  test 'lookup returns bad request without an integrity parameter' do
+    get lookup_api_v1_artifacts_path
+
+    assert_response :bad_request
+    assert_equal 'Missing integrity parameter', Oj.load(@response.body)['error']
+  end
+end

--- a/test/controllers/api/v1/artifacts_controller_test.rb
+++ b/test/controllers/api/v1/artifacts_controller_test.rb
@@ -77,10 +77,33 @@ class ApiV1ArtifactsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [artifact.id], Oj.load(@response.body).pluck('id')
   end
 
+  test 'lookup preloads package maintainers' do
+    maintainer = @registry.maintainers.create!(uuid: 'first', login: 'first')
+    @package.maintainerships.create!(maintainer: maintainer)
+    second_package = @registry.packages.create!(ecosystem: 'cargo', name: 'rand-core')
+    second_version = second_package.versions.create!(number: '1.0.0', registry: @registry)
+    second_maintainer = @registry.maintainers.create!(uuid: 'second', login: 'second')
+    second_package.maintainerships.create!(maintainer: second_maintainer)
+    second_version.artifacts.create!(identifier: 'rand-core-1.0.0.crate', integrity: @artifact.integrity)
+    queries = []
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      queries << sql if sql.include?('FROM "maintainerships"') || sql.include?('FROM "maintainers"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') do
+      get lookup_api_v1_artifacts_path(integrity: @artifact.integrity)
+    end
+
+    assert_response :success
+    assert_equal 2, queries.length
+    assert_equal %w[first second], Oj.load(@response.body).flat_map { |artifact| artifact.dig('version', 'package', 'maintainers') }.pluck('login').sort
+  end
+
   test 'lookup returns bad request without an integrity parameter' do
     get lookup_api_v1_artifacts_path
 
     assert_response :bad_request
-    assert_equal 'Missing integrity parameter', Oj.load(@response.body)['error']
+    assert_equal 'Missing integrity, sha256, sha1, or sha512 parameter', Oj.load(@response.body)['error']
   end
 end

--- a/test/integration/openapi_test.rb
+++ b/test/integration/openapi_test.rb
@@ -14,6 +14,13 @@ class OpenapiTest < ActiveSupport::TestCase
     assert document.dig('paths', '/registries/{registryName}/packages/{packageName}/versions/{versionNumber}/artifacts')
     assert document.dig('components', 'schemas', 'Artifact')
     assert document.dig('components', 'schemas', 'ArtifactLookup')
+
+    lookup = document.dig('paths', '/artifacts/lookup', 'get')
+    assert_includes lookup['description'], 'integrity, sha256, sha1, or sha512'
+    assert_equal %w[200 400], lookup.fetch('responses').keys
+
+    nested = document.dig('paths', '/registries/{registryName}/packages/{packageName}/versions/{versionNumber}/artifacts', 'get')
+    assert_equal %w[200 404], nested.fetch('responses').keys
   end
 
   test 'openapi operation ids are unique' do

--- a/test/integration/openapi_test.rb
+++ b/test/integration/openapi_test.rb
@@ -5,4 +5,25 @@ class OpenapiTest < ActiveSupport::TestCase
     f = YAML.load_file(Rails.root.join('openapi/api/v1/openapi.yaml'))
     assert_equal f.class, Hash
   end
+
+  test 'openapi.yaml documents artifact endpoints' do
+    document = YAML.load_file(Rails.root.join('openapi/api/v1/openapi.yaml'))
+
+    assert document.dig('paths', '/artifacts/lookup')
+    assert document.dig('paths', '/artifacts/{artifactId}')
+    assert document.dig('paths', '/registries/{registryName}/packages/{packageName}/versions/{versionNumber}/artifacts')
+    assert document.dig('components', 'schemas', 'Artifact')
+    assert document.dig('components', 'schemas', 'ArtifactLookup')
+  end
+
+  test 'openapi operation ids are unique' do
+    document = YAML.load_file(Rails.root.join('openapi/api/v1/openapi.yaml'))
+    operation_ids = document.fetch('paths').values.flat_map do |path|
+      path.values.filter_map do |operation|
+        operation['operationId'] if operation.is_a?(Hash)
+      end
+    end
+
+    assert_equal operation_ids.uniq, operation_ids
+  end
 end

--- a/test/models/artifact_test.rb
+++ b/test/models/artifact_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class ArtifactTest < ActiveSupport::TestCase
+  subject { @version.artifacts.build(identifier: 'module') }
+
+  context 'associations' do
+    should belong_to(:version)
+  end
+
+  context 'validations' do
+    should validate_presence_of(:version_id)
+    should validate_presence_of(:identifier)
+    should validate_uniqueness_of(:identifier).scoped_to(:version_id)
+  end
+
+  setup do
+    registry = Registry.create!(name: 'proxy.golang.org', url: 'https://proxy.golang.org', ecosystem: 'go')
+    package = registry.packages.create!(name: 'example.com/module', ecosystem: 'go')
+    @version = package.versions.create!(number: 'v1.0.0', registry: registry)
+  end
+
+  test 'accepts an opaque integrity value' do
+    artifact = @version.artifacts.create!(identifier: 'module.zip', integrity: 'h1:AbCdEf==')
+
+    assert_equal 'h1:AbCdEf==', artifact.integrity
+  end
+
+  test 'indexes integrity with a partial hash index' do
+    index = ActiveRecord::Base.connection.indexes(:artifacts).find do |candidate|
+      candidate.name == 'index_artifacts_on_integrity'
+    end
+
+    assert_equal :hash, index.using
+    assert_equal '(integrity IS NOT NULL)', index.where
+  end
+end

--- a/test/models/artifact_test.rb
+++ b/test/models/artifact_test.rb
@@ -33,4 +33,20 @@ class ArtifactTest < ActiveSupport::TestCase
     assert_equal :hash, index.using
     assert_equal '(integrity IS NOT NULL)', index.where
   end
+
+  test 'lookup queries an already normalized integrity once' do
+    artifact = @version.artifacts.create!(identifier: 'module.zip', integrity: "sha256-#{'a' * 64}")
+    queries = []
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      queries << sql if sql.start_with?('SELECT') && sql.include?('"artifacts"')
+    end
+
+    ids = ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') do
+      Artifact.lookup(integrity: artifact.integrity).pluck(:id)
+    end
+
+    assert_equal [artifact.id], ids
+    assert_equal 1, queries.length
+  end
 end

--- a/test/models/ecosystem/pypi_test.rb
+++ b/test/models/ecosystem/pypi_test.rb
@@ -133,37 +133,71 @@ class PypiTest < ActiveSupport::TestCase
     ]
   end
 
-  test 'artifacts_metadata maps every release file' do
-    version_json = JSON.parse(file_fixture('pypi/siuba-0.3.0.json').read)
-    package_metadata = { releases: { '0.3.0' => version_json['urls'] } }
+  test 'artifacts_metadata maps every package response release file' do
+    stub_request(:get, "https://pypistats.org/api/packages/yiban/recent")
+      .to_return({ status: 200, body: file_fixture('pypi/recent.json') })
+    package_json = JSON.parse(file_fixture('pypi/0.1.2.32.json').read)
+    package_metadata = @ecosystem.map_package_metadata(package_json)
 
-    artifacts = @ecosystem.artifacts_metadata(package_metadata, number: '0.3.0')
+    artifacts_by_version = @ecosystem.artifacts_metadata(package_metadata)
+    artifacts = artifacts_by_version.fetch('0.7.0.1')
 
+    assert_equal 5, artifacts_by_version.length
+    assert_equal 6, artifacts_by_version.values.sum(&:length)
     assert_equal 2, artifacts.length
     wheel = artifacts.find { |artifact| artifact[:kind] == 'wheel' }
     sdist = artifacts.find { |artifact| artifact[:kind] == 'sdist' }
-    assert_equal 'siuba-0.3.0-py3-none-any.whl', wheel[:identifier]
-    assert_equal "sha256-#{version_json['urls'][0]['digests']['sha256']}", wheel[:integrity]
+    assert_equal 'yiban-0.7.0.1-py3-none-any.whl', wheel[:identifier]
+    assert_equal "sha256-#{package_json.dig('releases', '0.7.0.1', 0, 'digests', 'sha256')}", wheel[:integrity]
     assert_equal({ python: 'py3', abi: 'none', platform: 'any' }, wheel.dig(:metadata, :wheel_tags))
-    assert_equal 'siuba-0.3.0.tar.gz', sdist[:identifier]
+    assert_equal 'yiban-0.7.0.1.tar.gz', sdist[:identifier]
   end
 
-  test 'update_versions stores artifacts idempotently' do
+  test 'registry sync stores package response artifacts idempotently' do
     registry = Registry.create!(default: true, name: 'Pypi artifacts', url: 'https://pypi.org', ecosystem: 'pypi')
-    ecosystem = Ecosystem::Pypi.new(registry)
-    package = registry.packages.create!(name: 'siuba', ecosystem: 'pypi')
-    version_json = JSON.parse(file_fixture('pypi/siuba-0.3.0.json').read)
-    package_metadata = { name: 'siuba', releases: { '0.3.0' => version_json['urls'] } }
-    registry.stubs(:ecosystem_instance).returns(ecosystem)
-    ecosystem.stubs(:package_metadata).with('siuba').returns(package_metadata)
+    ecosystem = registry.ecosystem_instance
+    stub_request(:get, "https://pypi.org/pypi/yiban/json")
+      .to_return({ status: 200, body: file_fixture('pypi/0.1.2.32.json') })
+    stub_request(:get, "https://pypistats.org/api/packages/yiban/recent")
+      .to_return({ status: 200, body: file_fixture('pypi/recent.json') })
+    ecosystem.stubs(:version_licenses).returns(nil)
+    ecosystem.stubs(:dependencies_metadata).returns([])
+    ecosystem.stubs(:has_dependent_repos?).returns(false)
+    Package.any_instance.stubs(:update_repo_metadata_async)
+    Package.any_instance.stubs(:check_status)
+
+    package = registry.sync_package('yiban', force: true)
+    artifacts = Artifact.joins(:version).where(versions: { package_id: package.id })
+    first_ids = artifacts.order(:identifier).pluck(:id)
+
+    registry.sync_package('yiban', force: true)
+
+    assert_equal 5, package.versions.count
+    assert_equal 6, artifacts.count
+    assert_equal first_ids, artifacts.order(:identifier).pluck(:id)
+    assert_equal %w[sdist wheel], package.versions.find_by!(number: '0.7.0.1').artifacts.order(:kind).pluck(:kind)
+  end
+
+  test 'update_versions stores artifacts from package response metadata' do
+    registry = Registry.create!(default: true, name: 'Pypi version artifacts', url: 'https://pypi.org', ecosystem: 'pypi')
+    ecosystem = registry.ecosystem_instance
+    package = registry.packages.create!(name: 'yiban', ecosystem: 'pypi')
+    stub_request(:get, "https://pypistats.org/api/packages/yiban/recent")
+      .to_return({ status: 200, body: file_fixture('pypi/recent.json') })
+    package_json = JSON.parse(file_fixture('pypi/0.1.2.32.json').read)
+    package_metadata = ecosystem.map_package_metadata(package_json)
+    ecosystem.stubs(:package_metadata).with('yiban').returns(package_metadata)
     ecosystem.stubs(:version_licenses).returns(nil)
 
     package.update_versions
-    package.update_versions
 
-    version = package.versions.find_by!(number: '0.3.0')
-    assert_equal 2, version.artifacts.count
-    assert_equal %w[sdist wheel], version.artifacts.order(:kind).pluck(:kind)
+    artifacts = Artifact.joins(:version).where(versions: { package_id: package.id })
+    assert_equal 5, package.versions.count
+    assert_equal 6, artifacts.count
+  end
+
+  test 'wheel_tags rejects a malformed filename' do
+    assert_nil @ecosystem.wheel_tags('broken.whl')
   end
 
   test 'dependencies_metadata' do

--- a/test/models/ecosystem/pypi_test.rb
+++ b/test/models/ecosystem/pypi_test.rb
@@ -133,6 +133,39 @@ class PypiTest < ActiveSupport::TestCase
     ]
   end
 
+  test 'artifacts_metadata maps every release file' do
+    version_json = JSON.parse(file_fixture('pypi/siuba-0.3.0.json').read)
+    package_metadata = { releases: { '0.3.0' => version_json['urls'] } }
+
+    artifacts = @ecosystem.artifacts_metadata(package_metadata, number: '0.3.0')
+
+    assert_equal 2, artifacts.length
+    wheel = artifacts.find { |artifact| artifact[:kind] == 'wheel' }
+    sdist = artifacts.find { |artifact| artifact[:kind] == 'sdist' }
+    assert_equal 'siuba-0.3.0-py3-none-any.whl', wheel[:identifier]
+    assert_equal "sha256-#{version_json['urls'][0]['digests']['sha256']}", wheel[:integrity]
+    assert_equal({ python: 'py3', abi: 'none', platform: 'any' }, wheel.dig(:metadata, :wheel_tags))
+    assert_equal 'siuba-0.3.0.tar.gz', sdist[:identifier]
+  end
+
+  test 'update_versions stores artifacts idempotently' do
+    registry = Registry.create!(default: true, name: 'Pypi artifacts', url: 'https://pypi.org', ecosystem: 'pypi')
+    ecosystem = Ecosystem::Pypi.new(registry)
+    package = registry.packages.create!(name: 'siuba', ecosystem: 'pypi')
+    version_json = JSON.parse(file_fixture('pypi/siuba-0.3.0.json').read)
+    package_metadata = { name: 'siuba', releases: { '0.3.0' => version_json['urls'] } }
+    registry.stubs(:ecosystem_instance).returns(ecosystem)
+    ecosystem.stubs(:package_metadata).with('siuba').returns(package_metadata)
+    ecosystem.stubs(:version_licenses).returns(nil)
+
+    package.update_versions
+    package.update_versions
+
+    version = package.versions.find_by!(number: '0.3.0')
+    assert_equal 2, version.artifacts.count
+    assert_equal %w[sdist wheel], version.artifacts.order(:kind).pluck(:kind)
+  end
+
   test 'dependencies_metadata' do
     stub_request(:get, "https://pypi.org/pypi/yiban/0.1.2.32/json")
       .to_return({ status: 200, body: file_fixture('pypi/yiban-0.1.2.32.json') })

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -116,4 +116,14 @@ class VersionTest < ActiveSupport::TestCase
       @version.sync_artifacts([{ filename: 'foo-1.0.0.gem' }])
     end
   end
+
+  test 'sync_artifacts keeps the last duplicate identifier' do
+    @version.sync_artifacts([
+      { identifier: 'foo-1.0.0.gem', size: 100 },
+      { identifier: 'foo-1.0.0.gem', size: 200 }
+    ])
+
+    assert_equal 1, @version.artifacts.count
+    assert_equal 200, @version.artifacts.first.size
+  end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -4,6 +4,7 @@ class VersionTest < ActiveSupport::TestCase
   context 'associations' do
     should belong_to(:package)
     should have_many(:dependencies)
+    should have_many(:artifacts)
   end
 
   context 'validations' do
@@ -74,5 +75,45 @@ class VersionTest < ActiveSupport::TestCase
     assert json.key?('integrity')
     assert json.key?('status')
     refute json.key?('dependencies')
+  end
+
+  test 'sync_artifacts upserts by identifier' do
+    artifacts_metadata = [
+      {
+        identifier: 'foo-1.0.0.gem',
+        filename: 'foo-1.0.0.gem',
+        kind: 'gem',
+        integrity: "sha256-#{'a' * 64}"
+      }
+    ]
+
+    @version.sync_artifacts(artifacts_metadata)
+    @version.sync_artifacts(artifacts_metadata.first.merge(size: 123).then { |artifact| [artifact] })
+
+    assert_equal 1, @version.artifacts.count
+    assert_equal 123, @version.artifacts.first.size
+  end
+
+  test 'sync_artifacts marks missing artifacts as removed' do
+    @version.sync_artifacts([{ identifier: 'old.gem' }, { identifier: 'current.gem' }])
+
+    @version.sync_artifacts([{ identifier: 'current.gem' }])
+
+    assert_equal 'removed', @version.artifacts.find_by!(identifier: 'old.gem').status
+    assert_nil @version.artifacts.find_by!(identifier: 'current.gem').status
+  end
+
+  test 'sync_artifacts leaves artifacts unchanged when metadata is unsupported' do
+    artifact = @version.artifacts.create!(identifier: 'foo-1.0.0.gem')
+
+    @version.sync_artifacts(nil)
+
+    assert_nil artifact.reload.status
+  end
+
+  test 'sync_artifacts requires an identifier' do
+    assert_raises ArgumentError do
+      @version.sync_artifacts([{ filename: 'foo-1.0.0.gem' }])
+    end
   end
 end


### PR DESCRIPTION
Adds an artifacts table for files attached to package versions. Integrity values remain opaque, with exact lookup before normalization of known SHA wrappers. The table uses JSONB metadata and a partial PostgreSQL hash index for integrity lookups.

PyPI sync now stores every release file, including wheel tags and digest metadata. Version syncs upsert artifacts by identifier and mark missing files as removed.

Adds paginated list and show endpoints, integrity lookup, and OpenAPI schemas.

Refs #1630