### PR TITLE
Improve repository_url detection across six ecosystems

### DIFF
--- a/app/models/ecosystem/bioconductor.rb
+++ b/app/models/ecosystem/bioconductor.rb
@@ -62,12 +62,14 @@ module Ecosystem
 
     def map_package_metadata(package)
       return false unless package
+      urls = package[:properties].fetch("URL", "").split(/[,\s]+/).reject(&:blank?)
+      bug_reports = package[:properties]["BugReports"]
       {
         name: package[:name],
-        homepage: package[:properties].fetch("URL", "").split(",").first,
+        homepage: urls.first,
         description: package[:html].css("h2").text.strip,
         licenses: package[:properties]["License"],
-        repository_url: repo_fallback(package[:properties].fetch("URL", "").split(",").first.presence, (package[:properties].fetch("URL", "").split(",").last.presence || package[:properties]["BugReports"])).to_s[0, 255],
+        repository_url: (find_repository_url(urls + [bug_reports].compact) || urls.first).to_s[0, 255],
         keywords_array: package[:properties]["biocViews"].split(", "),
         properties: package[:properties],
         downloads: downloads(package),

--- a/app/models/ecosystem/cocoapods.rb
+++ b/app/models/ecosystem/cocoapods.rb
@@ -92,7 +92,7 @@ module Ecosystem
         description: package["summary"],
         homepage: package["homepage"],
         licenses: parse_license(package["license"]),
-        repository_url: repo_fallback(package.dig("source", "git"), ""),
+        repository_url: repo_fallback(package.dig("source", "git"), package["homepage"]),
         versions: package["version_numbers"]
       }
     end

--- a/app/models/ecosystem/cpan.rb
+++ b/app/models/ecosystem/cpan.rb
@@ -62,12 +62,15 @@ module Ecosystem
 
     def map_package_metadata(package)
       return nil if package["distribution"].nil?
+      resources = package.fetch("resources", {})
+      repo_web = resources.dig("repository", "web")
+      candidates = [repo_web, resources.dig("repository", "url"), resources.dig("bugtracker", "web"), resources["homepage"]].compact
       {
         name: package["distribution"],
-        homepage: package.fetch("resources", {})["homepage"],
+        homepage: resources["homepage"],
         description: package["abstract"],
         licenses: package.fetch("license", []).join(","),
-        repository_url: repo_fallback(package.fetch("resources", {}).fetch("repository", {})["web"], package.fetch("resources", {})["homepage"]),
+        repository_url: find_repository_url(candidates) || repo_web,
         keywords_array: package.fetch("metadata", {})["keywords"],
         metadata:{
           author: package['author']

--- a/app/models/ecosystem/hackage.rb
+++ b/app/models/ecosystem/hackage.rb
@@ -52,15 +52,19 @@ module Ecosystem
 
     def map_package_metadata(package)
       return nil if package.nil?
+      page = package[:page]
+      home_page = find_attribute(page, "Home page")
+      source_repo = find_attribute(page, "Source repo").to_s.split.last
+      bug_tracker = find_attribute(page, "Bug tracker")
       {
         name: package[:name],
-        keywords_array: Array(package[:page].css('#content div').first.css('a')[0..-2].map(&:text)),
-        description: description(package[:page]),
-        licenses: find_attribute(package[:page], "License"),
-        homepage: find_attribute(package[:page], "Home page"),
-        repository_url: repo_fallback(repository_url(find_attribute(package[:page], "Source repository")), find_attribute(package[:page], "Home page")),
-        page: package[:page],
-        downloads: find_attribute(package[:page], "Downloads").split(' ').first.to_i,
+        keywords_array: Array(page.css('#content div').first.css('a')[0..-2].map(&:text)),
+        description: description(page),
+        licenses: find_attribute(page, "License"),
+        homepage: home_page,
+        repository_url: find_repository_url([source_repo, bug_tracker, home_page].compact) || source_repo,
+        page: page,
+        downloads: find_attribute(page, "Downloads").split(' ').first.to_i,
         downloads_period: 'total'
       }
     end
@@ -97,8 +101,8 @@ module Ecosystem
     end
 
     def find_attribute(page, name)
-      tr = page.css("#content tr").select { |t| t.css("th").text.to_s.start_with?(name) }.first
-      tr&.css("td")&.text&.strip 
+      tr = page.css("#content tr").select { |t| t.css("th").text.to_s.tr("\u00a0", " ").start_with?(name) }.first
+      tr&.css("td")&.text&.strip
     end
 
     def description(page)
@@ -107,15 +111,6 @@ module Ecosystem
       return "" unless index
 
       contents[0..(index - 1)].join("\n\n")
-    end
-
-    def repository_url(text)
-      return nil unless text.present?
-
-      match = text.match(/github.com\/(.+?)\.git/)
-      return nil unless match
-
-      "https://github.com/#{match[1]}"
     end
 
     def maintainers_metadata(name)

--- a/app/models/ecosystem/hex.rb
+++ b/app/models/ecosystem/hex.rb
@@ -69,9 +69,9 @@ module Ecosystem
       {
         name: package["name"],
         homepage: links.except("github").first.try(:last),
-        repository_url: links["github"],
+        repository_url: find_repository_url(links.values),
         description: package["meta"]["description"],
-        licenses: repo_fallback(package["meta"].fetch("licenses", []).join(","), links.except("github").first.try(:last)),
+        licenses: package["meta"].fetch("licenses", []).join(","),
         releases: package['releases'],
         downloads: package['downloads']['all'],
         downloads_period: 'total'

--- a/app/models/ecosystem/pub.rb
+++ b/app/models/ecosystem/pub.rb
@@ -57,11 +57,12 @@ module Ecosystem
     def map_package_metadata(package)
       latest_version = package["latest"]
       return false if latest_version.nil?
+      pubspec = latest_version["pubspec"]
       {
         name: package["name"],
-        homepage: latest_version["pubspec"]["homepage"],
-        description: latest_version["pubspec"]["description"],
-        repository_url: repo_fallback(latest_version["pubspec"]["repository"], latest_version["pubspec"]["homepage"]),
+        homepage: pubspec["homepage"],
+        description: pubspec["description"],
+        repository_url: find_repository_url([pubspec["repository"], pubspec["issue_tracker"], pubspec["homepage"]].compact) || pubspec["repository"],
         versions: package["versions"],
         status: package['isDiscontinued'] ? 'discontinued' : nil
       }

--- a/test/fixtures/files/hackage/pandoc
+++ b/test/fixtures/files/hackage/pandoc
@@ -1,0 +1,916 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link href="/package/pandoc-3.11/docs/quick-jump.css" rel="stylesheet" type="text/css" title="QuickJump" />
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="https://fonts.googleapis.com/css?family=PT+Sans:400,400i,700" rel="stylesheet">
+<link rel="stylesheet" href="/static/hackage.css" type="text/css" />
+<link rel="icon" type="image/png" href="/static/favicon.png" />
+<link rel="search" type="application/opensearchdescription+xml" title="Hackage" href="/packages/opensearch.xml" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-solarizedlight.min.css" media="(prefers-color-scheme: light)" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" media="(prefers-color-scheme: dark)" />
+  <title>
+    pandoc: Conversion between markup formats
+  </title>
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@hackage" />
+  <meta property="og:url" content="//hackage.haskell.org/package/pandoc" />
+  <meta property="og:site_name" content="Hackage" />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="pandoc" />
+  <meta property="og:description" content="Conversion between markup formats" />
+  
+  <link rel="canonical" href="https://hackage.haskell.org/package/pandoc" />
+  <script src="/static/jquery.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script>
+  <base href="//hackage.haskell.org/package/pandoc-3.11/" />
+</head>
+
+<body>
+  <div id="page-header">
+
+  <a class="caption" href="/">Hackage :: [Package]</a>
+
+<ul class="links" id="page-menu">
+
+    <li>
+      <form action="/packages/search" method="get" class="search">
+        <button type="submit">Search&nbsp;</button>
+        <input type="text" name="terms" />
+      </form>
+    </li>
+
+    <li><a href="/packages/browse">Browse</a></li>
+
+    <li><a href="/packages/recent">What's new</a></li>
+
+    <li><a href="/upload">Upload</a></li>
+
+    <li><a href="/accounts">User accounts</a></li>
+    
+
+</ul>
+
+</div>
+
+  <div id="content">
+    <h1><a href="//hackage.haskell.org/package/pandoc">pandoc</a>: <small>Conversion between markup formats</small></h1>
+    <div style="font-size: small">
+      [ <a href="/packages/tag/gpl">gpl</a>, <a href="/packages/tag/library">library</a>, <a href="/packages/tag/text">text</a> ]
+      [ <a href="/package/pandoc/tags/edit">Propose Tags</a> ]
+      [ <a href="https://github.com/haskell/security-advisories/blob/main/CONTRIBUTING.md">Report a vulnerability</a> ]
+    </div>
+
+          
+    
+
+    <div id="flex-container">
+      <div id="left-pane">
+
+        <div id="description">
+                    <p>Pandoc is a Haskell library for converting from one markup
+format to another.  The formats it can handle include</p><ul><li><p>light markup formats (many variants of Markdown,
+reStructuredText, AsciiDoc, Org-mode, Muse, Textile,
+txt2tags, djot)</p></li><li><p>HTML formats (HTML 4 and 5)</p></li><li><p>Ebook formats (EPUB v2 and v3, FB2)</p></li><li><p>Documentation formats (GNU TexInfo, Haddock, Vimdoc)</p></li><li><p>Roff formats (man, ms)</p></li><li><p>TeX formats (LaTeX, ConTeXt)</p></li><li><p>Typst</p></li><li><p>XML formats (DocBook 4 and 5, JATS, TEI Simple, OpenDocument)</p></li><li><p>Outline formats (OPML)</p></li><li><p>Bibliography formats (BibTeX, BibLaTeX, CSL JSON, CSL YAML,
+RIS)</p></li><li><p>Word processor formats (Docx, RTF, ODT)</p></li><li><p>Interactive notebook formats (Jupyter notebook ipynb)</p></li><li><p>Page layout formats (InDesign ICML)</p></li><li><p>Wiki markup formats (MediaWiki, DokuWiki, TikiWiki, TWiki,
+Vimwiki, XWiki, ZimWiki, Jira wiki, Creole)</p></li><li><p>Slide show formats (LaTeX Beamer, PowerPoint, Slidy,
+reveal.js, Slideous, S5, DZSlides)</p></li><li><p>Data formats (CSV and TSV tables, Excel spreadsheets)</p></li><li><p>PDF (via external programs such as pdflatex or wkhtmltopdf)</p></li></ul><p>Pandoc can convert mathematical content in documents
+between TeX, MathML, Word equations, roff eqn, typst,
+and plain text. It includes a powerful system for automatic
+citations and bibliographies, and it can be customized
+extensively using templates, filters, and custom readers
+and writers written in Lua.</p><p>For the pandoc command-line program, see the
+<code>pandoc-cli</code> package.</p>
+          
+                    <hr>
+          [<a href="#readme">Skip to Readme</a>]
+          
+        </div>
+
+        <div id="badges" style="margin-top: 20px;">
+                          <a href="reports/1">
+                <img src="https://img.shields.io/static/v1?label=Build&message=InstallOk&color=success" />
+              </a>
+            
+            
+            
+                          <img src="https://img.shields.io/static/v1?label=Documentation&message=Available&color=success" />
+            
+        </div>
+
+        <div id="modules">
+          <h2>Modules</h2><p style="font-size: small">[<a href="/package/pandoc-3.11/docs/doc-index.html">Index</a>] [<a id="quickjump-trigger" href="#">Quick Jump</a>]</p><div id="module-list"><ul class="modules"><li><i>Text</i><ul class="modules"><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc.html">Text.Pandoc</a></span><ul class="modules"><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-App.html">Text.Pandoc.App</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Asciify.html">Text.Pandoc.Asciify</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Chunks.html">Text.Pandoc.Chunks</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Citeproc.html">Text.Pandoc.Citeproc</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Class.html">Text.Pandoc.Class</a></span><ul class="modules"><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Class-IO.html">Text.Pandoc.Class.IO</a></span></li></ul></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Data.html">Text.Pandoc.Data</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Emoji.html">Text.Pandoc.Emoji</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Error.html">Text.Pandoc.Error</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Extensions.html">Text.Pandoc.Extensions</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Filter.html">Text.Pandoc.Filter</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Format.html">Text.Pandoc.Format</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Highlighting.html">Text.Pandoc.Highlighting</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-ImageSize.html">Text.Pandoc.ImageSize</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Logging.html">Text.Pandoc.Logging</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-MIME.html">Text.Pandoc.MIME</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-MediaBag.html">Text.Pandoc.MediaBag</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Options.html">Text.Pandoc.Options</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-PDF.html">Text.Pandoc.PDF</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Parsing.html">Text.Pandoc.Parsing</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Process.html">Text.Pandoc.Process</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers.html">Text.Pandoc.Readers</a></span><ul class="modules"><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-AsciiDoc.html">Text.Pandoc.Readers.AsciiDoc</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-BibTeX.html">Text.Pandoc.Readers.BibTeX</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-CSV.html">Text.Pandoc.Readers.CSV</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-CommonMark.html">Text.Pandoc.Readers.CommonMark</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Creole.html">Text.Pandoc.Readers.Creole</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-CslJson.html">Text.Pandoc.Readers.CslJson</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Djot.html">Text.Pandoc.Readers.Djot</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-DocBook.html">Text.Pandoc.Readers.DocBook</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Docx.html">Text.Pandoc.Readers.Docx</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-DokuWiki.html">Text.Pandoc.Readers.DokuWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-EPUB.html">Text.Pandoc.Readers.EPUB</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-EndNote.html">Text.Pandoc.Readers.EndNote</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-FB2.html">Text.Pandoc.Readers.FB2</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-HTML.html">Text.Pandoc.Readers.HTML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Haddock.html">Text.Pandoc.Readers.Haddock</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Ipynb.html">Text.Pandoc.Readers.Ipynb</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-JATS.html">Text.Pandoc.Readers.JATS</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Jira.html">Text.Pandoc.Readers.Jira</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-LaTeX.html">Text.Pandoc.Readers.LaTeX</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Man.html">Text.Pandoc.Readers.Man</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Markdown.html">Text.Pandoc.Readers.Markdown</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Mdoc.html">Text.Pandoc.Readers.Mdoc</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-MediaWiki.html">Text.Pandoc.Readers.MediaWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Muse.html">Text.Pandoc.Readers.Muse</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Native.html">Text.Pandoc.Readers.Native</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-ODT.html">Text.Pandoc.Readers.ODT</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-OPML.html">Text.Pandoc.Readers.OPML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Org.html">Text.Pandoc.Readers.Org</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Pod.html">Text.Pandoc.Readers.Pod</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Pptx.html">Text.Pandoc.Readers.Pptx</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-RIS.html">Text.Pandoc.Readers.RIS</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-RST.html">Text.Pandoc.Readers.RST</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-RTF.html">Text.Pandoc.Readers.RTF</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-TWiki.html">Text.Pandoc.Readers.TWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Textile.html">Text.Pandoc.Readers.Textile</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-TikiWiki.html">Text.Pandoc.Readers.TikiWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Txt2Tags.html">Text.Pandoc.Readers.Txt2Tags</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Typst.html">Text.Pandoc.Readers.Typst</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Vimwiki.html">Text.Pandoc.Readers.Vimwiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Readers-Xlsx.html">Text.Pandoc.Readers.Xlsx</a></span></li></ul></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Scripting.html">Text.Pandoc.Scripting</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-SelfContained.html">Text.Pandoc.SelfContained</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Shared.html">Text.Pandoc.Shared</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Slides.html">Text.Pandoc.Slides</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Sources.html">Text.Pandoc.Sources</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Templates.html">Text.Pandoc.Templates</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Transforms.html">Text.Pandoc.Transforms</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Translations.html">Text.Pandoc.Translations</a></span><ul class="modules"><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Translations-Types.html">Text.Pandoc.Translations.Types</a></span></li></ul></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-UTF8.html">Text.Pandoc.UTF8</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Version.html">Text.Pandoc.Version</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers.html">Text.Pandoc.Writers</a></span><ul class="modules"><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-ANSI.html">Text.Pandoc.Writers.ANSI</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-AnnotatedTable.html">Text.Pandoc.Writers.AnnotatedTable</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-AsciiDoc.html">Text.Pandoc.Writers.AsciiDoc</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-BBCode.html">Text.Pandoc.Writers.BBCode</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-BibTeX.html">Text.Pandoc.Writers.BibTeX</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-ChunkedHTML.html">Text.Pandoc.Writers.ChunkedHTML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-CommonMark.html">Text.Pandoc.Writers.CommonMark</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-ConTeXt.html">Text.Pandoc.Writers.ConTeXt</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-CslJson.html">Text.Pandoc.Writers.CslJson</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Djot.html">Text.Pandoc.Writers.Djot</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-DocBook.html">Text.Pandoc.Writers.DocBook</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Docx.html">Text.Pandoc.Writers.Docx</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-DokuWiki.html">Text.Pandoc.Writers.DokuWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-EPUB.html">Text.Pandoc.Writers.EPUB</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-FB2.html">Text.Pandoc.Writers.FB2</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-HTML.html">Text.Pandoc.Writers.HTML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Haddock.html">Text.Pandoc.Writers.Haddock</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-ICML.html">Text.Pandoc.Writers.ICML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Ipynb.html">Text.Pandoc.Writers.Ipynb</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-JATS.html">Text.Pandoc.Writers.JATS</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Jira.html">Text.Pandoc.Writers.Jira</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-LaTeX.html">Text.Pandoc.Writers.LaTeX</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Man.html">Text.Pandoc.Writers.Man</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Markdown.html">Text.Pandoc.Writers.Markdown</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Math.html">Text.Pandoc.Writers.Math</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-MediaWiki.html">Text.Pandoc.Writers.MediaWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Ms.html">Text.Pandoc.Writers.Ms</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Muse.html">Text.Pandoc.Writers.Muse</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Native.html">Text.Pandoc.Writers.Native</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-ODT.html">Text.Pandoc.Writers.ODT</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-OOXML.html">Text.Pandoc.Writers.OOXML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-OPML.html">Text.Pandoc.Writers.OPML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-OpenDocument.html">Text.Pandoc.Writers.OpenDocument</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Org.html">Text.Pandoc.Writers.Org</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Powerpoint.html">Text.Pandoc.Writers.Powerpoint</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-RST.html">Text.Pandoc.Writers.RST</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-RTF.html">Text.Pandoc.Writers.RTF</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Shared.html">Text.Pandoc.Writers.Shared</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-TEI.html">Text.Pandoc.Writers.TEI</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Texinfo.html">Text.Pandoc.Writers.Texinfo</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Textile.html">Text.Pandoc.Writers.Textile</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Txt2Tags.html">Text.Pandoc.Writers.Txt2Tags</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Typst.html">Text.Pandoc.Writers.Typst</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-Vimdoc.html">Text.Pandoc.Writers.Vimdoc</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-XML.html">Text.Pandoc.Writers.XML</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-XWiki.html">Text.Pandoc.Writers.XWiki</a></span></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-Writers-ZimWiki.html">Text.Pandoc.Writers.ZimWiki</a></span></li></ul></li><li><span class="module"><a href="/package/pandoc-3.11/docs/Text-Pandoc-XML.html">Text.Pandoc.XML</a></span></li></ul></li></ul></li></ul></div>
+        </div>
+
+                <div id="flags">
+          <h2>Flags</h2><details><summary>Automatic Flags</summary><table class="flags-table automatic-flags"><thead><th>Name</th><th>Description</th><th>Default</th></thead><tbody><tr><td class="flag-name"><span class="code">embed_data_files</span></td><td class="flag-desc"><p>Embed data files in binary for relocatable executable.</p></td><td class="flag-disabled">Disabled</td></tr><tr><td class="flag-name"><span class="code">http</span></td><td class="flag-desc"><p>Support for fetching resources using HTTP.</p></td><td class="flag-enabled">Enabled</td></tr></tbody></table></details><p class="tip"><span>Use </span><span class="code">-f &lt;flag&gt;</span><span> to enable a flag, or </span><span class="code">-f -&lt;flag&gt;</span><span> to disable that flag. </span><a href="https://cabal.readthedocs.io/en/latest/setup-commands.html#controlling-flag-assignments">More info</a></p>
+        </div>
+        
+
+        <div id="downloads">
+          <h2>Downloads</h2><ul><li><a href="/package/pandoc-3.11/pandoc-3.11.tar.gz">pandoc-3.11.tar.gz</a> [<a href="/package/pandoc-3.11/src/">browse</a>] (Cabal source package)</li><li><a href="/package/pandoc-3.11/pandoc.cabal">Package description</a> (as included in the package)</li></ul>
+        </div>
+
+        <div id="maintainer-corner">
+          <h4>Maintainer's Corner</h4>
+          <p><a href="/package/pandoc/maintainers">Package maintainers</a></p>
+          <ul>
+            <li>
+              <a href="/user/JohnMacFarlane">JohnMacFarlane</a>
+            </li>
+          </ul>
+          <p>For package maintainers and hackage trustees</p>
+          <ul>
+            <li>
+              <a href="//hackage.haskell.org/package/pandoc/maintain">
+                edit package information
+              </a>
+            </li>
+          </ul>
+          <p>Candidates</p>
+          <ul>
+            <li>
+              No Candidates
+            </li>
+          </ul>
+        </div>
+
+      </div><!-- /left-pane -->
+
+
+      <div id="properties">
+        <table class="properties">
+          <tbody>
+
+            <tr>
+              <th>Versions <span style="font-weight:normal;font-size: small;">[<a href="/package/pandoc.rss">RSS</a>]</span></th>
+              <td><a href="/package/pandoc-0.4">0.4</a>, <a href="/package/pandoc-0.41">0.41</a>, <a href="/package/pandoc-0.42">0.42</a>, <a href="/package/pandoc-0.43">0.43</a>, <a href="/package/pandoc-0.44">0.44</a>, <a href="/package/pandoc-0.45">0.45</a>, <a href="/package/pandoc-0.46">0.46</a>, <a href="/package/pandoc-1.0">1.0</a>, <a href="/package/pandoc-1.0.0.1">1.0.0.1</a>, <a href="/package/pandoc-1.1">1.1</a>, <a href="/package/pandoc-1.2">1.2</a>, <a href="/package/pandoc-1.2.1">1.2.1</a>, <a href="/package/pandoc-1.3">1.3</a>, <a href="/package/pandoc-1.4">1.4</a>, <a href="/package/pandoc-1.5">1.5</a>, <a href="/package/pandoc-1.5.0.1">1.5.0.1</a>, <a href="/package/pandoc-1.5.1">1.5.1</a>, <a href="/package/pandoc-1.5.1.1">1.5.1.1</a>, <a href="/package/pandoc-1.6">1.6</a>, <a href="/package/pandoc-1.6.0.1">1.6.0.1</a>, <a href="/package/pandoc-1.8">1.8</a>, <a href="/package/pandoc-1.8.0.1">1.8.0.1</a>, <a href="/package/pandoc-1.8.0.2">1.8.0.2</a>, <a href="/package/pandoc-1.8.0.3">1.8.0.3</a>, <a href="/package/pandoc-1.8.1">1.8.1</a>, <a href="/package/pandoc-1.8.1.1">1.8.1.1</a>, <a href="/package/pandoc-1.8.1.2">1.8.1.2</a>, <a href="/package/pandoc-1.8.2">1.8.2</a>, <a href="/package/pandoc-1.8.2.1">1.8.2.1</a>, <a href="/package/pandoc-1.9">1.9</a>, <a href="/package/pandoc-1.9.0.2">1.9.0.2</a>, <a href="/package/pandoc-1.9.0.3">1.9.0.3</a>, <a href="/package/pandoc-1.9.0.4">1.9.0.4</a>, <a href="/package/pandoc-1.9.0.5">1.9.0.5</a>, <a href="/package/pandoc-1.9.1">1.9.1</a>, <a href="/package/pandoc-1.9.1.1">1.9.1.1</a>, <a href="/package/pandoc-1.9.1.2">1.9.1.2</a>, <a href="/package/pandoc-1.9.2">1.9.2</a>, <a href="/package/pandoc-1.9.3">1.9.3</a>, <a href="/package/pandoc-1.9.4">1.9.4</a>, <a href="/package/pandoc-1.9.4.1">1.9.4.1</a>, <a href="/package/pandoc-1.9.4.2">1.9.4.2</a>, <a href="/package/pandoc-1.9.4.3">1.9.4.3</a>, <a href="/package/pandoc-1.9.4.4">1.9.4.4</a>, <a href="/package/pandoc-1.9.4.5">1.9.4.5</a>, <a href="/package/pandoc-1.10">1.10</a>, <a href="/package/pandoc-1.10.0.1">1.10.0.1</a>, <a href="/package/pandoc-1.10.0.2">1.10.0.2</a>, <a href="/package/pandoc-1.10.0.3">1.10.0.3</a>, <a href="/package/pandoc-1.10.0.4">1.10.0.4</a>, <a href="/package/pandoc-1.10.0.5">1.10.0.5</a>, <a href="/package/pandoc-1.10.1">1.10.1</a>, <a href="/package/pandoc-1.11">1.11</a>, <a href="/package/pandoc-1.11.1">1.11.1</a>, <a href="/package/pandoc-1.12">1.12</a>, <a href="/package/pandoc-1.12.0.1">1.12.0.1</a>, <a href="/package/pandoc-1.12.0.2">1.12.0.2</a>, <a href="/package/pandoc-1.12.1">1.12.1</a>, <a href="/package/pandoc-1.12.2">1.12.2</a>, <a href="/package/pandoc-1.12.2.1">1.12.2.1</a>, <a href="/package/pandoc-1.12.3">1.12.3</a>, <a href="/package/pandoc-1.12.3.1">1.12.3.1</a>, <a href="/package/pandoc-1.12.3.2">1.12.3.2</a>, <a href="/package/pandoc-1.12.3.3">1.12.3.3</a>, <a href="/package/pandoc-1.12.4">1.12.4</a>, <a href="/package/pandoc-1.12.4.2">1.12.4.2</a>, <a href="/package/pandoc-1.13">1.13</a>, <a href="/package/pandoc-1.13.0.1">1.13.0.1</a>, <a href="/package/pandoc-1.13.1">1.13.1</a>, <a href="/package/pandoc-1.13.2">1.13.2</a>, <a href="/package/pandoc-1.13.2.1">1.13.2.1</a>, <a class="deprecated" href="/package/pandoc-1.14">1.14</a>, <a class="deprecated" href="/package/pandoc-1.14.0.1">1.14.0.1</a>, <a class="deprecated" href="/package/pandoc-1.14.0.2">1.14.0.2</a>, <a class="deprecated" href="/package/pandoc-1.14.0.3">1.14.0.3</a>, <a class="deprecated" href="/package/pandoc-1.14.0.4">1.14.0.4</a>, <a href="/package/pandoc-1.14.1">1.14.1</a>, <a class="deprecated" href="/package/pandoc-1.15">1.15</a>, <a class="deprecated" href="/package/pandoc-1.15.0.1">1.15.0.1</a>, <a href="/package/pandoc-1.15.0.2">1.15.0.2</a>, <a href="/package/pandoc-1.15.0.3">1.15.0.3</a>, <a href="/package/pandoc-1.15.0.4">1.15.0.4</a>, <a href="/package/pandoc-1.15.0.5">1.15.0.5</a>, <a href="/package/pandoc-1.15.0.6">1.15.0.6</a>, <a href="/package/pandoc-1.15.1">1.15.1</a>, <a href="/package/pandoc-1.15.1.1">1.15.1.1</a>, <a href="/package/pandoc-1.15.2">1.15.2</a>, <a href="/package/pandoc-1.15.2.1">1.15.2.1</a>, <a href="/package/pandoc-1.16">1.16</a>, <a href="/package/pandoc-1.16.0.1">1.16.0.1</a>, <a href="/package/pandoc-1.16.0.2">1.16.0.2</a>, <a href="/package/pandoc-1.17">1.17</a>, <a href="/package/pandoc-1.17.0.1">1.17.0.1</a>, <a href="/package/pandoc-1.17.0.2">1.17.0.2</a>, <a href="/package/pandoc-1.17.0.3">1.17.0.3</a>, <a href="/package/pandoc-1.17.1">1.17.1</a>, <a href="/package/pandoc-1.17.2">1.17.2</a>, <a href="/package/pandoc-1.18">1.18</a>, <a href="/package/pandoc-1.19">1.19</a>, <a href="/package/pandoc-1.19.1">1.19.1</a>, <a href="/package/pandoc-1.19.2">1.19.2</a>, <a href="/package/pandoc-1.19.2.1">1.19.2.1</a>, <a href="/package/pandoc-1.19.2.2">1.19.2.2</a>, <a href="/package/pandoc-1.19.2.3">1.19.2.3</a>, <a href="/package/pandoc-1.19.2.4">1.19.2.4</a>, <a href="/package/pandoc-2.0">2.0</a>, <a href="/package/pandoc-2.0.0.1">2.0.0.1</a>, <a href="/package/pandoc-2.0.1">2.0.1</a>, <a href="/package/pandoc-2.0.1.1">2.0.1.1</a>, <a href="/package/pandoc-2.0.2">2.0.2</a>, <a href="/package/pandoc-2.0.3">2.0.3</a>, <a href="/package/pandoc-2.0.4">2.0.4</a>, <a href="/package/pandoc-2.0.5">2.0.5</a>, <a href="/package/pandoc-2.0.6">2.0.6</a>, <a href="/package/pandoc-2.1">2.1</a>, <a href="/package/pandoc-2.1.1">2.1.1</a>, <a href="/package/pandoc-2.1.2">2.1.2</a>, <a href="/package/pandoc-2.1.3">2.1.3</a>, <a href="/package/pandoc-2.2">2.2</a>, <a href="/package/pandoc-2.2.1">2.2.1</a>, <a href="/package/pandoc-2.2.2">2.2.2</a>, <a href="/package/pandoc-2.2.2.1">2.2.2.1</a>, <a href="/package/pandoc-2.2.3">2.2.3</a>, <a href="/package/pandoc-2.2.3.1">2.2.3.1</a>, <a href="/package/pandoc-2.2.3.2">2.2.3.2</a>, <a href="/package/pandoc-2.3">2.3</a>, <a href="/package/pandoc-2.3.1">2.3.1</a>, <a href="/package/pandoc-2.4">2.4</a>, <a href="/package/pandoc-2.5">2.5</a>, <a href="/package/pandoc-2.6">2.6</a>, <a href="/package/pandoc-2.7">2.7</a>, <a href="/package/pandoc-2.7.1">2.7.1</a>, <a href="/package/pandoc-2.7.2">2.7.2</a>, <a href="/package/pandoc-2.7.3">2.7.3</a>, <a href="/package/pandoc-2.8">2.8</a>, <a href="/package/pandoc-2.8.0.1">2.8.0.1</a>, <a href="/package/pandoc-2.8.1">2.8.1</a>, <a href="/package/pandoc-2.9">2.9</a>, <a href="/package/pandoc-2.9.1">2.9.1</a>, <a href="/package/pandoc-2.9.1.1">2.9.1.1</a>, <a href="/package/pandoc-2.9.2">2.9.2</a>, <a href="/package/pandoc-2.9.2.1">2.9.2.1</a>, <a href="/package/pandoc-2.10">2.10</a>, <a href="/package/pandoc-2.10.1">2.10.1</a>, <a href="/package/pandoc-2.11">2.11</a>, <a href="/package/pandoc-2.11.0.1">2.11.0.1</a>, <a href="/package/pandoc-2.11.0.2">2.11.0.2</a>, <a class="deprecated" href="/package/pandoc-2.11.0.3">2.11.0.3</a>, <a href="/package/pandoc-2.11.0.4">2.11.0.4</a>, <a href="/package/pandoc-2.11.1">2.11.1</a>, <a href="/package/pandoc-2.11.1.1">2.11.1.1</a>, <a href="/package/pandoc-2.11.2">2.11.2</a>, <a href="/package/pandoc-2.11.3">2.11.3</a>, <a href="/package/pandoc-2.11.3.1">2.11.3.1</a>, <a href="/package/pandoc-2.11.3.2">2.11.3.2</a>, <a href="/package/pandoc-2.11.4">2.11.4</a>, <a href="/package/pandoc-2.12">2.12</a>, <a href="/package/pandoc-2.13">2.13</a>, <a href="/package/pandoc-2.14">2.14</a>, <a href="/package/pandoc-2.14.0.1">2.14.0.1</a>, <a href="/package/pandoc-2.14.0.2">2.14.0.2</a>, <a href="/package/pandoc-2.14.0.3">2.14.0.3</a>, <a href="/package/pandoc-2.14.1">2.14.1</a>, <a href="/package/pandoc-2.14.2">2.14.2</a>, <a href="/package/pandoc-2.15">2.15</a>, <a href="/package/pandoc-2.16">2.16</a>, <a href="/package/pandoc-2.16.1">2.16.1</a>, <a href="/package/pandoc-2.16.2">2.16.2</a>, <a href="/package/pandoc-2.17">2.17</a>, <a href="/package/pandoc-2.17.0.1">2.17.0.1</a>, <a href="/package/pandoc-2.17.1">2.17.1</a>, <a href="/package/pandoc-2.17.1.1">2.17.1.1</a>, <a href="/package/pandoc-2.18">2.18</a>, <a href="/package/pandoc-2.19">2.19</a>, <a href="/package/pandoc-2.19.1">2.19.1</a>, <a href="/package/pandoc-2.19.2">2.19.2</a>, <a href="/package/pandoc-3.0">3.0</a>, <a href="/package/pandoc-3.0.1">3.0.1</a>, <a href="/package/pandoc-3.1">3.1</a>, <a href="/package/pandoc-3.1.1">3.1.1</a>, <a href="/package/pandoc-3.1.2">3.1.2</a>, <a href="/package/pandoc-3.1.3">3.1.3</a>, <a href="/package/pandoc-3.1.4">3.1.4</a>, <a href="/package/pandoc-3.1.5">3.1.5</a>, <a href="/package/pandoc-3.1.6">3.1.6</a>, <a href="/package/pandoc-3.1.6.1">3.1.6.1</a>, <a href="/package/pandoc-3.1.6.2">3.1.6.2</a>, <a href="/package/pandoc-3.1.7">3.1.7</a>, <a href="/package/pandoc-3.1.8">3.1.8</a>, <a href="/package/pandoc-3.1.9">3.1.9</a>, <a href="/package/pandoc-3.1.10">3.1.10</a>, <a href="/package/pandoc-3.1.11">3.1.11</a>, <a href="/package/pandoc-3.1.11.1">3.1.11.1</a>, <a href="/package/pandoc-3.1.12">3.1.12</a>, <a href="/package/pandoc-3.1.12.1">3.1.12.1</a>, <a href="/package/pandoc-3.1.12.2">3.1.12.2</a>, <a href="/package/pandoc-3.1.12.3">3.1.12.3</a>, <a href="/package/pandoc-3.1.13">3.1.13</a>, <a href="/package/pandoc-3.2">3.2</a>, <a href="/package/pandoc-3.2.1">3.2.1</a>, <a href="/package/pandoc-3.3">3.3</a>, <a href="/package/pandoc-3.4">3.4</a>, <a href="/package/pandoc-3.5">3.5</a>, <a href="/package/pandoc-3.6">3.6</a>, <a href="/package/pandoc-3.6.1">3.6.1</a>, <a href="/package/pandoc-3.6.2">3.6.2</a>, <a href="/package/pandoc-3.6.3">3.6.3</a>, <a href="/package/pandoc-3.6.4">3.6.4</a>, <a href="/package/pandoc-3.7">3.7</a>, <a href="/package/pandoc-3.7.0.1">3.7.0.1</a>, <a href="/package/pandoc-3.7.0.2">3.7.0.2</a>, <a href="/package/pandoc-3.8">3.8</a>, <a href="/package/pandoc-3.8.1">3.8.1</a>, <a href="/package/pandoc-3.8.2">3.8.2</a>, <a href="/package/pandoc-3.8.2.1">3.8.2.1</a>, <a href="/package/pandoc-3.8.3">3.8.3</a>, <a href="/package/pandoc-3.9">3.9</a>, <a href="/package/pandoc-3.9.0.1">3.9.0.1</a>, <a href="/package/pandoc-3.9.0.2">3.9.0.2</a>, <a href="/package/pandoc-3.10">3.10</a>, <a href="/package/pandoc-3.10.1">3.10.1</a>, <a href="/package/pandoc-3.10.2">3.10.2</a>, <strong>3.11</strong> (<a href="/package/pandoc/preferred">info</a>)</td>
+            </tr>
+
+                        <tr>
+              <th>Change&nbsp;log</th>
+              <td class="word-wrap"><a href="/package/pandoc-3.11/changelog">changelog.md</a></td>
+            </tr>
+            
+
+            <tr>
+              <th>Dependencies</th>
+              <td><span style="white-space: nowrap"><a href="/package/aeson">aeson</a> (&gt;=2.0.1.0 &amp;&amp; &lt;2.4)</span>, <span style="white-space: nowrap"><a href="/package/aeson-pretty">aeson-pretty</a> (&gt;=0.8.9 &amp;&amp; &lt;0.9)</span>, <span style="white-space: nowrap"><a href="/package/array">array</a> (&gt;=0.5 &amp;&amp; &lt;0.6)</span>, <span style="white-space: nowrap"><a href="/package/asciidoc">asciidoc</a> (&gt;=0.1.0.5 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/attoparsec">attoparsec</a> (&gt;=0.12 &amp;&amp; &lt;0.15)</span>, <span style="white-space: nowrap"><a href="/package/base">base</a> (&gt;=4.18 &amp;&amp; &lt;5)</span>, <span style="white-space: nowrap"><a href="/package/base64-bytestring">base64-bytestring</a> (&gt;=0.1 &amp;&amp; &lt;1.3)</span>, <span style="white-space: nowrap"><a href="/package/binary">binary</a> (&gt;=0.7 &amp;&amp; &lt;0.11)</span>, <span style="white-space: nowrap"><a href="/package/blaze-html">blaze-html</a> (&gt;=0.9 &amp;&amp; &lt;0.10)</span>, <span style="white-space: nowrap"><a href="/package/blaze-markup">blaze-markup</a> (&gt;=0.8 &amp;&amp; &lt;0.9)</span>, <span style="white-space: nowrap"><a href="/package/bytestring">bytestring</a> (&gt;=0.9 &amp;&amp; &lt;0.13)</span>, <span style="white-space: nowrap"><a href="/package/case-insensitive">case-insensitive</a> (&gt;=1.2 &amp;&amp; &lt;1.3)</span>, <span style="white-space: nowrap"><a href="/package/citeproc">citeproc</a> (&gt;=0.13.0.1 &amp;&amp; &lt;0.14)</span>, <span style="white-space: nowrap"><a href="/package/commonmark">commonmark</a> (&gt;=0.3 &amp;&amp; &lt;0.4)</span>, <span style="white-space: nowrap"><a href="/package/commonmark-extensions">commonmark-extensions</a> (&gt;=0.2.7.1 &amp;&amp; &lt;0.3)</span>, <span style="white-space: nowrap"><a href="/package/commonmark-pandoc">commonmark-pandoc</a> (&gt;=0.3 &amp;&amp; &lt;0.4)</span>, <span style="white-space: nowrap"><a href="/package/containers">containers</a> (&gt;=0.6.0.1 &amp;&amp; &lt;0.9)</span>, <span style="white-space: nowrap"><a href="/package/crypton">crypton</a> (&gt;=0.30 &amp;&amp; &lt;1.2)</span>, <span style="white-space: nowrap"><a href="/package/crypton-connection">crypton-connection</a> (&gt;=0.3.1 &amp;&amp; &lt;0.5)</span>, <span style="white-space: nowrap"><a href="/package/crypton-x509-system">crypton-x509-system</a> (&gt;=1.6.7 &amp;&amp; &lt;1.10)</span>, <span style="white-space: nowrap"><a href="/package/data-default">data-default</a> (&gt;=0.4 &amp;&amp; &lt;0.9)</span>, <span style="white-space: nowrap"><a href="/package/deepseq">deepseq</a> (&gt;=1.3 &amp;&amp; &lt;1.6)</span>, <span style="white-space: nowrap"><a href="/package/directory">directory</a> (&gt;=1.2.3 &amp;&amp; &lt;1.4)</span>, <span style="white-space: nowrap"><a href="/package/djot">djot</a> (&gt;=0.1.4.2 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/doclayout">doclayout</a> (&gt;=0.5.0.3 &amp;&amp; &lt;0.6)</span>, <span style="white-space: nowrap"><a href="/package/doctemplates">doctemplates</a> (&gt;=0.11 &amp;&amp; &lt;0.12)</span>, <span style="white-space: nowrap"><a href="/package/emojis">emojis</a> (&gt;=0.1.5 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/exceptions">exceptions</a> (&gt;=0.8 &amp;&amp; &lt;0.11)</span>, <span style="white-space: nowrap"><a href="/package/file-embed">file-embed</a> (&gt;=0.0 &amp;&amp; &lt;0.1)</span>, <span style="white-space: nowrap"><a href="/package/filepath">filepath</a> (&gt;=1.1 &amp;&amp; &lt;1.6)</span>, <span style="white-space: nowrap"><a href="/package/Glob">Glob</a> (&gt;=0.7 &amp;&amp; &lt;0.11)</span>, <span style="white-space: nowrap"><a href="/package/gridtables">gridtables</a> (&gt;=0.1 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/haddock-library">haddock-library</a> (&gt;=1.10 &amp;&amp; &lt;1.12)</span>, <span style="white-space: nowrap"><a href="/package/http-client">http-client</a> (&gt;=0.4.30 &amp;&amp; &lt;0.8)</span>, <span style="white-space: nowrap"><a href="/package/http-client-tls">http-client-tls</a> (&gt;=0.2.4 &amp;&amp; &lt;0.5)</span>, <span style="white-space: nowrap"><a href="/package/http-types">http-types</a> (&gt;=0.8 &amp;&amp; &lt;0.13)</span>, <span style="white-space: nowrap"><a href="/package/ipynb">ipynb</a> (&gt;=0.2 &amp;&amp; &lt;0.3)</span>, <span style="white-space: nowrap"><a href="/package/jira-wiki-markup">jira-wiki-markup</a> (&gt;=1.5.1 &amp;&amp; &lt;1.6)</span>, <span style="white-space: nowrap"><a href="/package/JuicyPixels">JuicyPixels</a> (&gt;=3.1.6.1 &amp;&amp; &lt;3.4)</span>, <span style="white-space: nowrap"><a href="/package/libyaml">libyaml</a> (&gt;=0.1.4 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/mime-types">mime-types</a> (&gt;=0.1.1 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/mtl">mtl</a> (&gt;=2.3 &amp;&amp; &lt;2.4)</span>, <span style="white-space: nowrap"><a href="/package/network">network</a> (&gt;=2.6 &amp;&amp; &lt;3.3)</span>, <span style="white-space: nowrap"><a href="/package/network-uri">network-uri</a> (&gt;=2.6 &amp;&amp; &lt;2.8)</span>, <span style="white-space: nowrap"><a href="/package/pandoc">pandoc</a></span>, <span style="white-space: nowrap"><a href="/package/pandoc-types">pandoc-types</a> (&gt;=1.23.1.2 &amp;&amp; &lt;1.24)</span>, <span style="white-space: nowrap"><a href="/package/parsec">parsec</a> (&gt;=3.1 &amp;&amp; &lt;3.2)</span>, <span style="white-space: nowrap"><a href="/package/pretty">pretty</a> (&gt;=1.1 &amp;&amp; &lt;1.2)</span>, <span style="white-space: nowrap"><a href="/package/pretty-show">pretty-show</a> (&gt;=1.10 &amp;&amp; &lt;1.11)</span>, <span style="white-space: nowrap"><a href="/package/process">process</a> (&gt;=1.2.3 &amp;&amp; &lt;1.7)</span>, <span style="white-space: nowrap"><a href="/package/random">random</a> (&gt;=1.2 &amp;&amp; &lt;1.4)</span>, <span style="white-space: nowrap"><a href="/package/safe">safe</a> (&gt;=0.3.18 &amp;&amp; &lt;0.4)</span>, <span style="white-space: nowrap"><a href="/package/scientific">scientific</a> (&gt;=0.3 &amp;&amp; &lt;0.4)</span>, <span style="white-space: nowrap"><a href="/package/skylighting">skylighting</a> (&gt;=0.14.7 &amp;&amp; &lt;0.15)</span>, <span style="white-space: nowrap"><a href="/package/skylighting-core">skylighting-core</a> (&gt;=0.14.7 &amp;&amp; &lt;0.15)</span>, <span style="white-space: nowrap"><a href="/package/split">split</a> (&gt;=0.2 &amp;&amp; &lt;0.3)</span>, <span style="white-space: nowrap"><a href="/package/syb">syb</a> (&gt;=0.1 &amp;&amp; &lt;0.8)</span>, <span style="white-space: nowrap"><a href="/package/tagsoup">tagsoup</a> (&gt;=0.14.6 &amp;&amp; &lt;0.15)</span>, <span style="white-space: nowrap"><a href="/package/temporary">temporary</a> (&gt;=1.1 &amp;&amp; &lt;1.4)</span>, <span style="white-space: nowrap"><a href="/package/texmath">texmath</a> (&gt;=0.13.2.2 &amp;&amp; &lt;0.14)</span>, <span style="white-space: nowrap"><a href="/package/text">text</a> (&gt;=1.1.1.0 &amp;&amp; &lt;2.2)</span>, <span style="white-space: nowrap"><a href="/package/text-conversions">text-conversions</a> (&gt;=0.3 &amp;&amp; &lt;0.4)</span>, <span style="white-space: nowrap"><a href="/package/time">time</a> (&gt;=1.5 &amp;&amp; &lt;1.17)</span>, <span style="white-space: nowrap"><a href="/package/tls">tls</a> (&gt;=2.0.1 &amp;&amp; &lt;2.5)</span>, <span style="white-space: nowrap"><a href="/package/typst">typst</a> (&gt;=0.11.0.1 &amp;&amp; &lt;0.12)</span>, <span style="white-space: nowrap"><a href="/package/unicode-collation">unicode-collation</a> (&gt;=0.1.1 &amp;&amp; &lt;0.2)</span>, <span style="white-space: nowrap"><a href="/package/unicode-data">unicode-data</a> (&gt;=0.6 &amp;&amp; &lt;0.9)</span>, <span style="white-space: nowrap"><a href="/package/unicode-transforms">unicode-transforms</a> (&gt;=0.3 &amp;&amp; &lt;0.5)</span>, <span style="white-space: nowrap"><a href="/package/unix">unix</a> (&gt;=2.4 &amp;&amp; &lt;2.9)</span>, <span style="white-space: nowrap"><a href="/package/vector">vector</a> (&gt;=0.12 &amp;&amp; &lt;0.14)</span>, <span style="white-space: nowrap"><a href="/package/xml">xml</a> (&gt;=1.3.12 &amp;&amp; &lt;1.4)</span>, <span style="white-space: nowrap"><a href="/package/xml-conduit">xml-conduit</a> (&gt;=1.9.1.1 &amp;&amp; &lt;1.11)</span>, <span style="white-space: nowrap"><a href="/package/xml-types">xml-types</a> (&gt;=0.3 &amp;&amp; &lt;0.4)</span>, <span style="white-space: nowrap"><a href="/package/yaml">yaml</a> (&gt;=0.11 &amp;&amp; &lt;0.12)</span>, <span style="white-space: nowrap"><a href="/package/zip-archive">zip-archive</a> (&gt;=0.4.3.1 &amp;&amp; &lt;0.5)</span>, <span style="white-space: nowrap"><a href="/package/zlib">zlib</a> (&gt;=0.5 &amp;&amp; &lt;0.8)</span><span style="font-size: small"> [<a href="/package/pandoc-3.11/dependencies">details</a>]</span></td>
+            </tr>
+
+                        <tr>
+              <th>Tested with</th>
+              <td class="word-wrap">
+                ghc ==9.6.7, ghc ==9.8.4, ghc ==9.10.3, ghc ==9.12.2
+              </td>
+            </tr>
+            
+
+            <tr>
+              <th>License</th>
+              <td class="word-wrap"><a href="/package/pandoc-3.11/src/COPYING.md">GPL-2.0-or-later</a></td>
+            </tr>
+
+                        <tr>
+              <th>Copyright</th>
+              <td class="word-wrap">(c) 2006-2024 John MacFarlane</td>
+            </tr>
+            
+
+            <tr>
+              <th>Author</th>
+              <td class="word-wrap">John MacFarlane &lt;jgm@berkeley.edu&gt;</td>
+            </tr>
+            <tr>
+              <th>Maintainer</th>
+              <td class="word-wrap">John MacFarlane &lt;jgm@berkeley.edu&gt;</td>
+            </tr>
+
+            <tr>
+              <th>Uploaded</th>
+              <td>by <a href="/user/JohnMacFarlane">JohnMacFarlane</a> at <span title="Sat Aug 29 00:42:25 UTC 2026">2026-08-29T00:42:25Z</span></td>
+            </tr>
+
+            
+
+            <!-- Obsolete/deprecated 'Stability' field hidden
+                 c.f. http://stackoverflow.com/questions/3841218/conventions-for-stability-field-of-cabal-packages
+            <tr>
+              <th>Stability</th>
+              <td>alpha</td>
+            </tr>
+            -->
+
+                        <tr>
+              <th>Category</th>
+              <td><a href="/packages/#cat:Text">Text</a></td>
+            </tr>
+            
+
+                        <tr>
+              <th>Home page</th>
+              <td class="word-wrap">
+                                <a href="https://pandoc.org">https://pandoc.org</a>
+                
+              </td>
+            </tr>
+            
+
+                        <tr>
+              <th>Bug&nbsp;tracker</th>
+              <td class="word-wrap">
+                                <a href="https://github.com/jgm/pandoc/issues">https://github.com/jgm/pandoc/issues</a>
+                
+              </td>
+            </tr>
+            
+
+                        <tr>
+              <th>Source&nbsp;repo</th>
+              <td class="word-wrap">head: git clone <a href="https://github.com/jgm/pandoc.git">https://github.com/jgm/pandoc.git</a></td>
+            </tr>
+            
+
+                        <tr>
+              <th>Distributions</th>
+              <td>Arch:<a href="https://archlinux.org/packages/extra/x86_64/haskell-pandoc">3.10.2</a>, Fedora:<a href="https://src.fedoraproject.org/rpms/ghc-pandoc">3.7.0.2</a>, LTSHaskell:<a href="https://www.stackage.org/package/pandoc">3.7.0.2</a>, Stackage:<a href="https://www.stackage.org/package/pandoc">3.10.2</a></td>
+            </tr>
+            
+
+                        <tr>
+              <th>Reverse Dependencies</th>
+              <td>93 direct, 78 indirect <span style="font-size: small" class="revdepdetails"> [<a href="">details</a>]</span></td>
+            </tr>
+            <script>
+              $('.revdepdetails').click(function(e) {
+                e.preventDefault();
+                var html = '<div><b>Direct</b><br /><p><a href="/package/BlogLiterately">BlogLiterately</a>, <a href="/package/BlogLiterately-diagrams">BlogLiterately-diagrams</a>, <a href="/package/Elm">Elm</a>, <a href="/package/Graphalyze">Graphalyze</a>, <a href="/package/Lykah">Lykah</a>, <a href="/package/PandocAgda">PandocAgda</a>, <a href="/package/achille">achille</a>, <a href="/package/acme-everything">acme-everything</a>, <a href="/package/agda-snippets-hakyll">agda-snippets-hakyll</a>, <a href="/package/ampersand">ampersand</a>, <a href="/package/anansi-pandoc">anansi-pandoc</a>, <a href="/package/bamboo">bamboo</a>, <a href="/package/blagda">blagda</a>, <a href="/package/blaze-html-contrib">blaze-html-contrib</a>, <a href="/package/blogination">blogination</a>, <a href="/package/celtchar">celtchar</a>, <a href="/package/compdoc">compdoc</a>, <a href="/package/compdoc-dhall-decoder">compdoc-dhall-decoder</a>, <a href="/package/corebot-bliki">corebot-bliki</a>, <a href="/package/daino">daino</a>, <a href="/package/diagrams-pandoc">diagrams-pandoc</a>, <a href="/package/dixi">dixi</a>, <a href="/package/ema">ema</a>, <a href="/package/ema-extra">ema-extra</a>, <a href="/package/emanote">emanote</a>, <a href="/package/fluffy-parser">fluffy-parser</a>, <a href="/package/frame-markdown">frame-markdown</a>, <a href="/package/fromhtml">fromhtml</a>, <a href="/package/geek">geek</a>, <a href="/package/geek-server">geek-server</a>, <a href="/package/gitit">gitit</a>, <a href="/package/haggis">haggis</a>, <a href="/package/hakyll">hakyll</a>, <a href="/package/hakyll-R">hakyll-R</a>, <a href="/package/hakyll-agda">hakyll-agda</a>, <a href="/package/hakyll-alectryon">hakyll-alectryon</a>, <a href="/package/hakyll-contrib">hakyll-contrib</a>, <a href="/package/hakyll-contrib-links">hakyll-contrib-links</a>, <a href="/package/hakyllbars">hakyllbars</a>, <a href="/package/halipeto">halipeto</a>, <a href="/package/hamsql">hamsql</a>, <a href="/package/heckle">heckle</a>, <a href="/package/hsec-tools">hsec-tools</a>, <a href="/package/informative">informative</a>, <a href="/package/knit-haskell">knit-haskell</a>, <a href="/package/mdcat">mdcat</a>, <a href="/package/modulo">modulo</a>, <a href="/package/mps">mps</a>, <a href="/package/neuron">neuron</a>, <a href="/package/notmuch-web">notmuch-web</a>, <a href="/package/ob">ob</a>, <a href="/package/panda">panda</a>, <a href="/package/pandoc-citeproc">pandoc-citeproc</a>, <a href="/package/pandoc-columns">pandoc-columns</a>, <a href="/package/pandoc-crossref">pandoc-crossref</a>, <a href="/package/pandoc-csv2table">pandoc-csv2table</a>, <a href="/package/pandoc-dhall-decoder">pandoc-dhall-decoder</a>, <a href="/package/pandoc-highlighting-extensions">pandoc-highlighting-extensions</a>, <a href="/package/pandoc-include">pandoc-include</a>, <a href="/package/pandoc-include-plus">pandoc-include-plus</a>, <a href="/package/pandoc-linear-table">pandoc-linear-table</a>, <a href="/package/pandoc-logic-proof">pandoc-logic-proof</a>, <a href="/package/pandoc-lua-engine">pandoc-lua-engine</a>, <a href="/package/pandoc-markdown-ghci-filter">pandoc-markdown-ghci-filter</a>, <a href="/package/pandoc-plot">pandoc-plot</a>, <a href="/package/pandoc-pyplot">pandoc-pyplot</a>, <a href="/package/pandoc-query">pandoc-query</a>, <a href="/package/pandoc-server">pandoc-server</a>, <a href="/package/pandoc-sidenote">pandoc-sidenote</a>, <a href="/package/pandoc-throw">pandoc-throw</a>, <a href="/package/pandocz">pandocz</a>, <a href="/package/panhandle">panhandle</a>, <a href="/package/panpipe">panpipe</a>, <a href="/package/patat">patat</a>, <a href="/package/pencil">pencil</a>, <a href="/package/provenience">provenience</a>, <a href="/package/readme-lhs">readme-lhs</a>, <a href="/package/repo-based-blog">repo-based-blog</a>, <a href="/package/rib">rib</a>, <a href="/package/semdoc">semdoc</a>, <a href="/package/shakebook">shakebook</a>, <a href="/package/sitepipe">sitepipe</a>, <a href="/package/slick">slick</a>, <a href="/package/snipcheck">snipcheck</a>, <a href="/package/sprinkles">sprinkles</a>, <a href="/package/swarm">swarm</a>, <a href="/package/uniform-pandoc">uniform-pandoc</a>, <a href="/package/wai-middleware-content-type">wai-middleware-content-type</a>, <a href="/package/wordchoice">wordchoice</a>, <a href="/package/yesod-goodies">yesod-goodies</a>, <a href="/package/yesod-markdown">yesod-markdown</a>, <a href="/package/yesod-rst">yesod-rst</a>, <a href="/package/zettelkast">zettelkast</a></p></div><div><b>Indirect</b><br /><p><a href="/package/CarneadesDSL">CarneadesDSL</a>, <a href="/package/CarneadesIntoDung">CarneadesIntoDung</a>, <a href="/package/Hawk">Hawk</a>, <a href="/package/MFlow">MFlow</a>, <a href="/package/ReplaceUmlaut">ReplaceUmlaut</a>, <a href="/package/bamboo-plugin-highlight">bamboo-plugin-highlight</a>, <a href="/package/bamboo-plugin-photo">bamboo-plugin-photo</a>, <a href="/package/bamboo-theme-blueprint">bamboo-theme-blueprint</a>, <a href="/package/bamboo-theme-mini-html5">bamboo-theme-mini-html5</a>, <a href="/package/bird">bird</a>, <a href="/package/buchhaltung">buchhaltung</a>, <a href="/package/claferwiki">claferwiki</a>, <a href="/package/elm-get">elm-get</a>, <a href="/package/elm-yesod">elm-yesod</a>, <a href="/package/ema-generics">ema-generics</a>, <a href="/package/fix-symbols-gitit">fix-symbols-gitit</a>, <a href="/package/gbu">gbu</a>, <a href="/package/hack">hack</a>, <a href="/package/hack-contrib">hack-contrib</a>, <a href="/package/hack-contrib-press">hack-contrib-press</a>, <a href="/package/hack-frontend-happstack">hack-frontend-happstack</a>, <a href="/package/hack-frontend-monadcgi">hack-frontend-monadcgi</a>, <a href="/package/hack-handler-cgi">hack-handler-cgi</a>, <a href="/package/hack-handler-epoll">hack-handler-epoll</a>, <a href="/package/hack-handler-evhttp">hack-handler-evhttp</a>, <a href="/package/hack-handler-fastcgi">hack-handler-fastcgi</a>, <a href="/package/hack-handler-happstack">hack-handler-happstack</a>, <a href="/package/hack-handler-hyena">hack-handler-hyena</a>, <a href="/package/hack-handler-kibro">hack-handler-kibro</a>, <a href="/package/hack-handler-simpleserver">hack-handler-simpleserver</a>, <a href="/package/hack-middleware-cleanpath">hack-middleware-cleanpath</a>, <a href="/package/hack-middleware-clientsession">hack-middleware-clientsession</a>, <a href="/package/hack-middleware-gzip">hack-middleware-gzip</a>, <a href="/package/hack-middleware-jsonp">hack-middleware-jsonp</a>, <a href="/package/hakyll-blaze-templates">hakyll-blaze-templates</a>, <a href="/package/hakyll-contrib-csv">hakyll-contrib-csv</a>, <a href="/package/hakyll-contrib-elm">hakyll-contrib-elm</a>, <a href="/package/hakyll-contrib-hyphenation">hakyll-contrib-hyphenation</a>, <a href="/package/hakyll-contrib-i18n">hakyll-contrib-i18n</a>, <a href="/package/hakyll-convert">hakyll-convert</a>, <a href="/package/hakyll-dhall">hakyll-dhall</a>, <a href="/package/hakyll-diagrams">hakyll-diagrams</a>, <a href="/package/hakyll-dir-list">hakyll-dir-list</a>, <a href="/package/hakyll-elm">hakyll-elm</a>, <a href="/package/hakyll-favicon">hakyll-favicon</a>, <a href="/package/hakyll-filestore">hakyll-filestore</a>, <a href="/package/hakyll-images">hakyll-images</a>, <a href="/package/hakyll-ogmarkup">hakyll-ogmarkup</a>, <a href="/package/hakyll-process">hakyll-process</a>, <a href="/package/hakyll-sass">hakyll-sass</a>, <a href="/package/hakyll-series">hakyll-series</a>, <a href="/package/hakyll-shakespeare">hakyll-shakespeare</a>, <a href="/package/hakyll-shortcut-links">hakyll-shortcut-links</a>, <a href="/package/hakyll-typescript">hakyll-typescript</a>, <a href="/package/haskelm">haskelm</a>, <a href="/package/hcheat">hcheat</a>, <a href="/package/hledger">hledger</a>, <a href="/package/hledger-ui">hledger-ui</a>, <a href="/package/hledger-web">hledger-web</a>, <a href="/package/kawaii">kawaii</a>, <a href="/package/latex-formulae-hakyll">latex-formulae-hakyll</a>, <a href="/package/latex-svg-hakyll">latex-svg-hakyll</a>, <a href="/package/loli">loli</a>, <a href="/package/moe">moe</a>, <a href="/package/nemesis">nemesis</a>, <a href="/package/nemesis-titan">nemesis-titan</a>, <a href="/package/nested-routes">nested-routes</a>, <a href="/package/on-a-horse">on-a-horse</a>, <a href="/package/perf-analysis">perf-analysis</a>, <a href="/package/snap-elm">snap-elm</a>, <a href="/package/snow-white">snow-white</a>, <a href="/package/sparrow">sparrow</a>, <a href="/package/spata">spata</a>, <a href="/package/uniform-latex2pdf">uniform-latex2pdf</a>, <a href="/package/yesod-bootstrap">yesod-bootstrap</a>, <a href="/package/yesod-comments">yesod-comments</a>, <a href="/package/yesod-crud-persist">yesod-crud-persist</a>, <a href="/package/yesod-raml-docs">yesod-raml-docs</a></p></div><span style="font-size: small"> [<a href="/package/pandoc/reverse">details</a>]</span>'
+                modal.open({ content: html});
+              });
+            </script>
+            
+
+            
+
+            <tr>
+              <th>Downloads</th>
+              <td>380737 total (1105 in the last 30 days)</td>
+            </tr>
+
+            <tr>
+              <th> Rating</th>
+              <td>3.0 (votes: 24)
+              <span style="font-size: small">[estimated by <a href="https://en.wikipedia.org/wiki/Bayesian_average">Bayesian average</a>]</span></td>
+            </tr>
+
+            <tr>
+              <th>Your&nbsp;Rating</th>
+              <td>
+                <ul class="star-rating">
+                  <li class="star uncool" id="1">&lambda;</li>
+                  <li class="star uncool" id="2">&lambda;</li>
+                  <li class="star uncool" id="3">&lambda;</li>
+                </ul>
+              
+              </td>
+            </tr>
+            <tr>
+              <th>Status</th>
+              <td>Docs available <span style="font-size: small">[<a href="/package/pandoc-3.11/reports/1">build log</a>]</span><br />Last success reported on 2026-08-29 <span style="font-size: small">[<a href="/package/pandoc-3.11/reports/">all 1 reports</a>]</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div> <!-- /properties -->
+    </div><!-- /flex-container -->
+
+        <hr />
+    <div id="readme-container">
+      <h2 id="readme">Readme for pandoc-3.11</h2>
+      [<a href="#description">back to package description</a>]
+      <div class="embedded-author-content"><!-- Do not edit this file.  It is generated automatically from
+README.template and MANUAL.txt via the command:
+pandoc --lua-filter tools/update-readme.lua README.template -o README.md
+-->
+<h1 id="pandoc">Pandoc</h1>
+<p><a href="https://github.com/jgm/pandoc/releases"><img src="https://img.shields.io/github/release/jgm/pandoc.svg?label=current+release" alt="githubrelease" /></a>
+<a href="https://hackage.haskell.org/package/pandoc"><img src="https://img.shields.io/hackage/v/pandoc.svg?label=hackage" alt="hackagerelease" /></a>
+<a href="https://formulae.brew.sh/formula/pandoc"><img src="https://img.shields.io/homebrew/v/pandoc.svg" alt="homebrew" /></a>
+<a href="https://www.stackage.org/lts/package/pandoc"><img src="https://stackage.org/package/pandoc/badge/lts" alt="stackage LTSpackage" /></a>
+<a href="https://github.com/jgm/pandoc/actions"><img src="https://github.com/jgm/pandoc/workflows/CI%20tests/badge.svg" alt="CItests" /></a>
+<a href="https://www.gnu.org/licenses/gpl.html"><img src="https://img.shields.io/badge/license-GPLv2+-lightgray.svg" alt="license" /></a>
+<a href="https://groups.google.com/forum/#!forum/pandoc-discuss"><img src="https://img.shields.io/badge/pandoc-discuss-red.svg?style=social" alt="pandoc-discuss on googlegroups" /></a></p>
+<h2 id="the-universal-markup-converter">The universal markup converter</h2>
+<p>Pandoc is a <a href="https://haskell.org">Haskell</a> library for converting from
+one markup format to another, and a command-line tool that uses this
+library.</p>
+<p>It can convert <em>from</em></p>
+<div id="input-formats">
+<ul>
+<li><code>asciidoc</code> (<a href="https://asciidoc.org/">AsciiDoc</a> markup)
+</li>
+<li><code>bibtex</code> (<a href="https://ctan.org/pkg/bibtex">BibTeX</a> bibliography)
+</li>
+<li><code>biblatex</code> (<a href="https://ctan.org/pkg/biblatex">BibLaTeX</a> bibliography)
+</li>
+<li><code>bits</code> (<a href="https://jats.nlm.nih.gov/extensions/bits/">BITS</a> XML, alias
+for <code>jats</code>)
+</li>
+<li><code>commonmark</code> (<a href="https://commonmark.org">CommonMark</a> Markdown)
+</li>
+<li><code>commonmark_x</code> (<a href="https://commonmark.org">CommonMark</a> Markdown with
+extensions)
+</li>
+<li><code>creole</code> (<a href="http://www.wikicreole.org/wiki/Creole1.0">Creole 1.0</a>)
+</li>
+<li><code>csljson</code> (<a href="https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html">CSL
+JSON</a>
+bibliography)
+</li>
+<li><code>csv</code> (<a href="https://tools.ietf.org/html/rfc4180">CSV</a> table)
+</li>
+<li><code>tsv</code>
+(<a href="https://www.iana.org/assignments/media-types/text/tab-separated-values">TSV</a>
+table)
+</li>
+<li><code>djot</code> (<a href="https://djot.net">Djot markup</a>)
+</li>
+<li><code>docbook</code> (<a href="https://docbook.org">DocBook</a>)
+</li>
+<li><code>docx</code> (<a href="https://en.wikipedia.org/wiki/Office_Open_XML">Word docx</a>)
+</li>
+<li><code>dokuwiki</code> (<a href="https://www.dokuwiki.org/dokuwiki">DokuWiki markup</a>)
+</li>
+<li><code>endnotexml</code> (<a href="https://support.clarivate.com/Endnote/s/article/EndNote-XML-Document-Type-Definition">EndNote XML
+bibliography</a>)
+</li>
+<li><code>epub</code> (<a href="http://idpf.org/epub">EPUB</a>)
+</li>
+<li><code>fb2</code>
+(<a href="http://www.fictionbook.org/index.php/Eng:XML_Schema_Fictionbook_2.1">FictionBook2</a>
+e-book)
+</li>
+<li><code>gfm</code> (<a href="https://help.github.com/articles/github-flavored-markdown/">GitHub-Flavored
+Markdown</a>),
+or the deprecated and less accurate <code>markdown_github</code>; use
+<a href="https://pandoc.org/MANUAL.html#markdown-variants"><code>markdown_github</code></a>
+only if you need extensions not supported in
+<a href="https://pandoc.org/MANUAL.html#markdown-variants"><code>gfm</code></a>.
+</li>
+<li><code>haddock</code> (<a href="https://www.haskell.org/haddock/doc/html/ch03s08.html">Haddock
+markup</a>)
+</li>
+<li><code>html</code> (<a href="https://www.w3.org/html/">HTML</a>)
+</li>
+<li><code>ipynb</code> (<a href="https://nbformat.readthedocs.io/en/latest/">Jupyter
+notebook</a>)
+</li>
+<li><code>jats</code> (<a href="https://jats.nlm.nih.gov">JATS</a> XML)
+</li>
+<li><code>jira</code>
+(<a href="https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all">Jira</a>/Confluence
+wiki markup)
+</li>
+<li><code>json</code> (JSON version of native AST)
+</li>
+<li><code>latex</code> (<a href="https://www.latex-project.org/">LaTeX</a>)
+</li>
+<li><code>markdown</code> (<a href="https://pandoc.org/MANUAL.html#pandocs-markdown">Pandoc’s
+Markdown</a>)
+</li>
+<li><code>markdown_mmd</code>
+(<a href="https://fletcherpenney.net/multimarkdown/">MultiMarkdown</a>)
+</li>
+<li><code>markdown_phpextra</code> (<a href="https://michelf.ca/projects/php-markdown/extra/">PHP Markdown
+Extra</a>)
+</li>
+<li><code>markdown_strict</code> (original unextended
+<a href="https://daringfireball.net/projects/markdown/">Markdown</a>)
+</li>
+<li><code>mediawiki</code> (<a href="https://www.mediawiki.org/wiki/Help:Formatting">MediaWiki
+markup</a>)
+</li>
+<li><code>man</code> (<a href="https://man.cx/groff_man(7)">roff man</a>)
+</li>
+<li><code>mdoc</code> (<a href="https://mandoc.bsd.lv/man/mdoc.7.html">mdoc</a> manual page
+markup)
+</li>
+<li><code>muse</code> (<a href="https://amusewiki.org/library/manual">Muse</a>)
+</li>
+<li><code>native</code> (native Haskell)
+</li>
+<li><code>odt</code> (<a href="https://en.wikipedia.org/wiki/OpenDocument">OpenDocument text
+document</a>)
+</li>
+<li><code>opml</code> (<a href="https://opml.org/spec2.opml">OPML</a>)
+</li>
+<li><code>org</code> (<a href="https://orgmode.org">Emacs Org mode</a>)
+</li>
+<li><code>pod</code> (Perl’s <a href="https://perldoc.perl.org/perlpod">Plain Old
+Documentation</a>)
+</li>
+<li><code>pptx</code>
+(<a href="https://en.wikipedia.org/wiki/Microsoft_PowerPoint">PowerPoint</a>)
+</li>
+<li><code>ris</code> (<a href="https://en.wikipedia.org/wiki/RIS_(file_format)">RIS</a>
+bibliography)
+</li>
+<li><code>rtf</code> (<a href="https://en.wikipedia.org/wiki/Rich_Text_Format">Rich Text
+Format</a>)
+</li>
+<li><code>rst</code>
+(<a href="https://docutils.sourceforge.io/docs/ref/rst/introduction.html">reStructuredText</a>)
+</li>
+<li><code>t2t</code> (<a href="https://txt2tags.org">txt2tags</a>)
+</li>
+<li><code>textile</code> (<a href="https://textile-lang.com">Textile</a>)
+</li>
+<li><code>tikiwiki</code> (<a href="https://doc.tiki.org/Wiki-Syntax-Text#The_Markup_Language_Wiki-Syntax">TikiWiki
+markup</a>)
+</li>
+<li><code>twiki</code> (<a href="https://twiki.org/cgi-bin/view/TWiki/TextFormattingRules">TWiki
+markup</a>)
+</li>
+<li><code>typst</code> (<a href="https://typst.app">typst</a>)
+</li>
+<li><code>vimwiki</code> (<a href="https://vimwiki.github.io">Vimwiki</a>)
+</li>
+<li><code>xlsx</code> (<a href="https://en.wikipedia.org/wiki/Microsoft_Excel#File_formats">Excel
+spreadsheet</a>)
+</li>
+<li><code>xml</code> (XML version of native AST)
+</li>
+<li>the path of a custom Lua reader, see <a href="https://pandoc.org/MANUAL.html#custom-readers-and-writers">Custom readers and
+writers</a>
+below
+</li>
+</ul>
+</div>
+<p>It can convert <em>to</em></p>
+<div id="output-formats">
+<ul>
+<li><code>ansi</code> (text with <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">ANSI escape
+codes</a>, for terminal
+viewing)
+</li>
+<li><code>asciidoc</code> (modern <a href="https://asciidoc.org/">AsciiDoc</a> as interpreted by
+<a href="https://asciidoctor.org/">Asciidoctor</a>)
+</li>
+<li><code>asciidoc_legacy</code> (<a href="https://asciidoc.org/">AsciiDoc</a> as interpreted by
+<a href="https://github.com/asciidoc-py/asciidoc-py"><code>asciidoc-py</code></a>).
+</li>
+<li><code>asciidoctor</code> (deprecated synonym for <code>asciidoc</code>)
+</li>
+<li><code>bbcode</code> <a href="https://www.bbcode.org/reference.php">BBCode</a>
+</li>
+<li><code>bbcode_fluxbb</code> <a href="https://web.archive.org/web/20210623155046/https://fluxbb.org/forums/help.php#bbcode">BBCode
+(FluxBB)</a>
+</li>
+<li><code>bbcode_phpbb</code> <a href="https://www.phpbb.com/community/help/bbcode">BBCode
+(phpBB)</a>
+</li>
+<li><code>bbcode_steam</code> <a href="https://steamcommunity.com/comment/ForumTopic/formattinghelp">BBCode
+(Steam)</a>
+</li>
+<li><code>bbcode_hubzilla</code> <a href="https://hubzilla.org/help/member/bbcode">BBCode
+(Hubzilla)</a>
+</li>
+<li><code>bbcode_xenforo</code> <a href="https://www.xenfocus.com/community/help/bb-codes/">BBCode
+(xenForo)</a>
+</li>
+<li><code>beamer</code> (<a href="https://ctan.org/pkg/beamer">LaTeX beamer</a> slide show)
+</li>
+<li><code>bibtex</code> (<a href="https://ctan.org/pkg/bibtex">BibTeX</a> bibliography)
+</li>
+<li><code>biblatex</code> (<a href="https://ctan.org/pkg/biblatex">BibLaTeX</a> bibliography)
+</li>
+<li><code>chunkedhtml</code> (zip archive of multiple linked HTML files)
+</li>
+<li><code>commonmark</code> (<a href="https://commonmark.org">CommonMark</a> Markdown)
+</li>
+<li><code>commonmark_x</code> (<a href="https://commonmark.org">CommonMark</a> Markdown with
+extensions)
+</li>
+<li><code>context</code> (<a href="https://www.contextgarden.net/">ConTeXt</a>)
+</li>
+<li><code>csljson</code> (<a href="https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html">CSL
+JSON</a>
+bibliography)
+</li>
+<li><code>djot</code> (<a href="https://djot.net">Djot markup</a>)
+</li>
+<li><code>docbook</code> or <code>docbook4</code> (<a href="https://docbook.org">DocBook</a> 4)
+</li>
+<li><code>docbook5</code> (DocBook 5)
+</li>
+<li><code>docx</code> (<a href="https://en.wikipedia.org/wiki/Office_Open_XML">Word docx</a>)
+</li>
+<li><code>dokuwiki</code> (<a href="https://www.dokuwiki.org/dokuwiki">DokuWiki markup</a>)
+</li>
+<li><code>epub</code> or <code>epub3</code> (<a href="http://idpf.org/epub">EPUB</a> v3 book)
+</li>
+<li><code>epub2</code> (EPUB v2)
+</li>
+<li><code>fb2</code>
+(<a href="http://www.fictionbook.org/index.php/Eng:XML_Schema_Fictionbook_2.1">FictionBook2</a>
+e-book)
+</li>
+<li><code>gfm</code> (<a href="https://help.github.com/articles/github-flavored-markdown/">GitHub-Flavored
+Markdown</a>),
+or the deprecated and less accurate <code>markdown_github</code>; use
+<a href="https://pandoc.org/MANUAL.html#markdown-variants"><code>markdown_github</code></a>
+only if you need extensions not supported in
+<a href="https://pandoc.org/MANUAL.html#markdown-variants"><code>gfm</code></a>.
+</li>
+<li><code>haddock</code> (<a href="https://www.haskell.org/haddock/doc/html/ch03s08.html">Haddock
+markup</a>)
+</li>
+<li><code>html</code> or <code>html5</code> (<a href="https://www.w3.org/html/">HTML</a>,
+i.e. <a href="https://html.spec.whatwg.org/">HTML5</a>/XHTML <a href="https://www.w3.org/TR/html-polyglot/">polyglot
+markup</a>)
+</li>
+<li><code>html4</code> (<a href="https://www.w3.org/TR/xhtml1/">XHTML</a> 1.0 Transitional)
+</li>
+<li><code>icml</code> (<a href="https://web.archive.org/web/20211006210211/https://wwwimages.adobe.com/www.adobe.com/content/dam/acom/en/devnet/indesign/sdk/cs6/idml/idml-cookbook.pdf">InDesign
+ICML</a>)
+</li>
+<li><code>ipynb</code> (<a href="https://nbformat.readthedocs.io/en/latest/">Jupyter
+notebook</a>)
+</li>
+<li><code>jats_archiving</code> (<a href="https://jats.nlm.nih.gov">JATS</a> XML, Archiving and
+Interchange Tag Set)
+</li>
+<li><code>jats_articleauthoring</code> (<a href="https://jats.nlm.nih.gov">JATS</a> XML, Article
+Authoring Tag Set)
+</li>
+<li><code>jats_publishing</code> (<a href="https://jats.nlm.nih.gov">JATS</a> XML, Journal
+Publishing Tag Set)
+</li>
+<li><code>jats</code> (alias for <code>jats_archiving</code>)
+</li>
+<li><code>jira</code>
+(<a href="https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all">Jira</a>/Confluence
+wiki markup)
+</li>
+<li><code>json</code> (JSON version of native AST)
+</li>
+<li><code>latex</code> (<a href="https://www.latex-project.org/">LaTeX</a>)
+</li>
+<li><code>man</code> (<a href="https://man.cx/groff_man(7)">roff man</a>)
+</li>
+<li><code>markdown</code> (<a href="https://pandoc.org/MANUAL.html#pandocs-markdown">Pandoc’s
+Markdown</a>)
+</li>
+<li><code>markdown_mmd</code>
+(<a href="https://fletcherpenney.net/multimarkdown/">MultiMarkdown</a>)
+</li>
+<li><code>markdown_phpextra</code> (<a href="https://michelf.ca/projects/php-markdown/extra/">PHP Markdown
+Extra</a>)
+</li>
+<li><code>markdown_strict</code> (original unextended
+<a href="https://daringfireball.net/projects/markdown/">Markdown</a>)
+</li>
+<li><code>markua</code> (<a href="https://leanpub.com/markua/read">Markua</a>)
+</li>
+<li><code>mediawiki</code> (<a href="https://www.mediawiki.org/wiki/Help:Formatting">MediaWiki
+markup</a>)
+</li>
+<li><code>ms</code> (<a href="https://man.cx/groff_ms(7)">roff ms</a>)
+</li>
+<li><code>muse</code> (<a href="https://amusewiki.org/library/manual">Muse</a>)
+</li>
+<li><code>native</code> (native Haskell)
+</li>
+<li><code>odt</code> (<a href="https://en.wikipedia.org/wiki/OpenDocument">OpenDocument text
+document</a>)
+</li>
+<li><code>opml</code> (<a href="https://opml.org/spec2.opml">OPML</a>)
+</li>
+<li><code>opendocument</code> (<a href="https://www.oasis-open.org/2021/06/16/opendocument-v1-3-oasis-standard-published/">OpenDocument
+XML</a>)
+</li>
+<li><code>org</code> (<a href="https://orgmode.org">Emacs Org mode</a>)
+</li>
+<li><code>pdf</code> (<a href="https://www.adobe.com/pdf/">PDF</a>)
+</li>
+<li><code>plain</code> (plain text)
+</li>
+<li><code>pptx</code>
+(<a href="https://en.wikipedia.org/wiki/Microsoft_PowerPoint">PowerPoint</a>
+slide show)
+</li>
+<li><code>rst</code>
+(<a href="https://docutils.sourceforge.io/docs/ref/rst/introduction.html">reStructuredText</a>)
+</li>
+<li><code>rtf</code> (<a href="https://en.wikipedia.org/wiki/Rich_Text_Format">Rich Text
+Format</a>)
+</li>
+<li><code>texinfo</code> (<a href="https://www.gnu.org/software/texinfo/">GNU Texinfo</a>)
+</li>
+<li><code>textile</code> (<a href="https://textile-lang.com">Textile</a>)
+</li>
+<li><code>t2t</code> (<a href="https://txt2tags.org">txt2tags</a>)
+</li>
+<li><code>slideous</code> (<a href="https://goessner.net/articles/slideous/">Slideous</a> HTML
+and JavaScript slide show)
+</li>
+<li><code>slidy</code> (<a href="https://www.w3.org/Talks/Tools/Slidy2/">Slidy</a> HTML and
+JavaScript slide show)
+</li>
+<li><code>dzslides</code> (<a href="https://paulrouget.com/dzslides/">DZSlides</a> HTML5 +
+JavaScript slide show)
+</li>
+<li><code>revealjs</code> (<a href="https://revealjs.com/">reveal.js</a> HTML5 + JavaScript
+slide show)
+</li>
+<li><code>s5</code> (<a href="https://meyerweb.com/eric/tools/s5/">S5</a> HTML and JavaScript
+slide show)
+</li>
+<li><code>tei</code> (<a href="https://github.com/TEIC/TEI-Simple">TEI Simple</a>)
+</li>
+<li><code>typst</code> (<a href="https://typst.app">typst</a>)
+</li>
+<li><code>vimdoc</code>
+(<a href="https://vimhelp.org/helphelp.txt.html#help-writing">Vimdoc</a>)
+</li>
+<li><code>xml</code> (XML version of native AST)
+</li>
+<li><code>xwiki</code> (<a href="https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/XWikiSyntax/">XWiki
+markup</a>)
+</li>
+<li><code>zimwiki</code> (<a href="https://zim-wiki.org/manual/Help/Wiki_Syntax.html">ZimWiki
+markup</a>)
+</li>
+<li>the path of a custom Lua writer, see <a href="https://pandoc.org/MANUAL.html#custom-readers-and-writers">Custom readers and
+writers</a>
+below
+</li>
+</ul>
+</div>
+<p>Pandoc can also produce PDF output via LaTeX, Groff ms, or HTML.</p>
+<p>Pandoc’s enhanced version of Markdown includes syntax for tables,
+definition lists, metadata blocks, footnotes, citations, math, and much
+more. See the User’s Manual below under <a href="https://pandoc.org/MANUAL.html#pandocs-markdown">Pandoc’s
+Markdown</a>.</p>
+<p>Pandoc has a modular design: it consists of a set of readers, which
+parse text in a given format and produce a native representation of the
+document (an <em>abstract syntax tree</em> or AST), and a set of writers, which
+convert this native representation into a target format. Thus, adding an
+input or output format requires only adding a reader or writer. Users
+can also run custom pandoc filters to modify the intermediate AST (see
+the documentation for <a href="https://pandoc.org/filters.html">filters</a> and
+<a href="https://pandoc.org/lua-filters.html">Lua filters</a>).</p>
+<p>Because pandoc’s intermediate representation of a document is less
+expressive than many of the formats it converts between, one should not
+expect perfect conversions between every format and every other. Pandoc
+attempts to preserve the structural elements of a document, but not
+formatting details such as margin size. And some document elements, such
+as complex tables, may not fit into pandoc’s simple document model.
+While conversions from pandoc’s Markdown to all formats aspire to be
+perfect, conversions from formats more expressive than pandoc’s Markdown
+can be expected to be lossy.</p>
+<h2 id="installing">Installing</h2>
+<p>Here’s <a href="INSTALL.md">how to install pandoc</a>.</p>
+<h2 id="documentation">Documentation</h2>
+<p>Pandoc’s website contains a full <a href="https://pandoc.org/MANUAL.html">User’s
+Guide</a>. It is also available
+<a href="MANUAL.txt">here</a> as pandoc-flavored Markdown. The website also
+contains some <a href="https://pandoc.org/demos.html">examples of the use of
+pandoc</a>, a limited <a href="https://pandoc.org/try">online
+demo</a>, and a <a href="https://pandoc.org/app">WebAssembly-based online
+demo</a>.</p>
+<h2 id="contributing">Contributing</h2>
+<p>Pull requests, bug reports, and feature requests are welcome. Please
+make sure to read <a href="CONTRIBUTING.md">the contributor guidelines</a> before
+opening a new issue.</p>
+<h2 id="license">License</h2>
+<p>© 2006-2024 John MacFarlane (<a href="mailto:jgm@berkeley.edu">jgm@berkeley.edu</a>). Released under the
+<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" title="GNU General Public License">GPL</a>,
+version 2 or greater. This software carries no warranty of any kind.
+(See COPYRIGHT for full copyright and warranty notices.)</p>
+</div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1.29.0/components/prism-core.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    
+  </div> <!-- /content -->
+
+  <style>
+  div#overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #000;
+    opacity: 0.5;
+    filter: alpha(opacity=50);
+  }
+
+  div#modal {
+    position: absolute;
+    width: 200px;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 14px;
+    padding: 8px;
+  }
+
+  div#modal #content {
+    border-radius: 8px;
+    padding: 20px;
+  }
+
+  div#modal #close {
+    position: absolute;
+    background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAbCAYAAABm409WAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABCdJREFUeNqcVl1IbFUUnjNzr47enLFkvKUoDNk1S0kxDPHBH4gCTfHJH4jgYgrpg1APmqjQS2gggiLViyBdkEAxjARFSPBBfPCv/LcRS5tSlLzXMcdxZvWt3d6HmTkzXW8LPs45a6/1rbX3XmvvYzL9hxBRC/AjRZcD4BGQE41Di0JciMfnQDF/n5+fm2ZmZkxnZ2e6TWFhoSknJ4T3a03TmkxPE5C/q9JbX1+nmpoaslgsxEPhSE9Pp6GhIbq5uVEuU8DztyLv7e2NShwOzIRcLpdy/S4auQNws0VHR8etiIORmppKh4eHKshXkQLwZtH4+Pgzkyvk5+cHL1dOMLmTNV6vV6xrsFNxcTHV1tZSSkpKiL6srIyam5spLS0tRM97IuWRHsDv97ezZmRkxJDV3t4enZ6e0sDAADkcDqGrqqqizc1NwdLe3m7YeFXCeoBAIPADa8rLyw0BZmdnhfX19TX19fVRY2OjTg4/amhoMPisra2J8YuLizeY3wzDfVY4nU6DcW5uLq2srAiHy8tLQi+I96urK1EM8fHxBp/h4WGV1EMOYOF3VsTExETdPO4JJZx5T08Pmc3miPZc4iwej+dTMweAwxOOZLfbja2uaSabzcaFoOtQKSYkY0pISIhY8jzGgqLx8zMO0xXp8XKEZ1NZWUk7Ozv6smxvb6vsaHBwkJKTkw0+XOossP2AAzx3dHQkeqClpcVgPDY2pm9yW1sblZSU0OLiotD5fD6qqKgIsefu56pj6ezsfJ0DJMzNzX3MCt798ADd3d20sbFBXV1dhOXSj4apqSmanp6mvLy8EPvq6mpBfnJysoLvFBEAyHK73aL26uvrQxx4CYqKigzVkp2dTRkZGSHnFb9vbW2JAPPz84MqwD3glYmJiS954Pj4WDj+n6Oiv7//3w47ONjhEx24zwGsQDrw9tLS0s/qmH7WINwTSpqamrqgywXE0X0XSAYKkpKSPgL572zEGxW+XNHuhNHRUZ28tbX1G+jLgQwuINHJgA14ALyXmJj4GY6H35TD8vKyqB5utri4OEHKs+Py5Y7l7mbBrefDMfI9xj8E3gJeBGLVtRkr1+tN4H3gC1TPT1gyD91CJicnT7Kysr6F3yfAOzJ7Lh6LupMt3HDAC3I/MoFXgZfr6upeKy0tvV9QUHAvMzPzjtVq1fb39/27u7vehYWFx2gq1+rq6hZseWP5+QvwB/AY8GlBl/8dIF4GSQWcEmmAg08SOVO2vQE8AP8FuAE+ml3Ar8CfktzLB7UW9odxV87ELjee1/ElGSBRjvGeXQMXwKkkdMusOeATOe6P9NuiZhIr+8MuiW2yImJkAJ7BpSQ7B/6S73/zsnDmssoi/hdpkkQFskrEyhlqMjvO8ioIPqkPPPXHK2hMkwWgYFbXuCRThIFwYiX/CDAA8quvgv5A6LkAAAAASUVORK5CYII=) 0 0 no-repeat;
+    width: 24px;
+    height: 27px;
+    display: block;
+    text-indent: -9999px;
+    top: -7px;
+    right: -7px;
+  }
+
+  .cool {
+    color: gold;
+    text-shadow:
+    -1px -1px 0 #000,
+    1px -1px 0 #000,
+    -1px 1px 0 #000,
+    1px 1px 0 #000;
+  }
+
+  .uncool {
+    color: white;
+    text-shadow:
+    -1px -1px 0 #000,
+    1px -1px 0 #000,
+    -1px 1px 0 #000,
+    1px 1px 0 #000;
+  }
+
+  .star-rating {
+    margin: 0;
+    list-style-type: none;
+    font-size: 150%;
+    color: black;
+  }
+
+  .star-rating li {
+    float: left;
+    margin: 0 1% 0 1%;
+    cursor: pointer;
+  }
+
+  .clear-rating {
+    font-size: small;
+  }
+
+</style>
+
+<script>
+  // Modals
+  var modal = (function() {
+    var
+      method = {},
+      overlay,
+      modal,
+      content,
+      close;
+
+    // Center the modal in the viewport
+    method.center = function() {
+      var top, left;
+
+      top = Math.max($(window).height() - modal.outerHeight(), 0) / 2;
+      left = Math.max($(window).width() - modal.outerWidth(), 0) / 2;
+
+      modal.css({
+        top: top + $(window).scrollTop(),
+        left: left + $(window).scrollLeft()
+      });
+    };
+
+    // Open the modal
+    method.open = function(settings) {
+      content.empty().append(settings.content);
+
+      modal.css({
+        width: settings.width || 'auto',
+        height: settings.height || 'auto'
+      });
+
+      method.center();
+      $(window).bind('resize.modal', method.center);
+      modal.show();
+      overlay.show();
+    };
+
+    // Close the modal
+    method.close = function() {
+      modal.hide();
+      overlay.hide();
+      content.empty();
+      $(window).unbind('resize.modal');
+    };
+
+    // Generate the HTML and add it to the document
+    overlay = $('<div id="overlay"></div>');
+    modal = $('<div id="modal"></div>');
+    content = $('<div id="content"></div>');
+    close = $('<a id="close" href="#">close</a>');
+
+    modal.hide();
+    overlay.hide();
+    modal.append(content, close);
+
+    $(document).ready(function() {
+      $('body').append(overlay, modal);
+    });
+
+    close.click(function(e) {
+      e.preventDefault();
+      method.close();
+    });
+
+    return method;
+  }());
+</script>
+
+<script>
+  // Voting
+  var votesUrl = '/package/pandoc/votes';
+  var star = {
+    "id"       : undefined,
+    "selected" : false
+  };
+  $('.star').mouseenter(function() {
+    if (star.selected === false) {
+      fill_stars(this.id, "in");
+    }
+  });
+  $('.star').mouseleave(function() {
+    if (star.selected === false) {
+      fill_stars(this.id, "out");
+    }
+  });
+  $('.star').click(function() {
+    fill_stars(3, "out");
+    fill_stars(this.id, "in");
+    star.selected = true;
+    star.id = this.id;
+    var formData = {
+      score: this.id
+    }
+    $.post(votesUrl, formData).done(function(data) {
+        if(data != "Package voted for successfully") {
+            modal.open({ content: data});
+	}
+    });
+  });
+  $('.clear-rating').click(function(e) {
+    e.preventDefault()
+    fill_stars(3, "out");
+    star.selected = false;
+    $.ajax({
+      url: votesUrl,
+      type: 'DELETE',
+      success: function(result) {
+        if(result != "Package vote removed successfully") {
+          modal.open({ content: result });
+	}
+      }
+    });
+  });
+  $(function() {
+       var userRating = parseInt($("#userRating").val(),10);
+       if(userRating > 0) {
+         fill_stars(userRating,"in")
+         star.selected = true;
+         star.id       = userRating;
+       }
+  });
+  var fill_stars = function(num, direction) {
+    if (direction === "in")
+      for (i = 0; i <= parseInt(num); i++)
+        $("#" + i).removeClass('uncool').addClass('cool');
+    else
+      for (i = 0; i <= parseInt(num); i++)
+        $("#" + i).removeClass('cool').addClass('uncool');
+  }
+</script>
+  <div style="clear:both"></div>
+  <div id="footer">
+  <p>
+    Produced by <a href="/">hackage</a> and <a href="http://haskell.org/cabal/">Cabal</a> 3.16.1.0.
+  </p>
+</div>
+
+    <script src="/package/pandoc-3.11/docs/quick-jump.min.js" type="text/javascript"></script>
+  <script type="text/javascript"> quickNav.init("/package/pandoc-3.11/docs", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>
+  
+
+  
+
+</body>
+</html>

--- a/test/models/ecosystem/bioconductor_test.rb
+++ b/test/models/ecosystem/bioconductor_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class BioconductorTest < ActiveSupport::TestCase
+  setup do
+    @registry = Registry.new(default: true, name: 'bioconductor.org', url: 'https://bioconductor.org', ecosystem: 'bioconductor')
+    @ecosystem = Ecosystem::Bioconductor.new(@registry)
+  end
+
+  test 'repository_url falls back to BugReports when URL has no forge' do
+    properties = {
+      "URL" => "https://bioconductor.org/packages/BiocGenerics",
+      "BugReports" => "https://github.com/Bioconductor/BiocGenerics/issues",
+      "License" => "Artistic-2.0",
+      "biocViews" => "Infrastructure",
+    }
+    html = Nokogiri::HTML("<h2>BiocGenerics</h2>")
+    @ecosystem.stubs(:downloads).returns(nil)
+    mapped = @ecosystem.map_package_metadata(name: 'BiocGenerics', html: html, properties: properties)
+
+    assert_equal "https://bioconductor.org/packages/BiocGenerics", mapped[:homepage]
+    assert_equal "https://github.com/Bioconductor/BiocGenerics", mapped[:repository_url]
+  end
+
+  test 'repository_url scans all URL entries' do
+    properties = {
+      "URL" => "https://example.org/foo,\nhttps://github.com/Bioconductor/limma",
+      "License" => "GPL",
+      "biocViews" => "Infrastructure",
+    }
+    html = Nokogiri::HTML("<h2>limma</h2>")
+    @ecosystem.stubs(:downloads).returns(nil)
+    mapped = @ecosystem.map_package_metadata(name: 'limma', html: html, properties: properties)
+
+    assert_equal "https://example.org/foo", mapped[:homepage]
+    assert_equal "https://github.com/Bioconductor/limma", mapped[:repository_url]
+  end
+end

--- a/test/models/ecosystem/cocoapods_test.rb
+++ b/test/models/ecosystem/cocoapods_test.rb
@@ -92,6 +92,17 @@ class CocoapodsTest < ActiveSupport::TestCase
     assert_nil package_metadata[:keywords_array]
   end
 
+  test 'repository_url falls back to homepage when source.git is missing' do
+    pkg = {
+      "name" => "Foo",
+      "homepage" => "https://github.com/foo/bar",
+      "source" => { "http" => "https://example.com/foo.zip" },
+    }
+    mapped = @ecosystem.map_package_metadata(pkg)
+
+    assert_equal "https://github.com/foo/bar", mapped[:repository_url]
+  end
+
   test 'package_metadata returns false for deprecated pod with no name' do
     stub_request(:get, "https://cdn.cocoapods.org/all_pods_versions_6_c_e.txt")
       .to_return({ status: 200, body: "EmplateSDK/4.0.0\n" })

--- a/test/models/ecosystem/cpan_test.rb
+++ b/test/models/ecosystem/cpan_test.rb
@@ -95,6 +95,35 @@ class CpanTest < ActiveSupport::TestCase
     assert_equal package_metadata[:metadata][:author], 'GUILLEM'
   end
 
+  test 'repository_url falls back to bugtracker when repository is missing' do
+    @ecosystem.stubs(:fetch_version_metadata).returns([])
+    pkg = {
+      "distribution" => "Foo",
+      "resources" => {
+        "homepage" => "https://foo.example.com",
+        "bugtracker" => { "web" => "https://github.com/foo/bar/issues" },
+      },
+      "license" => [],
+    }
+    mapped = @ecosystem.map_package_metadata(pkg)
+
+    assert_equal "https://github.com/foo/bar", mapped[:repository_url]
+  end
+
+  test 'repository_url uses repository.url when repository.web is missing' do
+    @ecosystem.stubs(:fetch_version_metadata).returns([])
+    pkg = {
+      "distribution" => "Foo",
+      "resources" => {
+        "repository" => { "url" => "git://github.com/foo/bar.git" },
+      },
+      "license" => [],
+    }
+    mapped = @ecosystem.map_package_metadata(pkg)
+
+    assert_equal "https://github.com/foo/bar", mapped[:repository_url]
+  end
+
   test 'versions_metadata' do
     stub_request(:get, "https://fastapi.metacpan.org/v1/release/Dpkg")
       .to_return({ status: 200, body: file_fixture('cpan/Dpkg') })

--- a/test/models/ecosystem/hackage_test.rb
+++ b/test/models/ecosystem/hackage_test.rb
@@ -92,6 +92,20 @@ class HackageTest < ActiveSupport::TestCase
     assert_equal package_metadata[:downloads_period], 'total'
   end
 
+  test 'repository_url from Source repo and Bug tracker when Home page is not a forge' do
+    stub_request(:get, "https://hackage.haskell.org/package/pandoc")
+      .to_return({ status: 200, body: file_fixture('hackage/pandoc') })
+    package_metadata = @ecosystem.package_metadata('pandoc')
+
+    assert_equal "https://pandoc.org", package_metadata[:homepage]
+    assert_equal "https://github.com/jgm/pandoc", package_metadata[:repository_url]
+  end
+
+  test 'find_attribute matches nbsp headers' do
+    page = Nokogiri::HTML("<div id='content'><table><tr><th>Source&nbsp;repo</th><td>head: git clone https://gitlab.com/foo/bar.git</td></tr></table></div>")
+    assert_equal "head: git clone https://gitlab.com/foo/bar.git", @ecosystem.find_attribute(page, "Source repo")
+  end
+
   test 'versions_metadata' do
     stub_request(:get, "https://hackage.haskell.org/package/blockfrost-client")
       .to_return({ status: 200, body: file_fixture('hackage/blockfrost-client') })

--- a/test/models/ecosystem/hex_test.rb
+++ b/test/models/ecosystem/hex_test.rb
@@ -97,6 +97,27 @@ class HexTest < ActiveSupport::TestCase
     assert_equal package_metadata[:downloads_period], "total"
   end
 
+  test 'repository_url scans all link values, not just github key' do
+    pkg = {
+      "name" => "gleam_stdlib",
+      "meta" => {
+        "description" => "stdlib",
+        "licenses" => ["Apache-2.0"],
+        "links" => {
+          "Repository" => "https://github.com/gleam-lang/stdlib",
+          "Sponsor" => "https://github.com/sponsors/lpil",
+          "Website" => "https://gleam.run/",
+        },
+      },
+      "releases" => [],
+      "downloads" => { "all" => 1 },
+    }
+    mapped = @ecosystem.map_package_metadata(pkg)
+
+    assert_equal "https://github.com/gleam-lang/stdlib", mapped[:repository_url]
+    assert_equal "Apache-2.0", mapped[:licenses]
+  end
+
   test 'versions_metadata' do
     stub_request(:get, "https://hex.pm/api/packages/phoenix_copy")
       .to_return({ status: 200, body: file_fixture('hex/phoenix_copy') })

--- a/test/models/ecosystem/pub_test.rb
+++ b/test/models/ecosystem/pub_test.rb
@@ -89,6 +89,22 @@ class PubTest < ActiveSupport::TestCase
     assert_nil package_metadata[:keywords_array]
   end
 
+  test 'repository_url falls back to issue_tracker' do
+    pkg = {
+      "name" => "foo",
+      "latest" => {
+        "pubspec" => {
+          "homepage" => "https://foo.example.com",
+          "issue_tracker" => "https://github.com/foo/bar/issues",
+        },
+      },
+      "versions" => [],
+    }
+    mapped = @ecosystem.map_package_metadata(pkg)
+
+    assert_equal "https://github.com/foo/bar", mapped[:repository_url]
+  end
+
   test 'versions_metadata' do
     stub_request(:get, "https://pub.dev/api/packages/bloc")
       .to_return({ status: 200, body: file_fixture('pub/bloc') })


### PR DESCRIPTION
Follow-up to #1812, applying the same idea (scan more of the available link fields via `find_repository_url`) to other ecosystems with significant blank `repository_url` counts.

| ecosystem | change | blank rows |
|---|---|---|
| bioconductor | scan all `URL` entries + `BugReports` | 1,134 |
| hex | scan all `meta.links` values (not just `github` key); drop stray `repo_fallback` wrapping `licenses` | 3,225 |
| cpan | add `repository.url`, `bugtracker.web`, `homepage` as candidates; keep raw `repository.web` fallback for self-hosted git | 24,826 |
| pub | add `pubspec.issue_tracker` as candidate | 11,842 |
| cocoapods | fall back to `homepage` instead of `""` | 9,013 |
| hackage | normalise `&nbsp;` in table headers so `Source repo` matches (previously dead); add `Bug tracker`; replace github-only `.git` regex with `find_repository_url` | 7,475 |

Skipped puppet (0 blank), fdroid (16 blank), spack (12 blank) since their primary source fields are effectively mandatory.