### PR TITLE
Add scala:export_dependencies and scala:export_projects rake tasks

### DIFF
--- a/lib/tasks/scala.rake
+++ b/lib/tasks/scala.rake
@@ -1,0 +1,146 @@
+require 'csv'
+require 'set'
+
+SCALA_SUFFIX_RE = /(_sjs[0-9.]+|_native[0-9.]+)?_(2\.\d+|3)$/
+
+def scala_strip_suffix(name)
+  g, a = name.split(':', 2)
+  return name if a.nil?
+  "#{g}:#{a.sub(SCALA_SUFFIX_RE, '')}"
+end
+
+def scala_registry
+  Registry.find_by_name!(ENV['REGISTRY'] || 'maven')
+end
+
+def scala_packages(registry)
+  registry.packages.where(
+    "split_part(packages.name, ':', 2) ~ ? OR packages.repo_metadata->>'language' = 'Scala'",
+    '_(2\.1[0-3]|3)$'
+  )
+end
+
+namespace :scala do
+  desc "Top dependencies of published Scala packages (CSV to stdout). ENV: LIMIT (default 2000)"
+  task export_dependencies: :environment do
+    limit = (ENV['LIMIT'] || 2000).to_i
+    reg = scala_registry
+    scope = scala_packages(reg)
+
+    $stderr.puts "collecting scala package ids..."
+    pkg_repo = {}
+    scope.in_batches(of: 5000) do |rel|
+      rel.pluck(:id, :repository_url).each { |id, url| pkg_repo[id] = url }
+    end
+    $stderr.puts "  #{pkg_repo.size} scala packages"
+
+    $stderr.puts "collecting latest version ids..."
+    vid_pid = {}
+    pkg_repo.keys.each_slice(5000) do |ids|
+      Version.where(package_id: ids, latest: true).pluck(:id, :package_id).each { |vid, pid| vid_pid[vid] = pid }
+    end
+    $stderr.puts "  #{vid_pid.size} latest versions"
+
+    $stderr.puts "aggregating dependencies..."
+    agg = Hash.new { |h, k| h[k] = { pids: Set.new, repos: Set.new, raw: Set.new } }
+    done = 0
+    vid_pid.keys.each_slice(1000) do |vids|
+      Dependency.where(version_id: vids).pluck(:version_id, :package_name).each do |vid, dep_name|
+        next if dep_name.blank?
+        pid = vid_pid[vid]
+        entry = agg[scala_strip_suffix(dep_name)]
+        entry[:pids] << pid
+        entry[:repos] << pkg_repo[pid] if pkg_repo[pid].present?
+        entry[:raw] << dep_name
+      end
+      done += vids.size
+      $stderr.puts "  #{done}/#{vid_pid.size}" if (done % 20_000).zero?
+    end
+    $stderr.puts "  #{agg.size} distinct dependency names"
+
+    ranked = agg.sort_by { |_, v| -v[:repos].size }.first(limit)
+
+    $stderr.puts "looking up dependency metadata..."
+    raw_names = ranked.flat_map { |_, v| v[:raw].to_a }.uniq
+    meta = {}
+    raw_names.each_slice(1000) do |names|
+      reg.packages.where(name: names).each do |p|
+        logical = scala_strip_suffix(p.name)
+        cur = meta[logical]
+        meta[logical] = p if cur.nil? || (p.dependent_packages_count || 0) > (cur.dependent_packages_count || 0)
+      end
+    end
+
+    puts CSV.generate_line(%w[
+      logical_name scala_dependent_projects scala_dependent_packages
+      language repository_url homepage latest_release_published_at
+      total_dependent_packages status stars last_repo_push archived example_purl
+    ])
+    ranked.each do |logical, v|
+      p = meta[logical]
+      rm = p&.repo_metadata || {}
+      puts CSV.generate_line([
+        logical,
+        v[:repos].size,
+        v[:pids].size,
+        rm['language'],
+        p&.repository_url,
+        p&.homepage,
+        p&.latest_release_published_at&.iso8601,
+        p&.dependent_packages_count,
+        p&.status,
+        rm['stargazers_count'],
+        rm['pushed_at'],
+        rm['archived'],
+        p&.purl
+      ])
+    end
+    $stderr.puts "done: #{ranked.size} rows"
+  end
+
+  desc "Scala source projects on Maven Central grouped by repository (CSV to stdout)"
+  task export_projects: :environment do
+    reg = scala_registry
+    scope = scala_packages(reg).where.not(repository_url: [nil, ''])
+
+    $stderr.puts "grouping by repository_url..."
+    projects = Hash.new { |h, k| h[k] = { artifacts: 0, group_ids: Set.new, dep_pkgs: 0, dep_repos: 0, latest: nil, rm: nil, example: nil } }
+    scope.in_batches(of: 5000) do |rel|
+      rel.each do |p|
+        e = projects[p.repository_url]
+        e[:artifacts] += 1
+        e[:group_ids] << p.name.split(':', 2).first
+        e[:dep_pkgs] += p.dependent_packages_count.to_i
+        e[:dep_repos] += p.dependent_repos_count.to_i
+        e[:latest] = [e[:latest], p.latest_release_published_at].compact.max
+        e[:rm] ||= p.repo_metadata if p.repo_metadata.present?
+        e[:example] ||= p.name
+      end
+    end
+    $stderr.puts "  #{projects.size} projects"
+
+    puts CSV.generate_line(%w[
+      repository_url group_ids artifact_count total_dependent_packages
+      total_dependent_repos latest_release_published_at language stars
+      forks last_repo_push archived example_artifact
+    ])
+    projects.sort_by { |_, v| -v[:dep_pkgs] }.each do |repo, v|
+      rm = v[:rm] || {}
+      puts CSV.generate_line([
+        repo,
+        v[:group_ids].to_a.sort.join(' '),
+        v[:artifacts],
+        v[:dep_pkgs],
+        v[:dep_repos],
+        v[:latest]&.iso8601,
+        rm['language'],
+        rm['stargazers_count'],
+        rm['forks_count'],
+        rm['pushed_at'],
+        rm['archived'],
+        v[:example]
+      ])
+    end
+    $stderr.puts "done: #{projects.size} rows"
+  end
+end

--- a/test/tasks/scala_rake_test.rb
+++ b/test/tasks/scala_rake_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+require 'rake'
+
+class ScalaRakeTest < ActiveSupport::TestCase
+  setup do
+    if Rake::Task.tasks.empty?
+      silence_warnings { Packages::Application.load_tasks }
+    end
+    @registry = Registry.create!(name: 'maven', url: 'https://repo1.maven.org/maven2', ecosystem: 'maven')
+  end
+
+  teardown do
+    ENV.delete('REGISTRY')
+    ENV.delete('LIMIT')
+  end
+
+  test "scala_strip_suffix collapses cross-build suffixes" do
+    assert_equal 'org.typelevel:cats-core', scala_strip_suffix('org.typelevel:cats-core_2.13')
+    assert_equal 'org.typelevel:cats-core', scala_strip_suffix('org.typelevel:cats-core_3')
+    assert_equal 'org.typelevel:cats-core', scala_strip_suffix('org.typelevel:cats-core_sjs1_2.13')
+    assert_equal 'org.typelevel:cats-core', scala_strip_suffix('org.typelevel:cats-core_native0.4_3')
+    assert_equal 'org.slf4j:slf4j-api', scala_strip_suffix('org.slf4j:slf4j-api')
+    assert_equal 'com.foo:bar_baz', scala_strip_suffix('com.foo:bar_baz')
+    assert_equal 'no-colon', scala_strip_suffix('no-colon')
+  end
+
+  test "export_dependencies ranks collapsed deps by distinct scala source repos" do
+    cats = @registry.packages.create!(name: 'org.typelevel:cats-core_2.13', ecosystem: 'maven',
+                                       repository_url: 'https://github.com/typelevel/cats')
+    zio  = @registry.packages.create!(name: 'dev.zio:zio_3', ecosystem: 'maven',
+                                       repository_url: 'https://github.com/zio/zio')
+    slf4j = @registry.packages.create!(name: 'org.slf4j:slf4j-api', ecosystem: 'maven',
+                                        repository_url: 'https://github.com/qos-ch/slf4j',
+                                        dependent_packages_count: 999,
+                                        repo_metadata: { 'language' => 'Java', 'stargazers_count' => 10 })
+    stest = @registry.packages.create!(name: 'org.scalatest:scalatest_2.13', ecosystem: 'maven',
+                                        repository_url: 'https://github.com/scalatest/scalatest',
+                                        dependent_packages_count: 50,
+                                        repo_metadata: { 'language' => 'Scala' })
+
+    v_cats = cats.versions.create!(number: '2.9.0', registry: @registry, latest: true)
+    v_zio  = zio.versions.create!(number: '2.0.0', registry: @registry, latest: true)
+
+    Dependency.create!(version_id: v_cats.id, ecosystem: 'maven', package_name: 'org.slf4j:slf4j-api', requirements: '1.7.0')
+    Dependency.create!(version_id: v_cats.id, ecosystem: 'maven', package_name: 'org.scalatest:scalatest_2.13', requirements: '3.2.0')
+    Dependency.create!(version_id: v_zio.id,  ecosystem: 'maven', package_name: 'org.slf4j:slf4j-api', requirements: '1.7.0')
+    Dependency.create!(version_id: v_zio.id,  ecosystem: 'maven', package_name: 'org.scalatest:scalatest_3', requirements: '3.2.0')
+
+    ENV['REGISTRY'] = 'maven'
+    out, _ = capture_io { Rake::Task['scala:export_dependencies'].execute }
+    rows = CSV.parse(out, headers: true)
+
+    assert_equal 2, rows.size
+    by_name = rows.map { |r| [r['logical_name'], r] }.to_h
+
+    assert by_name.key?('org.slf4j:slf4j-api')
+    assert by_name.key?('org.scalatest:scalatest')
+    assert_equal '2', by_name['org.slf4j:slf4j-api']['scala_dependent_projects']
+    assert_equal '2', by_name['org.scalatest:scalatest']['scala_dependent_projects']
+    assert_equal 'Java', by_name['org.slf4j:slf4j-api']['language']
+    assert_equal 'Scala', by_name['org.scalatest:scalatest']['language']
+    assert_equal '999', by_name['org.slf4j:slf4j-api']['total_dependent_packages']
+  end
+
+  test "export_projects groups scala artifacts by repository_url" do
+    @registry.packages.create!(name: 'org.typelevel:cats-core_2.13', ecosystem: 'maven',
+                               repository_url: 'https://github.com/typelevel/cats',
+                               dependent_packages_count: 100,
+                               repo_metadata: { 'language' => 'Scala', 'stargazers_count' => 5000 })
+    @registry.packages.create!(name: 'org.typelevel:cats-core_3', ecosystem: 'maven',
+                               repository_url: 'https://github.com/typelevel/cats',
+                               dependent_packages_count: 40)
+    @registry.packages.create!(name: 'org.typelevel:cats-kernel_2.13', ecosystem: 'maven',
+                               repository_url: 'https://github.com/typelevel/cats',
+                               dependent_packages_count: 10)
+    @registry.packages.create!(name: 'com.example:javaonly', ecosystem: 'maven',
+                               repository_url: 'https://github.com/example/java',
+                               repo_metadata: { 'language' => 'Java' })
+
+    ENV['REGISTRY'] = 'maven'
+    out, _ = capture_io { Rake::Task['scala:export_projects'].execute }
+    rows = CSV.parse(out, headers: true)
+
+    assert_equal 1, rows.size
+    r = rows.first
+    assert_equal 'https://github.com/typelevel/cats', r['repository_url']
+    assert_equal '3', r['artifact_count']
+    assert_equal '150', r['total_dependent_packages']
+    assert_equal 'org.typelevel', r['group_ids']
+    assert_equal 'Scala', r['language']
+  end
+end


### PR DESCRIPTION
Two CSV exports for mapping the Scala ecosystem on Maven Central.

`scala:export_dependencies` writes one row per library that published Scala packages depend on, with cross-build suffixes (`_2.13`, `_3`, `_sjs*`, `_native*`) collapsed to a single logical name, ranked by how many distinct Scala source repositories depend on it. Columns include the linked repo language, `repository_url`, latest release date, overall `dependent_packages_count`, status, stars, `pushed_at`, archived, and an example purl. Top 2000 rows by default, override with `LIMIT`.

`scala:export_projects` writes one row per Scala source repository (grouped by `repository_url`) with artifact count, summed dependent counts, latest release date, and repo metadata.

Scala packages are selected by artifactId suffix regex `_(2\.1[0-3]|3)$` OR `repo_metadata->>'language' = 'Scala'`. Both tasks stream CSV to stdout with progress on stderr:

```
dokku run packages rake scala:export_dependencies > scala_dependencies.csv
dokku run packages rake scala:export_projects > scala_projects.csv
```